### PR TITLE
Better error message on skipping a second

### DIFF
--- a/whisper.cpp
+++ b/whisper.cpp
@@ -2780,7 +2780,7 @@ int whisper_full(
         }
 
         if (failed) {
-            fprintf(stderr, "\n%s: failed to generate timestamp token - using fallback strategy\n\n", __func__);
+            fprintf(stderr, "\n%s: failed to generate timestamp token - skipping one second\n\n", __func__);
             seek += 100;
             continue;
         }


### PR DESCRIPTION
Also, this works in the begging of the file, but in the middle I get repeated tokens sometimes and time timestamp keeps on advancing:
[00:22:16.000 --> 00:22:18.000]   Because you really need all the powers.
[00:22:18.000 --> 00:22:27.000]   [Indiscernible]
[00:22:27.000 --> 00:22:28.000]   Take off 1-8 center.
[00:22:28.000 --> 00:22:40.000]   [Indiscernible]
[00:22:40.000 --> 00:22:48.000]   [Indiscernible]
[00:22:48.000 --> 00:22:49.000]   80 knots.
[00:22:49.000 --> 00:22:53.000]   Yes.
[00:22:53.000 --> 00:22:54.000]   V1.
[00:22:54.000 --> 00:22:55.000]   V1.
[00:22:55.000 --> 00:22:56.000]   V1.
[00:22:56.000 --> 00:22:57.000]   V1.
[00:22:57.000 --> 00:22:58.000]   V1.
[00:22:58.000 --> 00:22:59.000]   V1.
[00:22:59.000 --> 00:23:00.000]   V1.
etc stuck at V1