### PR TITLE
Add "-mcpu=native" when building for aarch64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,8 @@ ifdef WHISPER_GPROF
 	CXXFLAGS += -pg
 endif
 ifneq ($(filter aarch64%,$(UNAME_M)),)
+	CFLAGS += -mcpu=native
+	CXXFLAGS += -mcpu=native
 endif
 ifneq ($(filter armv6%,$(UNAME_M)),)
 	# Raspberry Pi 1, 2, 3


### PR DESCRIPTION
Performance test was done in https://github.com/ggerganov/whisper.cpp/issues/89#issuecomment-1444918927 and https://github.com/ggerganov/whisper.cpp/issues/89#issuecomment-1443688585

1. While the test was done only for Ampere A1 on Oracle Cloud, there's a recommendation from ARM to just set `-mcpu=native`. We might as well do it for all ARM CPUs.
https://community.arm.com/arm-community-blogs/b/tools-software-ides-blog/posts/compiler-flags-across-architectures-march-mtune-and-mcpu

2. On Ampere A1 on Oracle Cloud, FP16 will be enabled with `-mcpu=native` which results in large performance gains.

3. If it's not acceptable to do this for all ARM CPUs, I can add an `ifdef WHISPER_AMPERE_A1` check before enabling `-mcpu=native`.

ARM CPUs aren't very good at reporting their names and cannot easily identify it.
```
cat /proc/cpuinfo
processor       : 0
BogoMIPS        : 50.00
Features        : fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm lrcpc dcpop asimddp ssbs
CPU implementer : 0x41
CPU architecture: 8
CPU variant     : 0x3
CPU part        : 0xd0c
CPU revision    : 1
```



