### PR TITLE
"Double" the performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,10 @@ arm_neon.h
 sync.sh
 libwhisper.a
 libwhisper.so
+bench.exe
+whisper.dll
 compile_commands.json
+CMakeSettings.json
 
 examples/arm_neon.h
 examples/whisper.objc/whisper.objc.xcodeproj/xcshareddata

--- a/extra/bench-all.ps1
+++ b/extra/bench-all.ps1
@@ -1,0 +1,68 @@
+# Helper script to run the bench tool on all models and print the results in share-able format
+
+Write-Host "Usage: .\bench-all.ps1 [n_threads]`n"
+
+if ($args.Length -eq 0) {
+    $n_threads = 4
+} else {
+    $n_threads = $args[0]
+}
+
+$models = @( "tiny", "base", "small", "medium", "large" )
+
+Write-Host "`nRunning memcpy benchmark with 1 thread`n"
+
+.\bench -w 1 -t 1
+
+Write-Host "`nRunning ggml_mul_mat benchmark with $n_threads threads`n"
+
+.\bench -w 2 -t $n_threads
+
+Write-Host "`nRunning benchmark for all models"
+Write-Host "This can take a while!`n"
+
+Write-Host "| CPU | OS | Config | Model | Th | Load | Enc. | Commit |"
+Write-Host "| --- | -- | ------ | ----- | -- | ---- | ---- | ------ |"
+
+$commit = git rev-parse --short HEAD
+$cpu_name = (Get-CimInstance -ClassName Win32_Processor).Name
+$os = ((Get-WMIObject win32_operatingsystem).name).split("|")[0]
+
+foreach ($model in $models) {
+    # run once to heat-up the cache
+    .\bench -m .\models\ggml-$model.bin -t $n_threads 2>&1 | Out-Null
+
+    # actual run
+    # store stderr output in a variable in order to parse it later
+    $output = .\bench -m .\models\ggml-$model.bin -t $n_threads 2>&1
+
+    # parse the output:
+    $load_time = (($output | Select-String "load time") -split "[\s]+")[4]
+    $encode_time =  (($output | Select-String "encode time") -split "[\s]+")[4]
+    $system_info = ($output | Select-String "system_info").ToString()
+    $n_threads = ($system_info -split "[\s]+")[3]
+
+    # convert the time values to float type
+    $load_time = [float]::Parse($load_time)
+    $encode_time = [float]::Parse($encode_time)
+
+    # floor to milliseconds
+    $load_time = [math]::Floor($load_time)
+    $encode_time = [math]::Floor($encode_time)
+
+    $config = ""
+
+    if ($system_info.Contains("AVX2 = 1")) {
+        $config += " AVX2"
+    }
+
+    if ($system_info.Contains("NEON = 1")) {
+        $config += " NEON"
+    }
+
+    if ($system_info.Contains("BLAS = 1")) {
+        $config += " BLAS"
+    }
+
+    Write-Host "| $cpu_name | $os |$config | $model | $n_threads | $load_time | $encode_time | $commit |"
+}

--- a/extra/bench-all.sh
+++ b/extra/bench-all.sh
@@ -2,7 +2,7 @@
 
 # Helper script to run the bench tool on all models and print the results in share-able format
 
-printf "Usage: ./bench.sh [n_threads]\n"
+printf "Usage: ./bench-all.sh [n_threads]\n"
 
 if [ -z "$1" ]; then
     n_threads=4

--- a/ggml.c
+++ b/ggml.c
@@ -1529,7 +1529,7 @@ static void ggml_thread_pool_init() {
 static void ggml_thread_pool_cleanup() {
 
 }
-static ggml_thread_t ggml_thread_create(pthread_t* out, void* unused, thread_ret_t(*func)(void*), void* arg) {
+static int ggml_thread_create(pthread_t* out, void* unused, thread_ret_t(*func)(void*), void* arg) {
     //if (!atomic_fetch_sub(&g_thread_pool.free_threads, 1) <= 0) {
     //    uintptr_t thread_slot_magic = atomic_fetch_add(&g_thread_pool.free_slot_magic_val, 1);
     //    for (int i = 0; i < GGML_MAX_THREADS; ++i) {


### PR DESCRIPTION
Well, it uses **50% less power** - that's "double" performance. Basically, instead of using spinlocks, I made `whisper.cpp` use condition variables with mutices (mutex plural?).

Whisper is not really a low latency system. This means that busy locks aren't the best choice for synchronisation. The more so, that `whisper.cpp` is also supposed to run on the web and on mobile devices, where users usually care about power usage. In this PR, I made `whisper.cpp` use the classical conditional variable + mutex lock schema instead. On a 12900KS without overclocking, this reduces the CPU usage (and hence the power consumption) by half. On the other hand, if we go for full 100% utilization, the computation time is reduced by about **25%**. Performance tables below.

This is a draft because I haven't implemented the lock using `pthreads` yet, and the current Windows implementation is rather naive and suboptimal. I am also yet to optimize the computations themselves.