### PR TITLE
Flush upon finishing inference

### DIFF
--- a/examples/stream/stream.cpp
+++ b/examples/stream/stream.cpp
@@ -383,6 +383,7 @@ int main(int argc, char ** argv) {
                     }
                 }
             }
+            fflush(stdout);
         }
     }
 


### PR DESCRIPTION
Was trying to parse when inference was complete, realized that \n is that signal, but without this flush it doesn't get flushed until next inference has ran.

Eg before this we'd get
```json
"\u001b[2K\r                                                                                                    \u001b[2K\r I want to figure out what's up with these new lines.",
"\n\u001b[2K\r                                                                                                    \u001b[2K\r (upbeat music)"
```
Now it should be
```json
"\u001b[2K\r                                                                                                    \u001b[2K\r I want to figure out what's up with these new lines.",
"\n",
"\u001b[2K\r                                                                                                    \u001b[2K\r (upbeat music)"
```
Note markdown fails to render so here is a screenshot of markdown:
<img width="733" alt="image" src="https://user-images.githubusercontent.com/857083/233520002-517a5c27-0ff0-4e32-b747-39b72501b479.png">
