### PR TITLE
Word-level timestamps

### DIFF
--- a/whisper.cpp
+++ b/whisper.cpp
@@ -1843,7 +1843,8 @@ whisper_token_data whisper_sample_best(
             }
         }
 
-        result.pt = max_ts/(sum_ts + 1e-6);
+        result.pt = max_ts/(sum_ts + 1e-10);
+        result.ptsum = sum_ts;
     }
 
     // find the top K tokens
@@ -2518,7 +2519,10 @@ int whisper_full(
                 prompt.push_back(token.id);
                 tokens_cur.push_back(token);
 
-                //printf("%s: %s\n", __func__, ctx->vocab.id_to_token[id].c_str());
+                //{
+                //    const auto tt = token.pt > 0.10 ? ctx->vocab.id_to_token[token.tid] : "[?]";
+                //    printf("%s: %10s %6.3f '%s'\n", __func__, tt.c_str(), token.pt, ctx->vocab.id_to_token[token.id].c_str());
+                //}
 
                 // end of text token
                 if (token.id == whisper_token_eot(ctx)) {
@@ -2801,6 +2805,10 @@ const char * whisper_full_get_token_text(struct whisper_context * ctx, int i_seg
 
 whisper_token whisper_full_get_token_id(struct whisper_context * ctx, int i_segment, int i_token) {
     return ctx->result_all[i_segment].tokens[i_token].id;
+}
+
+struct whisper_token_data whisper_full_get_token_data(struct whisper_context * ctx, int i_segment, int i_token) {
+    return ctx->result_all[i_segment].tokens[i_token];
 }
 
 float whisper_full_get_token_p(struct whisper_context * ctx, int i_segment, int i_token) {

--- a/whisper.h
+++ b/whisper.h
@@ -72,8 +72,9 @@ extern "C" {
         whisper_token id;  // token id
         whisper_token tid; // forced timestamp token id
 
-        float p;  // probability of the token
-        float pt; // probability of the timestamp token
+        float p;     // probability of the token
+        float pt;    // probability of the timestamp token
+        float ptsum; // sum of probabilities of all timestamp tokens
     };
 
     // Allocates all memory needed for the model and loads the model from the given file.
@@ -240,6 +241,10 @@ extern "C" {
     // Get the token text of the specified token in the specified segment.
     WHISPER_API const char * whisper_full_get_token_text(struct whisper_context * ctx, int i_segment, int i_token);
     WHISPER_API whisper_token whisper_full_get_token_id (struct whisper_context * ctx, int i_segment, int i_token);
+
+    // Get token data for the specified token in the specified segment.
+    // This contains probabilities, timestamps, etc.
+    WHISPER_API struct whisper_token_data whisper_full_get_token_data(struct whisper_context * ctx, int i_segment, int i_token);
 
     // Get the probability of the specified token in the specified segment.
     WHISPER_API float whisper_full_get_token_p(struct whisper_context * ctx, int i_segment, int i_token);


### PR DESCRIPTION
ref #49

In parallel to regular text tokens, we sample also the most probable timestamp token. For tokens with high timestamp probability (e.g. `p > 0.1`) we use this timestamp to mark the end of the token and the beginning of the next token. This gives us partial word-level time information. After that we do a second pass over the tokens and fill the missing start/end timestamps by proportionally splitting the time interval based on the word length.

Also added option to generate a "karaoke" movie using `ffmpeg`.

---

To use this, add the `-owts` command-line argument. There is a free parameter `-wt` that should be around `0.01`.

Here are a few examples:

```java
./main -m ./models/ggml-base.en.bin -f ./samples/jfk.wav -owts -wt 0.01
source ./samples/jfk.wav.wts
ffplay ./samples/jfk.wav.mp4
```

https://user-images.githubusercontent.com/1991296/198885665-b34b6845-11b8-4449-a255-d9ec2eab1344.mp4

---

```java
./main -m ./models/ggml-base.en.bin -f ./samples/mm0.wav -owts -wt 0.1
source ./samples/mm0.wav.wts
ffplay ./samples/mm0.wav.mp4
```

https://user-images.githubusercontent.com/1991296/198885703-0547ba17-c288-4827-8361-84cc440f2901.mp4

---

```java
./main -m ./models/ggml-base.en.bin -f ./samples/gb0.wav -owts -wt 0.01
source ./samples/gb0.wav.wts
ffplay ./samples/gb0.wav.mp4
```

https://user-images.githubusercontent.com/1991296/198885729-3fc9028c-a50c-4549-a11f-3306ef97e0c4.mp4

---

The accuracy is not great.
I think there are various ways to improve it, but it is a good start for now.