### PR TITLE
Fix shell script ./models/download-ggml-model.sh to handle spaces and special characters in paths

### DIFF
--- a/models/download-ggml-model.sh
+++ b/models/download-ggml-model.sh
@@ -12,7 +12,7 @@ pfx="resolve/main/ggml"
 # get the path of this script
 function get_script_path() {
     if [ -x "$(command -v realpath)" ]; then
-        echo "$(dirname $(realpath $0))"
+        echo "$(dirname "$(realpath "$0")")"
     else
         local ret="$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)"
         echo "$ret"


### PR DESCRIPTION
This pull request addresses an issue with the `get_script_path` function in the shell script ./models/download-ggml-model.sh, where it previously failed to handle spaces and special characters in directory paths correctly. 

Changes:
- Added double quotes around variables and commands in the `get_script_path` function to ensure proper parsing of paths with spaces and special characters.

This fix should ensure that the script works correctly even when executed from directories with spaces and special characters in their paths.