### PR TITLE
ggml : add f16 acceleration for POWER9 ppc64le

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,12 @@ endif
 ifeq ($(UNAME_M),amd64)
 	CFLAGS += -mavx -mavx2 -mfma -mf16c
 endif
+ifeq ($(UNAME_M),ppc64le)
+	POWER9_M := $(shell grep "POWER9" /proc/cpuinfo)
+	ifneq (,$(findstring POWER9,$(POWER9_M)))
+		CFLAGS += -mpower9-vector
+	endif
+endif
 ifndef WHISPER_NO_ACCELERATE
 	# Mac M1 - include Accelerate framework
 	ifeq ($(UNAME_S),Darwin)


### PR DESCRIPTION
Without this patch, the jfk.wav example runs in 36 seconds on my ppc64le machine.  With the patch, it runs in five seconds.  This fixes #240 and should help with #300.