### PR TITLE
Add runtime destination install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,6 +223,7 @@ target_compile_definitions(${TARGET} PUBLIC
 install(TARGETS ${TARGET}
     LIBRARY DESTINATION lib
     ARCHIVE DESTINATION lib/static
+    RUNTIME DESTINATION bin
     )
 
 #


### PR DESCRIPTION
Needed for mingw32 build to successfully install the dlls in the correct location. 

I realise the default setting in the CMakefile disables the shared library build for mingw32, but when I force it on, I need this change to install the dlls. 

(As an aside, we compile and ship binaries for about 9 different platforms for this library for the Julia ecosystem. https://github.com/JuliaPackaging/Yggdrasil/pull/6021)
