### PR TITLE
Store lang_id in context

### DIFF
--- a/whisper.cpp
+++ b/whisper.cpp
@@ -570,6 +570,8 @@ struct whisper_context {
 
     mutable std::mt19937 rng; // used for sampling at t > 0.0
 
+    int lang_id;
+
     // [EXPERIMENTAL] token-level timestamps data
     int64_t t_beg;
     int64_t t_last;
@@ -3303,7 +3305,7 @@ int whisper_full(
             fprintf(stderr, "%s: failed to auto-detect language\n", __func__);
             return -3;
         }
-
+        ctx->lang_id = lang_id;
         params.language = whisper_lang_str(lang_id);
 
         fprintf(stderr, "%s: auto-detected language: %s (p = %f)\n", __func__, params.language, probs[whisper_lang_id(params.language)]);
@@ -3400,6 +3402,7 @@ int whisper_full(
     std::vector<whisper_token> prompt_init = { whisper_token_sot(ctx) };
     if (whisper_is_multilingual(ctx)) {
         const int lang_id = whisper_lang_id(params.language);
+        ctx->lang_id = lang_id;
         prompt_init.push_back(whisper_token_lang(ctx, lang_id));
         if (params.translate) {
             prompt_init.push_back(whisper_token_translate());
@@ -4118,6 +4121,10 @@ int whisper_full_parallel(
 
 int whisper_full_n_segments(struct whisper_context * ctx) {
     return ctx->result_all.size();
+}
+
+int whisper_full_lang_id(struct whisper_context * ctx) {
+    return ctx->lang_id; 
 }
 
 int64_t whisper_full_get_segment_t0(struct whisper_context * ctx, int i_segment) {

--- a/whisper.h
+++ b/whisper.h
@@ -329,6 +329,9 @@ extern "C" {
     // A segment can be a few words, a sentence, or even a paragraph.
     WHISPER_API int whisper_full_n_segments(struct whisper_context * ctx);
 
+    // Language id associated with the current context
+    WHISPER_API int whisper_full_lang_id(struct whisper_context * ctx);
+
     // Get the start and end time of the specified segment.
     WHISPER_API int64_t whisper_full_get_segment_t0(struct whisper_context * ctx, int i_segment);
     WHISPER_API int64_t whisper_full_get_segment_t1(struct whisper_context * ctx, int i_segment);


### PR DESCRIPTION
This stores the language id in the context. This is useful if you are using the auto detect language feature, and want access to the language after the running `whisper_full`. 

I am not very familiar with C++ so feel free to ignore this if it is not the correct approach. If you do know another way to access this value without having to rerun the language detection with `whisper_lang_auto_detect`, it would be great if you could share that information with me. 

With this code you can do something like this:
```cpp
whisper_lang_str(whisper_full_lang_id(ctx));
```
After running `whisper_full` - to get a string like `en` or `cs`