### PR TITLE
fix typo in JSON output

### DIFF
--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -455,7 +455,7 @@ bool output_json(struct whisper_context * ctx, const char * fname, const whisper
                 value_i("ctx", whisper_model_n_text_ctx(ctx));
                 value_i("state", whisper_model_n_text_state(ctx));
                 value_i("head", whisper_model_n_text_head(ctx));
-                value_i("leyer", whisper_model_n_text_layer(ctx), true);
+                value_i("layer", whisper_model_n_text_layer(ctx), true);
             end_obj();
             value_i("mels", whisper_model_n_mels(ctx));
             value_i("f16", whisper_model_f16(ctx), true);
@@ -477,7 +477,7 @@ bool output_json(struct whisper_context * ctx, const char * fname, const whisper
                 const int64_t t1 = whisper_full_get_segment_t1(ctx, i);
 
                 start_obj();
-                    start_obj("timestanps");
+                    start_obj("timestamps");
                         value_s("from", to_timestamp(t0, true).c_str());
                         value_s("to", to_timestamp(t1, true).c_str(), true);
                     end_obj();

--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -371,6 +371,39 @@ bool output_csv(struct whisper_context * ctx, const char * fname) {
     return true;
 }
 
+char *escape_double_quotes(const char *str) {
+    if (str == NULL) {
+        return NULL;
+    }
+
+    size_t escaped_length = strlen(str) + 1;
+
+    for (size_t i = 0; str[i] != '\0'; i++) {
+        if (str[i] == '"') {
+            escaped_length++;
+        }
+    }
+
+    char *escaped = (char *)calloc(escaped_length, 1); // pre-zeroed
+    if (escaped == NULL) {
+        return NULL;
+    }
+
+    size_t pos = 0;
+    for (size_t i = 0; str[i] != '\0'; i++) {
+        if (str[i] == '"') {
+            escaped[pos++] = '\\';
+            escaped[pos++] = '"';
+        } else {
+            escaped[pos++] = str[i];
+        }
+    }
+
+    // no need to set zero due to calloc() being used prior
+
+    return escaped;
+}
+
 bool output_json(struct whisper_context * ctx, const char * fname, const whisper_params & params) {
     std::ofstream fout(fname);
     int indent = 0;
@@ -414,7 +447,9 @@ bool output_json(struct whisper_context * ctx, const char * fname, const whisper
 
     auto value_s = [&](const char *name, const char *val, bool end = false) {
         start_value(name);
-        fout << "\"" << val << (end ? "\"\n" : "\",\n");
+        char * val_escaped = escape_double_quotes(val);
+        fout << "\"" << val_escaped << (end ? "\"\n" : "\",\n");
+        free(val_escaped);
     };
 
     auto end_value = [&](bool end = false) {


### PR DESCRIPTION
`leyer` → `layer` 
`timestanps` → `timestamps`
