### PR TITLE
cmake : Update to more modern version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,15 +1,14 @@
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 3.19)
 
 project(whisper.cpp VERSION 1.0.4)
 
-set(CMAKE_EXPORT_COMPILE_COMMANDS "on")
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
-set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+# Add path to modules
+list( APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/" )
 
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     set(WHISPER_STANDALONE ON)
-    include(cmake/GitVars.cmake)
-    include(cmake/BuildTypes.cmake)
+    include(GitVars)
+    include(BuildTypes)
 
     # configure project version
     if (EXISTS "${CMAKE_SOURCE_DIR}/bindings/ios/Makefile-tmpl")
@@ -81,9 +80,6 @@ endif()
 #set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -march=native")
 
 # dependencies
-
-set(CMAKE_C_STANDARD   11)
-set(CMAKE_CXX_STANDARD 11)
 
 find_package(Threads REQUIRED)
 
@@ -189,6 +185,8 @@ add_library(${TARGET}
     whisper.h
     whisper.cpp
     )
+
+include(DefaultTargetOptions)
 
 target_include_directories(${TARGET} PUBLIC
     .

--- a/cmake/DefaultTargetOptions.cmake
+++ b/cmake/DefaultTargetOptions.cmake
@@ -1,0 +1,17 @@
+# Set the default compile features and properties for a target.
+
+if (NOT TARGET)
+    message(FATAL_ERROR "TARGET not set before including DefaultTargetOptions")
+endif()
+
+target_compile_features(${TARGET}
+    PRIVATE
+        cxx_std_11
+    )
+
+set_target_properties(${TARGET}
+    PROPERTIES
+        EXPORT_COMPILE_COMMANDS ON
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+        INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib"
+)

--- a/examples/bench.wasm/CMakeLists.txt
+++ b/examples/bench.wasm/CMakeLists.txt
@@ -8,6 +8,8 @@ add_executable(${TARGET}
     emscripten.cpp
     )
 
+include(DefaultTargetOptions)
+
 target_link_libraries(${TARGET} PRIVATE
     whisper
     )

--- a/examples/bench/CMakeLists.txt
+++ b/examples/bench/CMakeLists.txt
@@ -1,3 +1,6 @@
 set(TARGET bench)
 add_executable(${TARGET} bench.cpp)
+
+include(DefaultTargetOptions)
+
 target_link_libraries(${TARGET} PRIVATE whisper ${CMAKE_THREAD_LIBS_INIT})

--- a/examples/command.wasm/CMakeLists.txt
+++ b/examples/command.wasm/CMakeLists.txt
@@ -8,6 +8,8 @@ add_executable(${TARGET}
     emscripten.cpp
     )
 
+include(DefaultTargetOptions)
+
 target_link_libraries(${TARGET} PRIVATE
     whisper
     )

--- a/examples/command/CMakeLists.txt
+++ b/examples/command/CMakeLists.txt
@@ -2,6 +2,9 @@ if (WHISPER_SUPPORT_SDL2)
     # command
     set(TARGET command)
     add_executable(${TARGET} command.cpp)
+
+    include(DefaultTargetOptions)
+
     target_include_directories(${TARGET} PRIVATE ${SDL2_INCLUDE_DIRS})
     target_link_libraries(${TARGET} PRIVATE whisper ${SDL2_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 endif ()

--- a/examples/main/CMakeLists.txt
+++ b/examples/main/CMakeLists.txt
@@ -1,3 +1,6 @@
 set(TARGET main)
 add_executable(${TARGET} main.cpp)
+
+include(DefaultTargetOptions)
+
 target_link_libraries(${TARGET} PRIVATE whisper ${CMAKE_THREAD_LIBS_INIT})

--- a/examples/stream.wasm/CMakeLists.txt
+++ b/examples/stream.wasm/CMakeLists.txt
@@ -8,6 +8,8 @@ add_executable(${TARGET}
     emscripten.cpp
     )
 
+include(DefaultTargetOptions)
+
 target_link_libraries(${TARGET} PRIVATE
     whisper
     )

--- a/examples/stream/CMakeLists.txt
+++ b/examples/stream/CMakeLists.txt
@@ -2,6 +2,9 @@ if (WHISPER_SUPPORT_SDL2)
     # stream
     set(TARGET stream)
     add_executable(${TARGET} stream.cpp)
+
+    include(DefaultTargetOptions)
+
     target_include_directories(${TARGET} PRIVATE ${SDL2_INCLUDE_DIRS})
     target_link_libraries(${TARGET} PRIVATE whisper ${SDL2_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 endif ()

--- a/examples/talk.wasm/CMakeLists.txt
+++ b/examples/talk.wasm/CMakeLists.txt
@@ -9,6 +9,8 @@ add_executable(${TARGET}
     gpt-2.cpp
     )
 
+include(DefaultTargetOptions)
+
 target_link_libraries(${TARGET} PRIVATE
     whisper
     )

--- a/examples/talk/CMakeLists.txt
+++ b/examples/talk/CMakeLists.txt
@@ -8,6 +8,9 @@ if (WHISPER_SUPPORT_SDL2)
     # TODO: this is temporary
     #       need to export ggml symbols for MSVC, but too lazy ..
     add_executable(${TARGET} talk.cpp gpt-2.cpp ../../ggml.c ../../whisper.cpp)
+
+    include(DefaultTargetOptions)
+
     target_include_directories(${TARGET} PRIVATE ${SDL2_INCLUDE_DIRS} ../../)
     target_link_libraries(${TARGET} PRIVATE ${SDL2_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 endif ()

--- a/examples/whisper.wasm/CMakeLists.txt
+++ b/examples/whisper.wasm/CMakeLists.txt
@@ -8,6 +8,8 @@ add_executable(${TARGET}
     emscripten.cpp
     )
 
+include(DefaultTargetOptions)
+
 target_link_libraries(${TARGET} PRIVATE
     whisper
     )


### PR DESCRIPTION
- update from 3.0 (from 2014) to 3.19 (from 2020)
- move some global setting onto the targets (through a cmake include)

Right now it's not possible to include whisper.cpp using `add_subdirectory()` because it modifies the global cmake state (C++ version, install paths, etc.).

This PR starts to move it towards a proper target-based approach.

I created a cmake include file to more easily set the defaults on the many examples, though it could just as well be copied into each file if you like.

I don't have a way to test the EMSCRIPTEN changes, but they mirror all the other examples.