### PR TITLE
Support Raspberry Pi 4 + Android

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,70 @@
-CC_SDL=`sdl2-config --cflags --libs`
+UNAME_S := $(shell uname -s)
+UNAME_P := $(shell uname -p)
+UNAME_M := $(shell uname -m)
 
-main: ggml.o whisper.o main.o
-	g++ -pthread -o main ggml.o whisper.o main.o
+#
+# Compile flags
+#
+
+CFLAGS   = -O3 -std=c11
+CXXFLAGS = -O3 -std=c++11
+
+CFLAGS   += -Wall -Wextra -Wno-unused-parameter -Wno-unused-function
+CXXFLAGS += -Wall -Wextra -Wno-unused-parameter -Wno-unused-function
+
+# OS specific
+# TODO: support Windows
+ifeq ($(UNAME_S),Linux)
+	CFLAGS += -pthread
+endif
+ifeq ($(UNAME_S),Darwin)
+	CFLAGS += -pthread
+endif
+
+# Architecture specific
+ifeq ($(UNAME_P),x86_64)
+	CFLAGS += -mavx -mavx2 -mfma -mf16c
+endif
+ifneq ($(filter arm%,$(UNAME_P)),)
+	CFLAGS += -mfpu=neon
+endif
+ifneq ($(filter aarch64%,$(UNAME_M)),)
+	CFLAGS += -mfpu=neon
+endif
+ifneq ($(filter armv%,$(UNAME_M)),)
+	# Raspberry Pi 4
+	CFLAGS += -mcpu=cortex-a72 -mfloat-abi=hard -mfpu=neon-fp-armv8 -mfp16-format=ieee -mno-unaligned-access
+endif
+
+#
+# Build library + main
+#
+
+main: main.cpp ggml.o whisper.o
+	$(CXX) $(CXXFLAGS) main.cpp whisper.o ggml.o -o main
 	./main -h
 
 ggml.o: ggml.c ggml.h
-	gcc -pthread -O3 -mavx -mavx2 -mfma -mf16c -c ggml.c
+	$(CC)  $(CFLAGS)   -c ggml.c
 
 whisper.o: whisper.cpp whisper.h
-	gcc -pthread -O3 -std=c++11 -c whisper.cpp
+	$(CXX) $(CXXFLAGS) -c whisper.cpp
 
-main.o: main.cpp ggml.h
-	g++ -pthread -O3 -std=c++11 -c main.cpp
-
-stream: stream.cpp
-	g++ -pthread -O3 -std=c++11 -o stream stream.cpp ggml.o whisper.o $(CC_SDL)
-
-# clean up the directory
 clean:
 	rm -f *.o main
+
+#
+# Examples
+#
+
+CC_SDL=`sdl2-config --cflags --libs`
+
+stream: stream.cpp ggml.o whisper.o
+	$(CXX) $(CXXFLAGS) stream.cpp ggml.o whisper.o -o stream $(CC_SDL)
+
+#
+# Audio samples
+#
 
 # download a few audio samples into folder "./samples":
 .PHONY: samples
@@ -36,6 +82,9 @@ samples:
 	@ffmpeg -loglevel -0 -y -i samples/mm1.wav -ar 16000 -ac 1 -c:a pcm_s16le samples/mm0.wav
 	@rm samples/mm1.wav
 
+#
+# Models
+#
 
 # if not already downloaded, the following targets download the specified model and
 # runs it on all samples in the folder "./samples":

--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,12 @@ CXXFLAGS += -Wall -Wextra -Wno-unused-parameter -Wno-unused-function
 # OS specific
 # TODO: support Windows
 ifeq ($(UNAME_S),Linux)
-	CFLAGS += -pthread
+	CFLAGS   += -pthread
+	CXXFLAGS += -pthread
 endif
 ifeq ($(UNAME_S),Darwin)
-	CFLAGS += -pthread
+	CFLAGS   += -pthread
+	CXXFLAGS += -pthread
 endif
 
 # Architecture specific
@@ -26,14 +28,21 @@ ifeq ($(UNAME_P),x86_64)
 	CFLAGS += -mavx -mavx2 -mfma -mf16c
 endif
 ifneq ($(filter arm%,$(UNAME_P)),)
-	CFLAGS += -mfpu=neon
+	# Mac M1
 endif
-ifneq ($(filter aarch64%,$(UNAME_M)),)
-	CFLAGS += -mfpu=neon
+ifneq ($(filter aarch64%,$(UNAME_P)),)
+	endif
+	ifneq ($(filter armv6%,$(UNAME_M)),)
+	# Raspberry Pi 1, 2, 3
+	CFLAGS += -mfpu=neon-fp-armv8 -mfp16-format=ieee -mno-unaligned-access
 endif
-ifneq ($(filter armv%,$(UNAME_M)),)
+ifneq ($(filter armv7%,$(UNAME_M)),)
 	# Raspberry Pi 4
-	CFLAGS += -mcpu=cortex-a72 -mfloat-abi=hard -mfpu=neon-fp-armv8 -mfp16-format=ieee -mno-unaligned-access
+	CFLAGS += -mfpu=neon-fp-armv8 -mfp16-format=ieee -mno-unaligned-access -funsafe-math-optimizations
+endif
+ifneq ($(filter armv8%,$(UNAME_M)),)
+	# Raspberry Pi 4
+	CFLAGS += -mfp16-format=ieee -mno-unaligned-access
 endif
 
 #

--- a/ggml.h
+++ b/ggml.h
@@ -108,7 +108,7 @@ struct ggml_tensor {
     int64_t perf_time_us;
 
     void * data;
-    char pad[8];
+    char padding[8];
 };
 
 // computation graph

