### PR TITLE
Prompt previous tokens for streaming

### DIFF
--- a/examples/stream/stream.cpp
+++ b/examples/stream/stream.cpp
@@ -234,6 +234,7 @@ int main(int argc, char ** argv) {
     std::vector<float> pcmf32(n_samples_30s, 0.0f);
     std::vector<float> pcmf32_old;
 
+    std::vector<whisper_token> prompt_tokens;
     const int n_new_line = params.length_ms / params.step_ms - 1;
 
     // print some info about the processing
@@ -344,6 +345,8 @@ int main(int argc, char ** argv) {
             wparams.audio_ctx            = params.audio_ctx;
             wparams.speed_up             = params.speed_up;
 
+            wparams.prompt_tokens        = &prompt_tokens;
+            
             if (whisper_full(ctx, wparams, pcmf32.data(), pcmf32.size()) != 0) {
                 fprintf(stderr, "%s: failed to process audio\n", argv[0]);
                 return 6;
@@ -393,6 +396,16 @@ int main(int argc, char ** argv) {
 
                 // keep part of the audio for next iteration to try to mitigate word boundary issues
                 pcmf32_old = std::vector<float>(pcmf32.end() - n_samples_keep, pcmf32.end());
+
+                // Add tokens of the last full length segment as the prompt
+                prompt_tokens.clear();
+                const int n_segments = whisper_full_n_segments(ctx);
+                for (int i = 0; i < n_segments; ++i) {
+                    const int token_count = whisper_full_n_tokens(ctx, i);
+                    for (int j = 0; j < token_count; ++j) {
+                        prompt_tokens.push_back(whisper_full_get_token_id(ctx, i, j));
+                    }
+                }
             }
         }
     }

--- a/examples/stream/stream.cpp
+++ b/examples/stream/stream.cpp
@@ -345,7 +345,7 @@ int main(int argc, char ** argv) {
             wparams.audio_ctx            = params.audio_ctx;
             wparams.speed_up             = params.speed_up;
 
-            wparams.prompt_tokens        = &prompt_tokens[0];
+            wparams.prompt_tokens        = prompt_tokens.data();
             wparams.prompt_n_tokens      = prompt_tokens.size();
             
             if (whisper_full(ctx, wparams, pcmf32.data(), pcmf32.size()) != 0) {

--- a/examples/stream/stream.cpp
+++ b/examples/stream/stream.cpp
@@ -345,7 +345,8 @@ int main(int argc, char ** argv) {
             wparams.audio_ctx            = params.audio_ctx;
             wparams.speed_up             = params.speed_up;
 
-            wparams.prompt_tokens        = &prompt_tokens;
+            wparams.prompt_tokens        = &prompt_tokens[0];
+            wparams.prompt_n_tokens      = prompt_tokens.size();
             
             if (whisper_full(ctx, wparams, pcmf32.data(), pcmf32.size()) != 0) {
                 fprintf(stderr, "%s: failed to process audio\n", argv[0]);

--- a/whisper.cpp
+++ b/whisper.cpp
@@ -2412,6 +2412,7 @@ struct whisper_full_params whisper_full_default_params(enum whisper_sampling_str
                     /*.speed_up             =*/ false,
                     /*.audio_ctx            =*/ 0,
 
+                    /*.prompt_tokens        =*/ nullptr,
                     /*.language             =*/ "en",
 
                     /*.greedy               =*/ {
@@ -2455,6 +2456,7 @@ struct whisper_full_params whisper_full_default_params(enum whisper_sampling_str
                     /*.speed_up             =*/ false,
                     /*.audio_ctx            =*/ 0,
 
+                    /*.prompt_tokens        =*/ nullptr,
                     /*.language             =*/ "en",
 
                     /*.greedy               =*/ {
@@ -2582,6 +2584,14 @@ int whisper_full(
     auto & prompt_past = ctx->prompt_past;
     if (params.no_context) {
         prompt_past.clear();
+    }
+
+    // Prepend the prompt tokens to the prompt_past
+    if (params.prompt_tokens) {
+        for (int i = 0; i < (int) params.prompt_tokens->size(); i++) {
+            prompt_past.push_back((*params.prompt_tokens)[i]);
+        }
+        std::rotate(prompt_past.begin(), prompt_past.end() - params.prompt_tokens->size(), prompt_past.end());
     }
 
     // overwrite audio_ctx

--- a/whisper.cpp
+++ b/whisper.cpp
@@ -2413,6 +2413,8 @@ struct whisper_full_params whisper_full_default_params(enum whisper_sampling_str
                     /*.audio_ctx            =*/ 0,
 
                     /*.prompt_tokens        =*/ nullptr,
+                    /*.prompt_n_tokens      =*/ 0,
+
                     /*.language             =*/ "en",
 
                     /*.greedy               =*/ {
@@ -2457,6 +2459,8 @@ struct whisper_full_params whisper_full_default_params(enum whisper_sampling_str
                     /*.audio_ctx            =*/ 0,
 
                     /*.prompt_tokens        =*/ nullptr,
+                    /*.prompt_n_tokens      =*/ 0,
+
                     /*.language             =*/ "en",
 
                     /*.greedy               =*/ {
@@ -2588,10 +2592,11 @@ int whisper_full(
 
     // Prepend the prompt tokens to the prompt_past
     if (params.prompt_tokens) {
-        for (int i = 0; i < (int) params.prompt_tokens->size(); i++) {
-            prompt_past.push_back((*params.prompt_tokens)[i]);
+        // Parse tokens from the pointer (it points to an std::vector)
+        for (int i = 0; i < params.prompt_n_tokens; i++) {
+            prompt_past.push_back(params.prompt_tokens[i]);
         }
-        std::rotate(prompt_past.begin(), prompt_past.end() - params.prompt_tokens->size(), prompt_past.end());
+        std::rotate(prompt_past.begin(), prompt_past.end() - params.prompt_n_tokens, prompt_past.end());
     }
 
     // overwrite audio_ctx

--- a/whisper.cpp
+++ b/whisper.cpp
@@ -2591,7 +2591,7 @@ int whisper_full(
     }
 
     // Prepend the prompt tokens to the prompt_past
-    if (params.prompt_tokens) {
+    if (params.prompt_tokens && params.prompt_n_tokens > 0) {
         // Parse tokens from the pointer (it points to an std::vector)
         for (int i = 0; i < params.prompt_n_tokens; i++) {
             prompt_past.push_back(params.prompt_tokens[i]);

--- a/whisper.h
+++ b/whisper.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <vector>
 
 #ifdef WHISPER_SHARED
 #    ifdef _WIN32
@@ -208,6 +209,7 @@ extern "C" {
         bool speed_up;  // speed-up the audio by 2x using Phase Vocoder
         int  audio_ctx; // overwrite the audio context size (0 = use default)
 
+        const std::vector<whisper_token> * prompt_tokens;
         const char * language;
 
         struct {

--- a/whisper.h
+++ b/whisper.h
@@ -3,7 +3,6 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include <vector>
 
 #ifdef WHISPER_SHARED
 #    ifdef _WIN32
@@ -209,7 +208,7 @@ extern "C" {
         bool speed_up;  // speed-up the audio by 2x using Phase Vocoder
         int  audio_ctx; // overwrite the audio context size (0 = use default)
 
-        // std::vector<whisper_token>: tokents to provide the whisper model as initial prompt
+        // std::vector<whisper_token>: tokens to provide the whisper model as initial prompt
         const whisper_token * prompt_tokens;
         int prompt_n_tokens;
 

--- a/whisper.h
+++ b/whisper.h
@@ -209,7 +209,10 @@ extern "C" {
         bool speed_up;  // speed-up the audio by 2x using Phase Vocoder
         int  audio_ctx; // overwrite the audio context size (0 = use default)
 
-        const std::vector<whisper_token> * prompt_tokens;
+        // std::vector<whisper_token>: tokents to provide the whisper model as initial prompt
+        const whisper_token * prompt_tokens;
+        int prompt_n_tokens;
+
         const char * language;
 
         struct {


### PR DESCRIPTION
ref #90 

@ggerganov a quick and dirty fix on using previous length's tokens as prompt. Beware that this is the first time I wrote cpp code, but it works - the prompt contains the correct tokens.

I first tried to tokenize a given string but that was quite problematic and beyond my nonexistent cpp capabilities. I decided to just use the tokens provided my the model, and I used a vector pointer instead of vector itself because it gave weird errors. Not sure if it is the good practice or not.