### PR TITLE
Update SIMD header file inclusion to support XOP instruction set

### DIFF
--- a/ggml.c
+++ b/ggml.c
@@ -166,10 +166,10 @@ typedef double ggml_float;
 #undef bool
 #define bool _Bool
 #else
-#if defined(__AVX512F__) || defined(__AVX512BW__) || defined(__AVX__) || defined(__AVX2__)
-#include <immintrin.h>
-#elif defined(__XOP__)
+#ifdef (__XOP__)
 #include <x86intrin.h>
+#else
+#include <immintrin.h>
 #endif
 #endif
 #endif

--- a/ggml.c
+++ b/ggml.c
@@ -166,7 +166,7 @@ typedef double ggml_float;
 #undef bool
 #define bool _Bool
 #else
-#ifdef (__XOP__)
+#ifdef __XOP__
 #include <x86intrin.h>
 #else
 #include <immintrin.h>

--- a/ggml.c
+++ b/ggml.c
@@ -166,7 +166,11 @@ typedef double ggml_float;
 #undef bool
 #define bool _Bool
 #else
+#if defined(__AVX512F__) || defined(__AVX512BW__) || defined(__AVX__) || defined(__AVX2__)
 #include <immintrin.h>
+#elif defined(__XOP__)
+#include <x86intrin.h>
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
This adds support for the XOP instruction set on AMD processors by including the `x86intrin.h` header file when the `__XOP__` macro is defined. 