### PR TITLE
C++11style

### DIFF
--- a/models/convert-pt-to-ggml.py
+++ b/models/convert-pt-to-ggml.py
@@ -40,7 +40,7 @@ import code
 import torch
 import numpy as np
 import base64
-
+from pathlib import Path
 #from transformers import GPTJForCausalLM
 #from transformers import GPT2TokenizerFast
 
@@ -194,17 +194,17 @@ if len(sys.argv) < 4:
     print("Usage: convert-pt-to-ggml.py model.pt path-to-whisper-repo dir-output [use-f32]\n")
     sys.exit(1)
 
-fname_inp   = sys.argv[1]
-dir_whisper = sys.argv[2]
-dir_out     = sys.argv[3]
+fname_inp   = Path(sys.argv[1])
+dir_whisper = Path(sys.argv[2])
+dir_out     = Path(sys.argv[3])
 
 # try to load PyTorch binary data
 try:
     model_bytes = open(fname_inp, "rb").read()
     with io.BytesIO(model_bytes) as fp:
         checkpoint = torch.load(fp, map_location="cpu")
-except:
-    print("Error: failed to load PyTorch model file: %s" % fname_inp)
+except Exception:
+    print("Error: failed to load PyTorch model file:" , fname_inp)
     sys.exit(1)
 
 hparams = checkpoint["dims"]
@@ -218,17 +218,17 @@ list_vars = checkpoint["model_state_dict"]
 
 # load mel filters
 n_mels = hparams["n_mels"]
-with np.load(os.path.join(dir_whisper, "whisper/assets", "mel_filters.npz")) as f:
+with np.load(dir_whisper / "whisper" / "assets" / "mel_filters.npz") as f:
     filters = torch.from_numpy(f[f"mel_{n_mels}"])
     #print (filters)
 
 #code.interact(local=locals())
 
 multilingual = hparams["n_vocab"] == 51865
-tokenizer = os.path.join(dir_whisper, "whisper/assets", multilingual and "multilingual.tiktoken" or "gpt2.tiktoken")
+tokenizer = dir_whisper / "whisper" / "assets" / (multilingual and "multilingual.tiktoken" or "gpt2.tiktoken")
 
 # output in the same directory as the model
-fname_out = dir_out + "/ggml-model.bin"
+fname_out = dir_out / "ggml-model.bin"
 
 with open(tokenizer, "rb") as f:
     contents = f.read()
@@ -238,9 +238,9 @@ with open(tokenizer, "rb") as f:
 use_f16 = True
 if len(sys.argv) > 4:
     use_f16 = False
-    fname_out = dir_out + "/ggml-model-f32.bin"
+    fname_out = dir_out / "ggml-model-f32.bin"
 
-fout = open(fname_out, "wb")
+fout = fname_out.open("wb")
 
 fout.write(struct.pack("i", 0x67676d6c)) # magic: ggml in hex
 fout.write(struct.pack("i", hparams["n_vocab"]))
@@ -273,20 +273,19 @@ for key in tokens:
 
 for name in list_vars.keys():
     data = list_vars[name].squeeze().numpy()
-    print("Processing variable: " + name + " with shape: ", data.shape)
+    print("Processing variable: " , name ,  " with shape: ", data.shape)
 
     # reshape conv bias from [n] to [n, 1]
-    if name == "encoder.conv1.bias" or \
-       name == "encoder.conv2.bias":
+    if name in ["encoder.conv1.bias", "encoder.conv2.bias"]:
         data = data.reshape(data.shape[0], 1)
-        print("  Reshaped variable: " + name + " to shape: ", data.shape)
+        print(f"  Reshaped variable: {name} to shape: ", data.shape)
 
-    n_dims = len(data.shape);
+    n_dims = len(data.shape)
 
     # looks like the whisper models are in f16 by default
     # so we need to convert the small tensors to f32 until we fully support f16 in ggml
     # ftype == 0 -> float32, ftype == 1 -> float16
-    ftype = 1;
+    ftype = 1
     if use_f16:
         if n_dims < 2 or \
                 name == "encoder.conv1.bias"   or \
@@ -307,16 +306,16 @@ for name in list_vars.keys():
     #        data = data.transpose()
 
     # header
