### PR TITLE
Define WHISPER_BUILD so as to export symbols on Windows

### DIFF
--- a/whisper.cpp
+++ b/whisper.cpp
@@ -1,3 +1,4 @@
+#define WHISPER_BUILD
 #include "whisper.h"
 
 #include "ggml.h"


### PR DESCRIPTION
Without this no symbols are actually exported on Windows