### PR TITLE
Add AVX support, inline to ggml_fp16_to_fp32, ggml_fp16_t ggml_fp32_to_fp16 and some Makefile changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,10 @@ ifdef WHISPER_OPENBLAS
 	CFLAGS  += -DGGML_USE_OPENBLAS -I/usr/local/include/openblas
 	LDFLAGS += -lopenblas
 endif
+ifdef WHISPER_GPROF
+	CFLAGS  += -pg
+	CXXFLAGS  += -pg
+endif
 ifneq ($(filter aarch64%,$(UNAME_M)),)
 endif
 ifneq ($(filter armv6%,$(UNAME_M)),)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # whisper.cpp
 
+Add AVX support to ggerganov's whisper.cpp.
+
 [![Actions Status](https://github.com/ggerganov/whisper.cpp/workflows/CI/badge.svg)](https://github.com/ggerganov/whisper.cpp/actions)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 

--- a/ggml.c
+++ b/ggml.c
@@ -140,7 +140,7 @@ static inline uint32_t fp32_to_bits(float f) {
 	return fp32.as_bits;
 }
 
-float ggml_fp16_to_fp32(ggml_fp16_t h) {
+inline float ggml_fp16_to_fp32(ggml_fp16_t h) {
     const uint32_t w = (uint32_t) h << 16;
     const uint32_t sign = w & UINT32_C(0x80000000);
     const uint32_t two_w = w + w;
@@ -163,7 +163,7 @@ float ggml_fp16_to_fp32(ggml_fp16_t h) {
     return fp32_from_bits(result);
 }
 
-ggml_fp16_t ggml_fp32_to_fp16(float f) {
+inline ggml_fp16_t ggml_fp32_to_fp16(float f) {
 #if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) || defined(__GNUC__) && !defined(__STRICT_ANSI__)
     const float scale_to_inf = 0x1.0p+112f;
     const float scale_to_zero = 0x1.0p-110f;

--- a/ggml.h
+++ b/ggml.h
@@ -723,6 +723,7 @@ enum ggml_opt_result ggml_opt(
 // system info
 //
 
+int ggml_cpu_has_avx(void);
 int ggml_cpu_has_avx2(void);
 int ggml_cpu_has_avx512(void);
 int ggml_cpu_has_neon(void);

--- a/whisper.cpp
+++ b/whisper.cpp
@@ -3041,6 +3041,7 @@ const char * whisper_print_system_info() {
     static std::string s;
 
     s  = "";
+    s += "AVX = "       + std::to_string(ggml_cpu_has_avx())       + " | ";
     s += "AVX2 = "      + std::to_string(ggml_cpu_has_avx2())      + " | ";
     s += "AVX512 = "    + std::to_string(ggml_cpu_has_avx512())    + " | ";
     s += "NEON = "      + std::to_string(ggml_cpu_has_neon())      + " | ";


### PR DESCRIPTION
Old CPU has only AVX instructions, no AVX2 and no FMA instructions.
So, I added AVX support code to ggml.c, ggml.h and whisper.cpp.
I also added 'inline' to ggml_fp16_to_fp32, ggml_fp16_t ggml_fp32_to_fp16.

And I added Makefile to detect AVX,AVX2,FMA,F16C, OpenBLAS option, gprof option.
You can enable OpenBLAS and gprof, WHISPER_OPENBLAS=1 WHISPER_GPROF=1 make

Please ignore changes in README.md.
