### PR TITLE
talk/talk-llama: add basic example script for eleven-labs tts

### DIFF
--- a/examples/talk-llama/.gitignore
+++ b/examples/talk-llama/.gitignore
@@ -1,2 +1,1 @@
-eleven-labs.py
 audio.mp3

--- a/examples/talk-llama/eleven-labs.py
+++ b/examples/talk-llama/eleven-labs.py
@@ -1,0 +1,23 @@
+import sys
+import importlib.util
+
+api_key = "" #Write your https://beta.elevenlabs.io api key here
+if not api_key:
+    print("To use elevenlabs you have to register to https://beta.elevenlabs.io and add your elevenlabs api key to examples/talk-llama/eleven-labs.py")
+    sys.exit()
+
+if importlib.util.find_spec("elevenlabs") is None:
+    print("elevenlabs library is not installed, you can install it to your enviroment using 'pip install elevenlabs'")
+    sys.exit()
+
+from elevenlabs import ElevenLabs
+eleven = ElevenLabs(api_key)
+
+# Get a Voice object, by name or UUID
+voice = eleven.voices["Arnold"] #Possible Voices: Adam Antoni Arnold Bella Domi Elli Josh
+
+# Generate the TTS
+audio = voice.generate(str(sys.argv[2:]))
+
+# Save the TTS to a file
+audio.save("audio") 

--- a/examples/talk-llama/speak.sh
+++ b/examples/talk-llama/speak.sh
@@ -13,6 +13,7 @@
 say "$2"
 
 # Eleven Labs
+# To use it, install the elevenlabs module from pip (pip install elevenlabs), register to https://beta.elevenlabs.io to get an api key and paste it in /examples/talk-llama/eleven-labs.py 
 #
 #wd=$(dirname $0)
 #script=$wd/eleven-labs.py

--- a/examples/talk/.gitignore
+++ b/examples/talk/.gitignore
@@ -1,1 +1,1 @@
-eleven-labs.py
+audio.mp3

--- a/examples/talk/eleven-labs.py
+++ b/examples/talk/eleven-labs.py
@@ -1,0 +1,23 @@
+import sys
+import importlib.util
+
+api_key = "" #Write your https://beta.elevenlabs.io api key here
+if not api_key:
+    print("To use elevenlabs you have to register to https://beta.elevenlabs.io and add your elevenlabs api key to examples/talk/eleven-labs.py")
+    sys.exit()
+
+if importlib.util.find_spec("elevenlabs") is None:
+    print("elevenlabs library is not installed, you can install it to your enviroment using 'pip install elevenlabs'")
+    sys.exit()
+
+from elevenlabs import ElevenLabs
+eleven = ElevenLabs(api_key)
+
+# Get a Voice object, by name or UUID
+voice = eleven.voices["Arnold"] #Possible Voices: Adam Antoni Arnold Bella Domi Elli Josh
+
+# Generate the TTS
+audio = voice.generate(str(sys.argv[2:]))
+
+# Save the TTS to a file
+audio.save("audio") 

--- a/examples/talk/speak.sh
+++ b/examples/talk/speak.sh
@@ -13,6 +13,7 @@
 say "$2"
 
 # Eleven Labs
+# To use it, install the elevenlabs module from pip (pip install elevenlabs), register to https://beta.elevenlabs.io to get an api key and paste it in /examples/talk/eleven-labs.py 
 #
 #wd=$(dirname $0)
 #script=$wd/eleven-labs.py


### PR DESCRIPTION
Made a simple example script wich calls elevenlabs api trough the unofficial pip package

see #683 