### PR TITLE
Fixed language auto-detection for state provided processing.

### DIFF
--- a/whisper.cpp
+++ b/whisper.cpp
@@ -2856,7 +2856,7 @@ int whisper_lang_auto_detect_with_state(
     }
 
     // run the encoder
-    if (whisper_encode(ctx, seek, n_threads) != 0) {
+    if (whisper_encode_with_state(ctx, state, seek, n_threads) != 0) {
         fprintf(stderr, "%s: failed to encode\n", __func__);
         return -6;
     }


### PR DESCRIPTION
It seems I missed to pass the state for encoder during auto-detect language.

This is the fix.

Issue reported on: https://github.com/sandrohanea/whisper.net/issues/18