### PR TITLE
Use Accelerate framework on Apple silicon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ UNAME_M := $(shell uname -m)
 
 CFLAGS   = -O3 -std=c11  
 CXXFLAGS = -O3 -std=c++11
+LDFLAGS  =
 
 CFLAGS   += -Wall -Wextra -Wno-unused-parameter -Wno-unused-function
 CXXFLAGS += -Wall -Wextra -Wno-unused-parameter -Wno-unused-function
@@ -37,7 +38,11 @@ ifeq ($(UNAME_M),amd64)
 	CFLAGS += -mavx -mavx2 -mfma -mf16c
 endif
 ifneq ($(filter arm%,$(UNAME_M)),)
-	# Mac M1
+	# Mac M1 - include Accelerate framework
+	ifeq ($(UNAME_S),Darwin)
+		CFLAGS  += -DGGML_USE_ACCELERATE
+		LDFLAGS += -framework Accelerate
+	endif
 endif
 ifneq ($(filter aarch64%,$(UNAME_M)),)
 endif
@@ -59,7 +64,7 @@ endif
 #
 
 main: main.cpp ggml.o whisper.o
-	$(CXX) $(CXXFLAGS) main.cpp whisper.o ggml.o -o main
+	$(CXX) $(CXXFLAGS) main.cpp whisper.o ggml.o -o main $(LDFLAGS)
 	./main -h
 
 ggml.o: ggml.c ggml.h

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ clean:
 CC_SDL=`sdl2-config --cflags --libs`
 
 stream: stream.cpp ggml.o whisper.o
