### PR TITLE
examples : add missing #include <cstdint>

### DIFF
--- a/examples/common.cpp
+++ b/examples/common.cpp
@@ -6,6 +6,7 @@
 #include "dr_wav.h"
 
 #include <cmath>
+#include <cstdint>
 #include <regex>
 
 #ifndef M_PI


### PR DESCRIPTION
common.cpp uses `uint8_t` and `uint64_t`, which are defined in [cstdint](https://en.cppreference.com/w/cpp/header/cstdint).