### PR TITLE
ggml: correct behaviour of ggml_vec_sum_f32

### DIFF
--- a/ggml.c
+++ b/ggml.c
@@ -1109,8 +1109,8 @@ inline static void ggml_vec_sum_f32(const int n, float * s, const float * x) {
     ggml_float sum = 0.0;
     for (int i = 0; i < n; ++i) {
         sum += x[i];
-        *s += sum;
     }
+    *s = sum;
 #else
     vDSP_sve(x, 1, s, n);
 #endif


### PR DESCRIPTION
Assuming the new implementation with accelerate is correct, the implementation of ggml_vec_sum_f32 has been wrong since the initial release. This PR corrects the behaviour.