### PR TITLE
added handling for falsely as x86_64 announced ARM Macs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,24 @@ UNAME_S := $(shell uname -s)
 UNAME_P := $(shell uname -p)
 UNAME_M := $(shell uname -m)
 
+# Mac OS + Arm can report x86_64
+# ref: https://github.com/ggerganov/whisper.cpp/issues/66#issuecomment-1282546789
+ifeq ($(UNAME_S),Darwin)
+	ifneq ($(UNAME_P),arm)
+		SYSCTL_M := $(shell sysctl -n hw.optional.arm64)
+		ifeq ($(SYSCTL_M),1)
+			UNAME_P := arm
+			UNAME_M := arm64
+			warn := $(warning Your arch is announced as x86_64, but it seems to actually be ARM64. Not fixing that can lead to bad performance. For more info see: https://github.com/ggerganov/whisper.cpp/issues/66\#issuecomment-1282546789)
+		endif
+	endif
+endif
+
 #
 # Compile flags
 #
 
-CFLAGS   = -O3 -std=c11  
+CFLAGS   = -O3 -std=c11
 CXXFLAGS = -O3 -std=c++11
 LDFLAGS  =
 


### PR DESCRIPTION
MacOS can falsely announce the architecure to be x86_64.
This code handles this case.
related to #66