### PR TITLE
Add enconding parameter to vocab.json opening to fix errors

### DIFF
--- a/models/convert-pt-to-ggml.py
+++ b/models/convert-pt-to-ggml.py
@@ -234,7 +234,7 @@ dir_tokenizer = tokenizer.name_or_path
 # output in the same directory as the model
 fname_out = dir_out + "/ggml-model.bin"
 
-with open(dir_tokenizer + "/vocab.json", "r") as f:
+with open(dir_tokenizer + "/vocab.json", "r", encoding="utf8") as f:
     tokens = json.load(f)
 
 # use 16-bit or 32-bit floats


### PR DESCRIPTION
I had issues on Windows 10 using the premade .bin files so I tried to use models/convert-pt-to-ggml.py to convert my existing OpenAI Whisper .pt files. However, it throws an error:

```
>python convert-pt-to-ggml.py ..\..\..\models\tiny.en.pt ..\..\..\whisper .
hparams: {'n_mels': 80, 'n_vocab': 51864, 'n_audio_ctx': 1500, 'n_audio_state': 384, 'n_audio_head': 6, 'n_audio_layer': 4, 'n_text_ctx': 448, 'n_text_state': 384, 'n_text_head': 6, 'n_text_layer': 4}
Traceback (most recent call last):
  File "D:\programs\OpenAI-whisper\fork\whisper.cpp\models\convert-pt-to-ggml.py", line 238, in <module>
    tokens = json.load(f)
  File "C:\Users\Joonas\AppData\Local\Programs\Python\Python310\lib\json\__init__.py", line 293, in load
    return loads(fp.read(),
  File "C:\Users\Joonas\AppData\Local\Programs\Python\Python310\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 926: character maps to <undefined>
```

This is likely because my machine does not default to utf8 localization on Windows, but the legacy cp1252. 

It was an easy fix of adding `enconding="utf8"` to `open(dir_tokenizer + "/vocab.json", "r")`. Works perfectly. Should fix other Windows setups as well and I can't see any drawbacks on other systems, OpenAI Whisper's `vocab.json` most definitely is utf8.

This is my first pull request ever, so apologies if my fork+add upstream+create branch+commit+push+pull request process is wrong. :)