### PR TITLE
Fix the bug related to word splitting errors in the "tokenize" function.

### DIFF
--- a/whisper.cpp
+++ b/whisper.cpp
@@ -2451,25 +2451,20 @@ static std::vector<whisper_vocab::id> tokenize(const whisper_vocab & vocab, cons
         int n = word.size();
         while (i < n) {
             int j = n;
+            bool found = false;
             while (j > i) {
-                auto it = vocab.token_to_id.find(word.substr(i, j-i));
+                auto sub = word.substr(i, j-i);
+                auto it = vocab.token_to_id.find(sub);
                 if (it != vocab.token_to_id.end()) {
                     tokens.push_back(it->second);
                     i = j;
+                    found = true;
                     break;
                 }
                 --j;
             }
-            if (i == n) {
-                break;
-            }
-            if (j == i) {
-                auto sub = word.substr(i, 1);
-                if (vocab.token_to_id.find(sub) != vocab.token_to_id.end()) {
-                    tokens.push_back(vocab.token_to_id.at(sub));
-                } else {
-                    fprintf(stderr, "%s: unknown token '%s'\n", __func__, sub.data());
-                }
+            if (!found) {
+                fprintf(stderr, "unknown token \n");
                 ++i;
             }
         }


### PR DESCRIPTION
For example, we have prompts: "平凡"

平 (0xE5 0xB9 0xB3)
凡 (0xE5 0x87 0xA1)

We get tokens:

16716 (0xE5 0xB9 0xB3)
161 (0xE5)
229 (0x87)
94 (0xA1)

But the right tokens are:

16716 (0xE5 0xB9 0xB3)
6336 (0xE5 0x87)
94 (0xA1)