### PR TITLE
update csv output format to match OpenAI's Whisper dataframe output

### DIFF
--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -352,13 +352,14 @@ bool output_csv(struct whisper_context * ctx, const char * fname) {
     fprintf(stderr, "%s: saving output to '%s'\n", __func__, fname);
 
     const int n_segments = whisper_full_n_segments(ctx);
+    fout << "start,end,text\n";
     for (int i = 0; i < n_segments; ++i) {
         const char * text = whisper_full_get_segment_text(ctx, i);
         const int64_t t0 = whisper_full_get_segment_t0(ctx, i);
         const int64_t t1 = whisper_full_get_segment_t1(ctx, i);
 
         //need to multiply times returned from whisper_full_get_segment_t{0,1}() by 10 to get milliseconds.
-        fout << 10 * t0 << ", " << 10 * t1 << ", \"" << text    << "\"\n";
+        fout << 10 * t0 << "," << 10 * t1 << ",\"" << text    << "\"\n";
     }
 
     return true;


### PR DESCRIPTION
Currently, the csv output file does not have column field names. And when the file is read by data analysis tool (pandas e.g.), it will raise parsing and tokenizing errors.  
```python
import pandas as pd

pd.read_csv(output.csv, names=columns)
# pandas.errors.ParserError: Error tokenizing data
```

This can be resolved by setting delimiter to a whitespace character in the read function. However, this would cause the start timestamp and end timestamp to be read as string with commas by default.  
```python
pd.read_csv(output.csv, names=columns, delimiter=" ")
"""
      start      end                                               text
0        0,   10320,   We're not actually looking at on the screen, ...
1    10320,   18100,        And you can see that recording has started?
2    18100,   23600,                       Recording and transcription.
"""
```
This change allows the result csv file to be read successfully by default with the start and end timestamps as `int64` type.  