### PR TITLE
Add msvc compiler args /utf-8 fix error C3688

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required (VERSION 3.0)
 
 project(whisper.cpp VERSION 1.2.1)
 
+add_compile_options(/utf-8)
+
 # Add path to modules
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,9 @@ cmake_minimum_required (VERSION 3.0)
 
 project(whisper.cpp VERSION 1.2.1)
 
-add_compile_options(/utf-8)
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+    add_compile_options(/utf-8)
+endif ()
 
 # Add path to modules
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/")


### PR DESCRIPTION
By default, msvc compiler use ANSI file encodeing. In my computer ANSI = GB2312.
whisper.cpp 3284 line contains some non ASCII characters.
```
static const std::vector<std::string> non_speech_tokens = {
    "\"", "#", "(", ")", "*", "+", "/", ":", ";", "<", "=", ">", "@", "[", "\\", "]", "^",
    "_", "`", "{", "|", "}", "~", "「", "」", "『", "』", "<<", ">>", "<<<", ">>>", "--",
    "---", "-(", "-[", "('", "(\"", "((", "))", "(((", ")))", "[[", "]]", "{{", "}}", "♪♪",
    "♪♪♪","♩", "♪", "♫", "♬", "♭", "♮", "♯"
};
```
This will cause 
```
whisper.cpp(3282): error C3688: invalid literal suffix '�'; literal operator or literal operator template 'operator ""�' not found
```

Add /utf-8 to compiler args will fix the error.