### PR TITLE
Do sample_to_timestamp calculation with 64 bit precision to avoid overflow

### DIFF
--- a/whisper.cpp
+++ b/whisper.cpp
@@ -3387,8 +3387,8 @@ static int timestamp_to_sample(int64_t t, int n_samples) {
     return std::max(0, std::min((int) n_samples - 1, (int) ((t*WHISPER_SAMPLE_RATE)/100)));
 }
 
-static int64_t sample_to_timestamp(int64_t i_sample) {
-    return (100*i_sample)/WHISPER_SAMPLE_RATE;
+static int64_t sample_to_timestamp(int i_sample) {
+    return (100ll*i_sample)/WHISPER_SAMPLE_RATE;
 }
 
 // a cost-function / heuristic that is high for text that takes longer to pronounce

--- a/whisper.cpp
+++ b/whisper.cpp
@@ -3387,7 +3387,7 @@ static int timestamp_to_sample(int64_t t, int n_samples) {
     return std::max(0, std::min((int) n_samples - 1, (int) ((t*WHISPER_SAMPLE_RATE)/100)));
 }
 
-static int64_t sample_to_timestamp(int i_sample) {
+static int64_t sample_to_timestamp(int64_t i_sample) {
     return (100*i_sample)/WHISPER_SAMPLE_RATE;
 }
 


### PR DESCRIPTION
As written, the `sample_to_timestamp` function will overflow around 22 and a half minutes and it will start returning negative timestamps.

22m23s = 1343s
1343s * 16000 samples/s = 21488000 samples
Passing 21488000 to `sample_to_timestamp` would result in 100*21488000 (2148800000), which overflows to -2146167296 before that result is divided again by the sample rate.

By doing the multiplication with 64 bit precision, you avoid the overflow and you can now process audio clips longer than 22 minutes.