-    str = name.encode('utf-8')
-    fout.write(struct.pack("iii", n_dims, len(str), ftype))
+    str_ = name.encode('utf-8')
+    fout.write(struct.pack("iii", n_dims, len(str_), ftype))
     for i in range(n_dims):
         fout.write(struct.pack("i", data.shape[n_dims - 1 - i]))
-    fout.write(str);
+    fout.write(str_)
 
     # data
     data.tofile(fout)
 
 fout.close()
 
-print("Done. Output file: " + fname_out)
+print("Done. Output file: " , fname_out)
 print("")

--- a/models/convert-whisper-to-coreml.py
+++ b/models/convert-whisper-to-coreml.py
@@ -20,7 +20,7 @@ def linear_to_conv2d_map(state_dict, prefix, local_metadata, strict,
     """
     for k in state_dict:
         is_attention = all(substr in k for substr in ['attn', '.weight'])
-        is_mlp = any([k.endswith(s) for s in ['mlp.0.weight', 'mlp.2.weight']])
+        is_mlp = any(k.endswith(s) for s in ['mlp.0.weight', 'mlp.2.weight'])
 
         if (is_attention or is_mlp) and len(state_dict[k].shape) == 2:
             state_dict[k] = state_dict[k][:, :, None, None]
@@ -42,11 +42,10 @@ class LayerNormANE(LayerNormANEBase):
 class MultiHeadAttentionANE(MultiHeadAttention):
     def __init__(self, n_state: int, n_head: int):
         super().__init__(n_state, n_head)
-
-        setattr(self, 'query', nn.Conv2d(n_state, n_state, kernel_size=1))
-        setattr(self, 'key', nn.Conv2d(n_state, n_state, kernel_size=1, bias=False))
-        setattr(self, 'value', nn.Conv2d(n_state, n_state, kernel_size=1))
-        setattr(self, 'out', nn.Conv2d(n_state, n_state, kernel_size=1))
+        self.query =  nn.Conv2d(n_state, n_state, kernel_size=1)
+        self.key = nn.Conv2d(n_state, n_state, kernel_size=1, bias=False)
+        self.value = nn.Conv2d(n_state, n_state, kernel_size=1)
+        self.out = nn.Conv2d(n_state, n_state, kernel_size=1)
 
     def forward(self,
                 x: Tensor,
@@ -104,30 +103,28 @@ class MultiHeadAttentionANE(MultiHeadAttention):
 class ResidualAttentionBlockANE(ResidualAttentionBlock):
     def __init__(self, n_state: int, n_head: int, cross_attention: bool = False):
         super().__init__(n_state, n_head, cross_attention)
-
-        setattr(self, 'attn', MultiHeadAttentionANE(n_state, n_head))
-        setattr(self, 'attn_ln', LayerNormANE(n_state))
-
-        setattr(self, 'cross_attn', MultiHeadAttentionANE(n_state, n_head) if cross_attention else None)
-        setattr(self, 'cross_attn_ln', LayerNormANE(n_state) if cross_attention else None)
+        self.attn =  MultiHeadAttentionANE(n_state, n_head)
+        self.attn_ln = LayerNormANE(n_state)
+        self.cross_attn =  MultiHeadAttentionANE(n_state, n_head) if cross_attention else None
+        self.cross_attn_ln =  LayerNormANE(n_state) if cross_attention else None
 
         n_mlp = n_state * 4
-        setattr(self, 'mlp', nn.Sequential(
+        self.mlp =  nn.Sequential(
             nn.Conv2d(n_state, n_mlp, kernel_size=1),
             nn.GELU(),
             nn.Conv2d(n_mlp, n_state, kernel_size=1)
-        ))
-        setattr(self, 'mlp_ln', LayerNormANE(n_state))
+        )
+        self.mlp_ln = LayerNormANE(n_state)
 
 
 class AudioEncoderANE(AudioEncoder):
     def __init__(self, n_mels: int, n_ctx: int, n_state: int, n_head: int, n_layer: int):
         super().__init__(n_mels, n_ctx, n_state, n_head, n_layer)
 
-        setattr(self, 'blocks', nn.ModuleList(
+        self.blocks = nn.ModuleList(
             [ResidualAttentionBlockANE(n_state, n_head) for _ in range(n_layer)]
-        ))
-        setattr(self, 'ln_post', LayerNormANE(n_state))
+        )
+        self.ln_post = LayerNormANE(n_state)
 
     def forward(self, x: Tensor):
         """
@@ -168,10 +165,10 @@ class TextDecoderANE(TextDecoder):
     def __init__(self, n_vocab: int, n_ctx: int, n_state: int, n_head: int, n_layer: int):
         super().__init__(n_vocab, n_ctx, n_state, n_head, n_layer)
 
-        setattr(self, 'blocks', nn.ModuleList(
+        self.blocks= nn.ModuleList(
             [ResidualAttentionBlockANE(n_state, n_head, cross_attention=True) for _ in range(n_layer)]
-        ))
-        setattr(self, 'ln', LayerNormANE(n_state))
+        )
+        self.ln= LayerNormANE(n_state)
 
     def forward(self, x: Tensor, xa: Tensor, kv_cache: Optional[dict] = None):
         """
@@ -213,20 +210,20 @@ class WhisperANE(Whisper):
     def __init__(self, dims: ModelDimensions):
         super().__init__(dims)
 
-        setattr(self, 'encoder', AudioEncoderANE(
+        self.encoder = AudioEncoderANE(
             self.dims.n_mels,
             self.dims.n_audio_ctx,
             self.dims.n_audio_state,
             self.dims.n_audio_head,
             self.dims.n_audio_layer,
-        ))
-        setattr(self, 'decoder', TextDecoderANE(
+        )
+        self.decoder = TextDecoderANE(
             self.dims.n_vocab,
             self.dims.n_text_ctx,
             self.dims.n_text_state,
             self.dims.n_text_head,
             self.dims.n_text_layer,
-        ))
+        )
 
         self._register_load_state_dict_pre_hook(linear_to_conv2d_map)
 

--- a/whisper.cpp
+++ b/whisper.cpp
@@ -2902,9 +2902,9 @@ int whisper_lang_max_id() {
     return max_id;
 }
 
-int whisper_lang_id(const char *lang) {
+int whisper_lang_id(const char * lang) {
     if (!g_lang.count(lang)) {
-        for (const auto &kv : g_lang) {
+        for (const auto & kv : g_lang) {
             if (kv.second.second == lang) {
                 return kv.second.first;
             }

--- a/whisper.cpp
+++ b/whisper.cpp
@@ -3501,9 +3501,8 @@ static void whisper_process_logits(
         // the initial timestamp cannot be larger than max_initial_ts
         // ref: https://github.com/openai/whisper/blob/0b1ba3d46ebf7fe6f953acfd8cad62a4f851b49f/whisper/decoding.py#L426-L429
         if (is_initial && params.max_initial_ts > 0.0f) {
-            const float precision =
-                float(WHISPER_CHUNK_SIZE) / ctx.model.hparams.n_audio_ctx;
-            const int tid0 = std::round(params.max_initial_ts / precision);
+            const float precision = float(WHISPER_CHUNK_SIZE)/ctx.model.hparams.n_audio_ctx;
+            const int   tid0      = std::round(params.max_initial_ts/precision);
 
             std::fill(logits.begin() + vocab.token_beg + tid0 + 1,
                       logits.begin() + n_logits, -INFINITY);
@@ -3521,10 +3520,9 @@ static void whisper_process_logits(
         {
             const float logit_max = *std::max_element(logits.begin(), logits.end());
             float logsumexp = 0.0f;
-
-            for (auto &&i : logits) {
-                if (i > -INFINITY) {
-                    logsumexp += expf(i - logit_max);
+            for (int i = 0; i < n_logits; ++i) {
+                if (logits[i] > -INFINITY) {
+                    logsumexp += expf(logits[i] - logit_max);
                 }
             }
             logsumexp = logf(logsumexp) + logit_max;


### PR DESCRIPTION
tested by `./tests/run-tests.sh tiny.en`

- use STL to rewrite some for-loops.
- use `Path` to avoid catenating string path.
- `self.field = v` instead of `setattr(self, "field", v)`

about designated initializers, it seems to work on gcc, clang, and msvc. https://developercommunity.visualstudio.com/t/c-designated-initializers/518768 