-	$(CXX) $(CXXFLAGS) stream.cpp ggml.o whisper.o -o stream $(CC_SDL)
+	$(CXX) $(CXXFLAGS) stream.cpp ggml.o whisper.o -o stream $(CC_SDL) $(LDFLAGS)
 
 #
 # Audio samples

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 High-performance inference of [OpenAI's Whisper](https://github.com/openai/whisper) automatic speech recognition (ASR) model:
 
 - Plain C/C++ implementation without dependencies
-- ARM_NEON and AVX intrinsics support
+- Apple silicon first-class citizen - optimized via Arm Neon and Accelerate framework
+- AVX intrinsics support for x86 architectures
 - Mixed F16 / F32 precision
 - Low memory usage (Flash Attention + Flash Forward)
 - Zero memory allocations at runtime
@@ -224,7 +225,7 @@ https://user-images.githubusercontent.com/1991296/194935793-76afede7-cfa8-48d8-a
 The `stream` tool depends on SDL2 library to capture audio from the microphone. You can build it like this:
 
 ```bash
-# Install SDL2 on Linux 
+# Install SDL2 on Linux
 sudo apt-get install libsdl2-dev
 
 # Install SDL2 on Mac OS
@@ -240,6 +241,10 @@ make stream
 - Simple usage is demonstrated in [main.cpp](main.cpp)
 - Sample real-time audio transcription from the microphone is demonstrated in [stream.cpp](stream.cpp)
 
+The tensor operators are optimized heavily for Apple silicon CPUs. Depending on the computation size, Arm Neon SIMD
+instrisics or CBLAS Accelerate framwork routines are used. The latter are especially effective for bigger sizes since
+the framwork utilizes the special-purpose AMX coprocessor available in modern Apple products.
+
 ## Limitations
 
 - Very basic greedy sampling scheme - always pick up the top token. You can implement your own strategy
@@ -250,11 +255,12 @@ make stream
 
 | Model  | Disk   | Mem     |
 | ---    | ---    | ---     |
-| tiny   |  75 MB | ~240 MB |
-| base   | 142 MB | ~380 MB |
-| small  | 466 MB | ~970 MB |
-| medium | 1.5 GB | ~2.5 GB |
-| large  | 2.9 GB | ~4.6 GB |
+| tiny   |  75 MB | ~280 MB |
+| base   | 142 MB | ~430 MB |
+| small  | 466 MB | ~1.0 GB |
+| medium | 1.5 GB | ~2.6 GB |
+| large  | 2.9 GB | ~4.7 GB |
+
 
 ## ggml format
 

--- a/extra/convert-all.sh
+++ b/extra/convert-all.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+models=( "tiny.en" "tiny" "base.en" "base" "small.en" "small" "medium.en" "medium" "large" )
+
+for model in "${models[@]}"; do
+    python3 convert-pt-to-ggml.py ~/.cache/whisper/$model.pt ../whisper models/
+    mv -v models/ggml-model.bin models/ggml-$model.bin
+done

--- a/main.cpp
+++ b/main.cpp
@@ -21,7 +21,7 @@ std::string to_timestamp(int64_t t) {
     msec = msec - min * (1000 * 60);
     int64_t sec = msec / 1000;
     msec = msec - sec * 1000;
-    
+
     char buf[32];
     snprintf(buf, sizeof(buf), "%02d:%02d:%02d.%03d", (int) hr, (int) min, (int) sec, (int) msec);
 

--- a/whisper.cpp
+++ b/whisper.cpp
@@ -2425,7 +2425,7 @@ int whisper_full(
                 whisper_token id  = 0;
                 whisper_token tid = whisper_token_beg(ctx);
 
-                id = whisper_sample_best(ctx, result_len == 0);
+                id = whisper_sample_best(ctx, result_len == 0 || i > 32);
                 if (i > 0) {
                     tid = whisper_sample_timestamp(ctx);
                 }
@@ -2445,7 +2445,9 @@ int whisper_full(
                 // end of text token
                 if (id == whisper_token_eot(ctx)) {
                     if (result_len == 0) {
-                        result_len = i + 1;
+                        // TODO: figure out how to resolve this
+                        fprintf(stderr, "\n%s: failed to generate timestamp token - this should not happen\n\n", __func__);
+                        //result_len = i + 1;
                     }
                     break;
                 }

--- a/whisper.cpp
+++ b/whisper.cpp
@@ -15,7 +15,7 @@
 #include <vector>
 
 #define USE_FLASH_ATTN
-#define USE_FLASH_FF
+//#define USE_FLASH_FF
 
 // available whisper models
 enum e_model {
@@ -148,11 +148,11 @@ static const std::map<e_model, size_t> MEM_REQ_ENCODE = {
 };
 
 static const std::map<e_model, size_t> MEM_REQ_ENCODE_LAYER = {
-    { MODEL_TINY,     64ull*MB },
-    { MODEL_BASE,     84ull*MB },
-    { MODEL_SMALL,   128ull*MB },
-    { MODEL_MEDIUM,  172ull*MB },
-    { MODEL_LARGE,   216ull*MB },
+    { MODEL_TINY,    104ull*MB },
+    { MODEL_BASE,    138ull*MB },
+    { MODEL_SMALL,   208ull*MB },
+    { MODEL_MEDIUM,  280ull*MB },
+    { MODEL_LARGE,   354ull*MB },
 };
 
 static const std::map<e_model, size_t> MEM_REQ_DECODE = {

--- a/whisper.cpp
+++ b/whisper.cpp
@@ -156,11 +156,11 @@ static const std::map<e_model, size_t> MEM_REQ_ENCODE_LAYER = {
 };
 
 static const std::map<e_model, size_t> MEM_REQ_DECODE = {
-    { MODEL_TINY,     94ull*MB },
-    { MODEL_BASE,     96ull*MB },
-    { MODEL_SMALL,    98ull*MB },
-    { MODEL_MEDIUM,  100ull*MB },
-    { MODEL_LARGE,   102ull*MB },
+    { MODEL_TINY,    200ull*MB },
+    { MODEL_BASE,    202ull*MB },
+    { MODEL_SMALL,   204ull*MB },
+    { MODEL_MEDIUM,  206ull*MB },
+    { MODEL_LARGE,   208ull*MB },
 };
 
 static const std::map<e_model, size_t> MEM_REQ_DECODE_LAYER = {


### PR DESCRIPTION
TL;DR: x2 performance improvement in the Encoder on Apple silicon

Modern Apple products come with a special AMX matrix coprocessor. Currently, the only way to utilise it in your code is through [APPLE's Accelerate framework](https://developer.apple.com/documentation/accelerate). Among many things, it provides a [BLAS implementation](https://developer.apple.com/documentation/accelerate/blas) that apparently runs on the AMX.

Using the AMX for Whisper model inference is extremely beneficial for the Encoder part of the model. The tensor sizes in the encoder are big enough to compensate for the Accelerate framework overhead and even bring about x2 better performance compared to my previous F16 implementation. It is a shame not to use it, so this PR adds support for this.

Here is before and after comparison of running the `large` model on `jfk.wav`:

```java
# without Accelerate
whisper_print_timings:     load time =  1018.34 ms
whisper_print_timings:      mel time =    13.85 ms
whisper_print_timings:   sample time =     2.11 ms
whisper_print_timings:   encode time =  9123.14 ms / 285.10 ms per layer
whisper_print_timings:   decode time =  1154.06 ms / 36.06 ms per layer
whisper_print_timings:    total time = 11311.87 ms

# with Accelerate
whisper_print_timings:     load time =  1002.72 ms
whisper_print_timings:      mel time =    13.43 ms
whisper_print_timings:   sample time =     2.90 ms
whisper_print_timings:   encode time =  4071.11 ms / 127.22 ms per layer
whisper_print_timings:   decode time =  1117.53 ms / 34.92 ms per layer
whisper_print_timings:    total time =  6208.27 ms
```

This finally gives me the answer how PyTorch's implementation of the encoder was outperforming `whisper.cpp` encoder on my MacBook. I am pretty sure that PyTorch also ends up using the Accelerate framework under the hood. With this change, the encoder performance between the two implementations is now comparable.

My tests show that it is not beneficial to use CBLAS for the decoder part of the model. Multi-threaded Neon SIMD is significantly faster. Likely due to the smaller tensor sizes.