### PR TITLE
go: add wrapper for system info

### DIFF
--- a/bindings/go/examples/go-whisper/process.go
+++ b/bindings/go/examples/go-whisper/process.go
@@ -25,6 +25,8 @@ func Process(model whisper.Model, path string, flags *Flags) error {
 		return err
 	}
 
+	fmt.Printf("\n%s\n", context.SystemInfo())
+
 	// Open the file
 	fmt.Fprintf(flags.Output(), "Loading %q\n", path)
 	fh, err := os.Open(path)

--- a/bindings/go/params.go
+++ b/bindings/go/params.go
@@ -66,6 +66,11 @@ func (p *Params) Language() int {
 	return int(C.whisper_lang_id(p.language))
 }
 
+// Threads available
+func (p *Params) Threads() int {
+	return int(p.n_threads)
+}
+
 // Set number of threads to use
 func (p *Params) SetThreads(threads int) {
 	p.n_threads = C.int(threads)

--- a/bindings/go/pkg/whisper/context.go
+++ b/bindings/go/pkg/whisper/context.go
@@ -1,7 +1,9 @@
 package whisper
 
 import (
+	"fmt"
 	"io"
+	"runtime"
 	"strings"
 	"time"
 
@@ -117,13 +119,22 @@ func (context *context) PrintTimings() {
 	context.model.ctx.Whisper_print_timings()
 }
 
+// SystemInfo returns the system information
+func (context *context) SystemInfo() string {
+	return fmt.Sprintf("system_info: n_threads = %d / %d | %s\n",
+		context.params.Threads(),
+		runtime.NumCPU(),
+		whisper.Whisper_print_system_info(),
+	)
+}
+
 // Use mel data at offset_ms to try and auto-detect the spoken language
 // Make sure to call whisper_pcm_to_mel() or whisper_set_mel() first.
 // Returns the probabilities of all languages.
 func (context *context) WhisperLangAutoDetect(offset_ms int, n_threads int) ([]float32, error) {
 	langProbs, err := context.model.ctx.Whisper_lang_auto_detect(offset_ms, n_threads)
 	if err != nil {
-			return nil, err
+		return nil, err
 	}
 	return langProbs, nil
 }

--- a/bindings/go/pkg/whisper/interface.go
+++ b/bindings/go/pkg/whisper/interface.go
@@ -61,8 +61,11 @@ type Context interface {
 	IsLANG(Token, string) bool // Test for token associated with a specific language
 	IsText(Token) bool         // Test for text token
 
+	// Timings
 	PrintTimings()
 	ResetTimings()
+
+	SystemInfo() string
 }
 
 // Segment is the text result of a speech recognition.


### PR DESCRIPTION
```
whisper_init_from_file: loading model from '/home/glaslos/workspace/whisper.cpp/bindings/go/models/ggml-small.en.bin'
whisper_model_load: loading model
whisper_model_load: n_vocab       = 51864
whisper_model_load: n_audio_ctx   = 1500
whisper_model_load: n_audio_state = 768
whisper_model_load: n_audio_head  = 12
whisper_model_load: n_audio_layer = 12
whisper_model_load: n_text_ctx    = 448
whisper_model_load: n_text_state  = 768
whisper_model_load: n_text_head   = 12
whisper_model_load: n_text_layer  = 12
whisper_model_load: n_mels        = 80
whisper_model_load: f16           = 1
whisper_model_load: type          = 3
whisper_model_load: mem required  = 1027.00 MB (+   16.00 MB per decoder)
whisper_model_load: kv self size  =   15.75 MB
whisper_model_load: kv cross size =   52.73 MB
whisper_model_load: adding 1607 extra tokens
whisper_model_load: model ctx     =  464.56 MB
whisper_model_load: model size    =  464.44 MB

system_info: n_threads = 16 / 16 | AVX = 1 | AVX2 = 1 | AVX512 = 0 | FMA = 1 | NEON = 0 | ARM_FMA = 0 | F16C = 1 | FP16_VA = 0 | WASM_SIMD = 0 | BLAS = 0 | SSE3 = 1 | VSX = 0 | 

Loading "samples/jfk.wav"
  ...processing "samples/jfk.wav"

whisper_print_timings:     fallbacks =   0 p /   0 h
whisper_print_timings:     load time =   304.42 ms
whisper_print_timings:      mel time =    21.51 ms
whisper_print_timings:   sample time =     9.78 ms /    30 runs (    0.33 ms per run)
whisper_print_timings:   encode time =  1908.93 ms /     1 runs ( 1908.93 ms per run)
whisper_print_timings:   decode time =   880.89 ms /    30 runs (   29.36 ms per run)
whisper_print_timings:    total time =  3158.26 ms
[    0s->    8s]  And so, my fellow Americans, ask not what your country can do for you.
[    8s->   11s]  Ask what you can do for your country.
```