### PR TITLE
Revert stuttering commit

### DIFF
--- a/whisper.cpp
+++ b/whisper.cpp
@@ -3134,7 +3134,7 @@ struct whisper_full_params whisper_full_default_params(enum whisper_sampling_str
         /*.max_initial_ts   =*/  1.0f,
         /*.length_penalty   =*/ -1.0f,
 
-        /*.temperature_inc  =*/  0.0f, // TODO: temporary disabled until improve performance
+        /*.temperature_inc  =*/  0.2f,
         /*.entropy_thold    =*/  2.4f,
         /*.logprob_thold    =*/ -1.0f,
         /*.no_speech_thold  =*/  0.6f,


### PR DESCRIPTION
Revert "whisper : disable fallbacks until the performance is improved (#588)"

This reverts commit 8e361d90d7948de3ecae73e10878040044836800.

I'm honestly not sure what this fix did, but I noticed that after this commit, the quality dropped significantly, and I saw significant "stuttering" on a lot of runs, e.g.:

Before fix:
```
[00:04:05.000 --> 00:04:06.000]   OK, let's do it.
[00:04:06.000 --> 00:04:07.000]   Guitar.
[00:04:07.000 --> 00:04:09.000]   GU.
[00:04:09.000 --> 00:04:11.000]   I.T.A.R.
[00:04:11.000 --> 00:04:12.000]   That is correct!
[00:04:12.000 --> 00:04:14.000]   (CHEERING)
[00:04:14.000 --> 00:04:15.000]   Beautiful violin.
[00:04:15.000 --> 00:04:16.000]   It's a great band.
[00:04:16.000 --> 00:04:17.000]   It's a great band.
[00:04:17.000 --> 00:04:18.000]   It's a great band.
[00:04:18.000 --> 00:04:19.000]   It's a great band.
[00:04:19.000 --> 00:04:20.000]   It's a great band.
[00:04:20.000 --> 00:04:21.000]   It's a great band.
(repeats for over a minute)
```

After fix:
```
[00:04:05.000 --> 00:04:06.000]   OK, let's do it.
[00:04:06.000 --> 00:04:07.000]   Guitar.
[00:04:07.000 --> 00:04:09.000]   GU.
[00:04:09.000 --> 00:04:11.000]   I.T.A.R.
[00:04:11.000 --> 00:04:12.000]   That is correct!
[00:04:12.000 --> 00:04:14.000]   (CHEERING)
[00:04:14.000 --> 00:04:16.000]   (CHEERING)
[00:04:16.000 --> 00:04:18.000]   Wonderful violin to Marie Fett.
[00:04:18.000 --> 00:04:19.000]   To Brinleyston.
[00:04:19.000 --> 00:04:20.000]   I call that.
[00:04:20.000 --> 00:04:22.000]   Our second contestant is a real triple threat.
[00:04:22.000 --> 00:04:25.000]   He's tall, he's white, he's a man, it's Chris Pott!
[00:04:25.000 --> 00:04:27.000]   (CHEERING)
[00:04:27.000 --> 00:04:29.000]   Just specifically, that does make me a threat.
(continues normally)
```

I used `git bisect` to locate this, and verified that reverting it resulting in much better quality.