### PR TITLE
readme: Add alternate swift bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,6 +480,7 @@ in [models](models).
 - [X] Go: [bindings/go](bindings/go) | [#312](https://github.com/ggerganov/whisper.cpp/discussions/312)
 - [X] Ruby: [bindings/ruby](bindings/ruby) | [#507](https://github.com/ggerganov/whisper.cpp/discussions/507)
 - [X] Objective-C / Swift: [ggerganov/whisper.spm](https://github.com/ggerganov/whisper.spm) | [#313](https://github.com/ggerganov/whisper.cpp/discussions/313)
+  - [exPHAT/SwiftWhisper](https://github.com/exPHAT/SwiftWhisper)
 - [X] .NET: | [#422](https://github.com/ggerganov/whisper.cpp/discussions/422)
   - [sandrohanea/whisper.net](https://github.com/sandrohanea/whisper.net)
   - [NickDarvey/whisper](https://github.com/NickDarvey/whisper)


### PR DESCRIPTION
I made an alternate Swift wrapper with a full Swift-style API. Repo [here](https://github.com/exPHAT/SwiftWhisper).

I added it to the readme file the Swift section. Hopefully people who are unfamiliar interfacing with C via Swift find it useful!