### PR TITLE
fix decode missing token issue

### DIFF
--- a/convert-pt-to-ggml.py
+++ b/convert-pt-to-ggml.py
@@ -271,7 +271,7 @@ byte_decoder = {v:k for k, v in byte_encoder.items()}
 fout.write(struct.pack("i", len(tokens)))
 
 for key in tokens:
-    text = bytearray([byte_decoder[c] for c in key]).decode('utf-8', errors='replace').encode('utf-8')
+    text = bytearray([byte_decoder[c] for c in key])
     fout.write(struct.pack("i", len(text)))
     fout.write(text)
 


### PR DESCRIPTION
@ggerganov , thanks for the great project!
I fixed the #25 issue.  
Just fix one line in convert-pt-to-ggml.py. 
I think the root cause is :
`bytearray([byte_decoder[c] for c in key])`
This have already convert token to utf-8 so you don't need encode and decode again.

before change code:
<img width="1304" alt="截圖 2022-10-17 下午8 55 30" src="https://user-images.githubusercontent.com/6906747/196197590-159e8bdc-02e3-431b-b19f-2d74e82013ba.png">
after change code:
<img width="1277" alt="截圖 2022-10-17 下午8 53 46" src="https://user-images.githubusercontent.com/6906747/196197152-f47f617b-eba3-4793-a11e-df461301bd62.png">
