### PR TITLE
Fix uninitialized `exp_n_audio_ctx`

### DIFF
--- a/whisper.cpp
+++ b/whisper.cpp
@@ -601,7 +601,7 @@ struct whisper_context {
     std::vector<float> energy; // PCM signal energy
 
     // [EXPERIMENTAL] speed-up techniques
-    int32_t exp_n_audio_ctx; // 0 - use default
+    int32_t exp_n_audio_ctx = 0; // 0 - use default
 
     void use_buf(struct ggml_context * ctx, int i) {
 #if defined(WHISPER_USE_SCRATCH)


### PR DESCRIPTION
We've been using whisper.cpp (whisper.spm) in www.detail.co and have run into a number of crashes at this assertion:
https://github.com/ggerganov/whisper.cpp/blob/0d229163bbea769c7a3e0e500e45850c9a6e2e42/ggml.c#L1653-L1657

Debugging these it seems like `exp_n_audio_ctx` is not initialized before `whisper_lang_auto_detect` -> `whisper_encode`, and `n_ctx` is therefore set to a large random number, creating a mel tensor that runs out of memory.

https://github.com/ggerganov/whisper.cpp/blob/0d229163bbea769c7a3e0e500e45850c9a6e2e42/whisper.cpp#L1368

Initializing `exp_n_audio_ctx` to 0 fixes this issue for us.