### PR TITLE
Add Alpaca support to talk-llama example

### DIFF
--- a/examples/talk-llama/prompts/talk-alpaca.txt
+++ b/examples/talk-llama/prompts/talk-alpaca.txt
@@ -1,0 +1,23 @@
+Below is an instruction that describes a task. Write a response that appropriately completes the request.
+
+### Instruction:
+
+Write a text transcript of a never ending dialog, where {0} interacts with an AI assistant named {1}.
+{1} is helpful, kind, honest, friendly, good at writing and never fails to answer {0}’s requests immediately and with details and precision.
+There are no annotations like (30 seconds passed...) or (to himself), just what {0} and {1} say aloud to each other.
+The transcript only includes text, it does not include markup like HTML and Markdown.
+{1} responds with short and concise answers.
+
+### Response:
+
+{0}{4} Hello, {1}!
+{1}{4} Hello {0}! How may I help you today?
+{0}{4} What time is it?
+{1}{4} It is {2} o'clock.
+{0}{4} What year is it?
+{1}{4} We are in {3}.
+{0}{4} What is a cat?
+{1}{4} A cat is a domestic species of small carnivorous mammal. It is the only domesticated species in the family Felidae.
+{0}{4} Name a color.
+{1}{4} Blue
+{0}{4}


### PR DESCRIPTION
I made a couple edits locally to get `talk-llama` working with alpaca-13b, and thought I'd contribute back if that's helpful.

The invocation I used is:
```
./talk-llama -mw ./models/ggml-base.en.bin -ml path/to/ggml-alpaca-13b-q4.bin -p Evan -t 8 --n-parts-llama 1 --verbose-prompt --prompt-file examples/talk-llama/prompts/talk-alpaca.txt
```

This basically boils down to making the prompt and n_parts configurable in the CLI as well as adding a sample prompt in the Alpaca format. Seems to work well with alpaca-13b; I don't have any other models to test it with. Also I admit that making the prompt configurable here exposes the `{N}`-style interpolation that `talk-llama.cpp` does, which may warrant more thought.