### PR TITLE
Making the quick start instructions clearer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,9 @@ the Accelerate framework utilizes the special-purpose AMX coprocessor available 
 
 ## Quick start
 
-First, download one of the Whisper models converted in [ggml format](models). For example:
+First clone the repository.
+
+Then, download one of the Whisper models converted in [ggml format](models). For example:
 
 ```bash
 bash ./models/download-ggml-model.sh base.en


### PR DESCRIPTION
Users wanting to make use of this implementation of the whisper model with no prior knowledge of C/C++ may download the Whisper model but fail to use of the "make" command as specified given that they forgot or didn't know they needed to clone the repository first. Hope this modification clears things up.