### PR TITLE
Add static library make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,8 +60,11 @@ ggml.o: ggml.c ggml.h
 whisper.o: whisper.cpp whisper.h
 	$(CXX) $(CXXFLAGS) -c whisper.cpp
 
+libwhisper.a: ggml.o whisper.o
+	ar rcs libwhisper.a ggml.o whisper.o
+
 clean:
-	rm -f *.o main
+	rm -f *.o main libwhisper.a
 
 #
 # Examples


### PR DESCRIPTION
I've been writing a Rust wrapper for whisper.cpp, and I needed a easy way to build a static library. This seems easiest, and it seems to work based off just running `make libwhisper.a`. Any feedback is appreciated.