### PR TITLE
Nodejs Addon blocking main thread. Implemented Napi::AsyncWorker

### DIFF
--- a/examples/addon.node/addon.cpp
+++ b/examples/addon.node/addon.cpp
@@ -292,51 +292,64 @@ int run(whisper_params &params, std::vector<std::vector<std::string>> &result) {
     return 0;
 }
 
-Napi::Object whisper(const Napi::CallbackInfo& info) {
-    Napi::Env env = info.Env();
-    if (info.Length() <= 0 || !info[0].IsObject()) {
-        Napi::TypeError::New(env, "object expected").ThrowAsJavaScriptException();
-    }
-    whisper_params params;
-    std::vector<std::vector<std::string>> result;
+class Worker : public Napi::AsyncWorker {
+ public:
+  Worker(Napi::Function& callback, whisper_params params)
+      : Napi::AsyncWorker(callback), params(params) {}
 
-    Napi::Object whisper_params = info[0].As<Napi::Object>();
-    std::string language = whisper_params.Get("language").As<Napi::String>();
-    std::string model = whisper_params.Get("model").As<Napi::String>();
-    std::string input = whisper_params.Get("fname_inp").As<Napi::String>();
-
-    params.language = language;
-    params.model = model;
-    params.fname_inp.emplace_back(input);
-
-    // run model
+  void Execute() override {
     run(params, result);
+  }
 
-    fprintf(stderr, "RESULT:\n");
-    for (auto sentence:result) {
-        fprintf(stderr, "t0: %s, t1: %s, content: %s \n",
-                sentence[0].c_str(), sentence[1].c_str(), sentence[2].c_str());
-    }
-
-    Napi::Object res = Napi::Array::New(env, result.size());
+  void OnOK() override {
+    Napi::HandleScope scope(Env());
+    Napi::Object res = Napi::Array::New(Env(), result.size());
     for (uint64_t i = 0; i < result.size(); ++i) {
-        Napi::Object tmp = Napi::Array::New(env, 3);
-        for (uint64_t j = 0; j < 3; ++j) {
-            tmp[j] = Napi::String::New(env, result[i][j]);
-        }
-        res[i] = tmp;
+      Napi::Object tmp = Napi::Array::New(Env(), 3);
+      for (uint64_t j = 0; j < 3; ++j) {
+        tmp[j] = Napi::String::New(Env(), result[i][j]);
+      }
+      res[i] = tmp;
     }
+    Callback().Call({Env().Null(), res});
+  }
 
-    return res;
+ private:
+  whisper_params params;
+  std::vector<std::vector<std::string>> result;
+};
+
+
+
+Napi::Value whisper(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (info.Length() <= 0 || !info[0].IsObject()) {
+    Napi::TypeError::New(env, "object expected").ThrowAsJavaScriptException();
+  }
+  whisper_params params;
+
+  Napi::Object whisper_params = info[0].As<Napi::Object>();
+  std::string language = whisper_params.Get("language").As<Napi::String>();
+  std::string model = whisper_params.Get("model").As<Napi::String>();
+  std::string input = whisper_params.Get("fname_inp").As<Napi::String>();
+
+  params.language = language;
+  params.model = model;
+  params.fname_inp.emplace_back(input);
+
+  Napi::Function callback = info[1].As<Napi::Function>();
+  Worker* worker = new Worker(callback, params);
+  worker->Queue();
+  return env.Undefined();
 }
 
 
 Napi::Object Init(Napi::Env env, Napi::Object exports) {
-    exports.Set(
-            Napi::String::New(env, "whisper"),
-            Napi::Function::New(env, whisper)
-    );
-    return exports;
+  exports.Set(
+      Napi::String::New(env, "whisper"),
+      Napi::Function::New(env, whisper)
+  );
+  return exports;
 }
 
 NODE_API_MODULE(whisper, Init);


### PR DESCRIPTION
This pull request aims to modify the code for the Whisper Node.js addon to avoid running in a blocking manner. Previously, even though you could import it in Node.js and use a queuing system to prevent blocking the main thread, the Whisper addon would still block the entire execution of Node.js, preventing any other task from running until the transcription was complete.

For example, if you use a queue package like Bull and expect to receive three requests and execute three transcriptions in parallel, the current version of the Whisper addon would only process one request and block the main thread until the transcription is finished.

I have implemented a fix in my personal project, which allows me to execute numerous Whisper tasks simultaneously while receiving and registering new jobs to execute when threads become available. This modification will greatly enhance the efficiency and usability of the Whisper Node.js addon.