--- a/main.cpp
+++ b/main.cpp
@@ -149,11 +149,11 @@ int main(int argc, char ** argv) {
         // convert to mono, float
         pcmf32.resize(n);
         if (wav.channels == 1) {
-            for (size_t i = 0; i < n; i++) {
+            for (int i = 0; i < n; i++) {
                 pcmf32[i] = float(pcm16[i])/32768.0f;
             }
         } else {
-            for (size_t i = 0; i < n; i++) {
+            for (int i = 0; i < n; i++) {
                 pcmf32[i] = float(pcm16[2*i] + pcm16[2*i + 1])/65536.0f;
             }
         }

--- a/stream.cpp
+++ b/stream.cpp
@@ -238,7 +238,7 @@ int main(int argc, char ** argv) {
         }
 
         // process 3 seconds of new audio
-        while ((int) SDL_GetQueuedAudioSize(g_dev_id_in) < 3*WHISPER_SAMPLE_RATE*sizeof(float)) {
+        while (SDL_GetQueuedAudioSize(g_dev_id_in) < 3*WHISPER_SAMPLE_RATE*sizeof(float)) {
             SDL_Delay(1);
         }
         const int n_samples_new = SDL_GetQueuedAudioSize(g_dev_id_in)/sizeof(float);

--- a/whisper.cpp
+++ b/whisper.cpp
@@ -1291,7 +1291,8 @@ bool whisper_encode(
         struct ggml_tensor * inpO = ggml_add(ctxL, cur, inpFF);
 
         {
-            struct ggml_cgraph gf = { .n_threads = n_threads };
+            struct ggml_cgraph gf = {};
+            gf.n_threads = n_threads;
 
             ggml_build_forward_expand(&gf, inpO);
             ggml_graph_compute       (ctxL, &gf);
@@ -1327,7 +1328,8 @@ bool whisper_encode(
 
     // run the computation
     {
-        struct ggml_cgraph gf = { .n_threads = n_threads };
+        struct ggml_cgraph gf = {};
+        gf.n_threads = n_threads;
 
         ggml_build_forward_expand(&gf, cur);
         ggml_graph_compute       (ctx0, &gf);
@@ -1351,7 +1353,8 @@ bool whisper_encode(
 
     // pre-compute cross-attention memory
     {
-        struct ggml_cgraph gf = { .n_threads = n_threads };
+        struct ggml_cgraph gf = {};
+        gf.n_threads = n_threads;
 
         // TODO: hack to disconnect the encoded features from the previous graph
         cur->op = GGML_OP_NONE;
@@ -1461,7 +1464,8 @@ bool whisper_decode(
         };
 
         struct ggml_context * ctxL = ggml_init(paramsL);
-        struct ggml_cgraph gf = { .n_threads = n_threads };
+        struct ggml_cgraph gf = {};
+        gf.n_threads = n_threads;
 
         // norm
         {
@@ -1744,7 +1748,8 @@ bool whisper_decode(
 
     // run the computation
     {
-        struct ggml_cgraph gf = { .n_threads = n_threads };
+        struct ggml_cgraph gf = {};
+        gf.n_threads = n_threads;
 
         ggml_build_forward_expand(&gf, cur);
         ggml_graph_compute       (ctx0, &gf);
@@ -2334,7 +2339,7 @@ int whisper_full(
             }
         }
 
-        if (seek >= whisper_n_len(ctx)) {
+        if (seek + 100 >= whisper_n_len(ctx)) {
             break;
         }
 

--- a/whisper.cpp
+++ b/whisper.cpp
@@ -1031,8 +1031,6 @@ bool whisper_encode(
     const auto & mel_inp = wctx.mel;
     const auto & hparams = model.hparams;
 
-    const int n_vocab = hparams.n_vocab;
-
     const int n_ctx   = hparams.n_audio_ctx;
     const int n_state = hparams.n_audio_state;
     const int n_head  = hparams.n_audio_head;
@@ -2365,7 +2363,6 @@ int whisper_full(
 
         bool done = false;
         int seek_delta = 100*WHISPER_CHUNK_SIZE;
-        whisper_token last_id = 0;
 
         // print the prompt
         //printf("\n\n");
@@ -2395,8 +2392,6 @@ int whisper_full(
             // feel free to experiment!
             //
             {
-                const int n_vocab = whisper_n_vocab(ctx);
-
                 whisper_token id  = 0;
                 whisper_token tid = whisper_token_beg(ctx);
 
@@ -2410,7 +2405,6 @@ int whisper_full(
                     seek_delta = 2*(id - whisper_token_beg(ctx));
                     result_len = i + 1;
                 }
-                last_id = id;
 
                 // add it to the context
                 prompt.push_back(id);
@@ -2444,7 +2438,7 @@ int whisper_full(
 
             std::string text = "";
 
-            for (int i = 0; i < result_cur.size(); i++) {
+            for (int i = 0; i < (int) result_cur.size(); i++) {
                 if (params.print_special_tokens == false && result_cur[i].id >= whisper_token_eot(ctx)) {
                 } else {
                     text += whisper_token_to_str(ctx, result_cur[i].id);
@@ -2464,7 +2458,7 @@ int whisper_full(
                         result_all.push_back({ t0, t1, text });
                     }
                     text = "";
-                    while (result_cur[i].id > whisper_token_beg(ctx) && i < result_cur.size()) {
+                    while (result_cur[i].id > whisper_token_beg(ctx) && i < (int) result_cur.size()) {
                         i++;
                     }
                     i--;


### PR DESCRIPTION
ref #7
ref #8 
ref #15 

Should now build correctly on different platforms.
On Arm platforms without `__ARM_FEATURE_FP16_VECTOR_ARITHMETIC` we convert to 32-bit floats. There might be a more efficient way, but this is good for now.