### PR TITLE
readme : add Unity3d bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,7 @@ in [models](models).
   - [stlukey/whispercpp.py](https://github.com/stlukey/whispercpp.py) (Cython)
   - [aarnphm/whispercpp](https://github.com/aarnphm/whispercpp) (Pybind11)
 - [X] R: [bnosac/audio.whisper](https://github.com/bnosac/audio.whisper)
+- [X] Unity: [macoron/whisper.unity](https://github.com/Macoron/whisper.unity)
 
 ## Examples
 


### PR DESCRIPTION
Adds unity3d bindings link to readme.

Right now my repository seems to be more or less stable on all platforms (Windows, Mac, iOS and Android).

Link: https://github.com/Macoron/whisper.unity