### PR TITLE
Fix for signedness compiler warning

### DIFF
--- a/whisper.cpp
+++ b/whisper.cpp
@@ -3854,7 +3854,7 @@ int whisper_full(
                         return a.sequence.sum_logprobs_all > b.sequence.sum_logprobs_all;
                     });
 
-                    signed int cur_c = 0;
+                    unsigned int cur_c = 0;
 
                     for (int j = 0; j < n_decoders_cur; ++j) {
                         auto & decoder = ctx->decoders[j];

--- a/whisper.cpp
+++ b/whisper.cpp
@@ -3854,7 +3854,7 @@ int whisper_full(
                         return a.sequence.sum_logprobs_all > b.sequence.sum_logprobs_all;
                     });
 
-                    int cur_c = 0;
+                    signed int cur_c = 0;
 
                     for (int j = 0; j < n_decoders_cur; ++j) {
                         auto & decoder = ctx->decoders[j];


### PR DESCRIPTION
Eliminates the following compiler warning:

```
whisper.cpp:3868:55: warning: comparison of integer expressions of different signedness: ‘std::vector<whisper_full(whisper_context*, whisper_full_params, const float*, int)::beam_candidate>::size_type’ {aka ‘long unsigned int’} and ‘int’ [-Wsign-compare]
 3868 |                         while (beam_candidates.size() > cur_c && beam_candidates[cur_c].sequence.sum_logprobs_all == cur.sequence.sum_logprobs_all && i > 0) {
      |                                ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
```
gcc 11.3.0 on Ubuntu 22.04 using cmake.