### PR TITLE
Resolves some of warnings when compiling with clang/clang++

### DIFF
--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -550,11 +550,11 @@ int main(int argc, char ** argv) {
             // convert to mono, float
             pcmf32.resize(n);
             if (wav.channels == 1) {
-                for (int i = 0; i < n; i++) {
+                for (uint64_t i = 0; i < n; i++) {
                     pcmf32[i] = float(pcm16[i])/32768.0f;
                 }
             } else {
-                for (int i = 0; i < n; i++) {
+                for (uint64_t i = 0; i < n; i++) {
                     pcmf32[i] = float(pcm16[2*i] + pcm16[2*i + 1])/65536.0f;
                 }
             }
@@ -565,7 +565,7 @@ int main(int argc, char ** argv) {
 
                 pcmf32s[0].resize(n);
                 pcmf32s[1].resize(n);
-                for (int i = 0; i < n; i++) {
+                for (uint64_t i = 0; i < n; i++) {
                     pcmf32s[0][i] = float(pcm16[2*i])/32768.0f;
                     pcmf32s[1][i] = float(pcm16[2*i + 1])/32768.0f;
                 }

--- a/whisper.cpp
+++ b/whisper.cpp
@@ -2360,7 +2360,7 @@ struct whisper_token_data whisper_sample_timestamp(struct whisper_context * ctx,
 int whisper_tokenize(struct whisper_context * ctx, const char * text, whisper_token * tokens, int n_max_tokens) {
     const auto res = tokenize(ctx->vocab, text);
 
-    if (res.size() > n_max_tokens) {
+    if (n_max_tokens < (int) res.size()) {
         fprintf(stderr, "%s: too many resulting tokens: %d (max %d)\n", __func__, (int) res.size(), n_max_tokens);
         return -1;
     }

--- a/whisper.cpp
+++ b/whisper.cpp
@@ -2357,15 +2357,15 @@ struct whisper_token_data whisper_sample_timestamp(struct whisper_context * ctx,
     return res;
 }
 
-int whisper_tokenize(struct whisper_context * ctx, const char * text, whisper_token * tokens, std::size_t n_max_tokens) {
+int whisper_tokenize(struct whisper_context * ctx, const char * text, whisper_token * tokens, int n_max_tokens) {
     const auto res = tokenize(ctx->vocab, text);
 
     if (res.size() > n_max_tokens) {
-        fprintf(stderr, "%s: too many resulting tokens: %d (max %zu)\n", __func__, (int) res.size(), n_max_tokens);
+        fprintf(stderr, "%s: too many resulting tokens: %d (max %d)\n", __func__, (int) res.size(), n_max_tokens);
         return -1;
     }
 
-    for (std::size_t i = 0; i < res.size(); i++) {
+    for (int i = 0; i < (int) res.size(); i++) {
         tokens[i] = res[i];
     }
 
@@ -2438,7 +2438,7 @@ int whisper_lang_auto_detect(
     }
 
     std::vector<std::pair<float, int>> probs_id;
-    for (const auto &kv : g_lang) {
+    for (const auto & kv : g_lang) {
         const auto token_lang = whisper_token_lang(ctx, kv.second.first);
         probs_id.push_back({ ctx->probs[token_lang], kv.second.first });
     }
@@ -2464,7 +2464,7 @@ int whisper_lang_auto_detect(
     }
 
     {
-        for (std::size_t i = 0; i < probs_id.size(); i++) {
+        for (int i = 0; i < (int) probs_id.size(); i++) {
             if (lang_probs) {
                 lang_probs[probs_id[i].second] = probs_id[i].first;
             }

--- a/whisper.cpp
+++ b/whisper.cpp
@@ -2357,15 +2357,15 @@ struct whisper_token_data whisper_sample_timestamp(struct whisper_context * ctx,
     return res;
 }
 
-int whisper_tokenize(struct whisper_context * ctx, const char * text, whisper_token * tokens, int n_max_tokens) {
+int whisper_tokenize(struct whisper_context * ctx, const char * text, whisper_token * tokens, std::size_t n_max_tokens) {
     const auto res = tokenize(ctx->vocab, text);
 
     if (res.size() > n_max_tokens) {
-        fprintf(stderr, "%s: too many resulting tokens: %d (max %d)\n", __func__, (int) res.size(), n_max_tokens);
+        fprintf(stderr, "%s: too many resulting tokens: %d (max %zu)\n", __func__, (int) res.size(), n_max_tokens);
         return -1;
     }
 
-    for (int i = 0; i < res.size(); i++) {
+    for (std::size_t i = 0; i < res.size(); i++) {
         tokens[i] = res[i];
     }
 
@@ -2438,7 +2438,7 @@ int whisper_lang_auto_detect(
     }
 
     std::vector<std::pair<float, int>> probs_id;
-    for (const auto kv : g_lang) {
+    for (const auto &kv : g_lang) {
         const auto token_lang = whisper_token_lang(ctx, kv.second.first);
         probs_id.push_back({ ctx->probs[token_lang], kv.second.first });
     }
@@ -2464,7 +2464,7 @@ int whisper_lang_auto_detect(
     }
 
     {
-        for (int i = 0; i < probs_id.size(); i++) {
+        for (std::size_t i = 0; i < probs_id.size(); i++) {
             if (lang_probs) {
                 lang_probs[probs_id[i].second] = probs_id[i].first;
             }

--- a/whisper.h
+++ b/whisper.h
@@ -1,6 +1,7 @@
 #ifndef WHISPER_H
 #define WHISPER_H
 
+#include <cstddef>
 #include <stdint.h>
 #include <stdbool.h>
 
@@ -148,7 +149,7 @@ extern "C" {
             struct whisper_context * ctx,
                         const char * text,
                      whisper_token * tokens,
-                               int   n_max_tokens);
+	               std::size_t   n_max_tokens);
 
     // Largest language id (i.e. number of available languages - 1)
     WHISPER_API int whisper_lang_max_id();

--- a/whisper.h
+++ b/whisper.h
@@ -1,7 +1,6 @@
 #ifndef WHISPER_H
 #define WHISPER_H
 
-#include <cstddef>
 #include <stdint.h>
 #include <stdbool.h>
 
@@ -149,7 +148,7 @@ extern "C" {
             struct whisper_context * ctx,
                         const char * text,
                      whisper_token * tokens,
-	               std::size_t   n_max_tokens);
+	                           int   n_max_tokens);
 
     // Largest language id (i.e. number of available languages - 1)
     WHISPER_API int whisper_lang_max_id();


### PR DESCRIPTION
Mostly nit stuff that clang catches when compiling with -Wall -Wextra -pedantic.

- Fix comparison between sign/unsigned integers.
- Passes a constant reference (const&) instead of copying each time.