### PR TITLE
Go binding: NewContext now returns a clean context

### DIFF
--- a/bindings/go/pkg/whisper/model.go
+++ b/bindings/go/pkg/whisper/model.go
@@ -94,6 +94,7 @@ func (model *model) NewContext() (Context, error) {
 	params.SetPrintRealtime(false)
 	params.SetPrintTimestamps(false)
 	params.SetThreads(runtime.NumCPU())
+	params.SetNoContext(true)
 
 	// Return new context
 	return newContext(model, params)


### PR DESCRIPTION
It makes more sense to return a clean context upon `NewContext` call