### PR TITLE
add some tips about in the readme of the android project folder

### DIFF
--- a/examples/whisper.android/README.md
+++ b/examples/whisper.android/README.md
@@ -9,4 +9,6 @@ To use:
 5. Select the "release" active build variant, and use Android Studio to run and deploy to your device.
 [^1]: I recommend the tiny or base models for running on an Android device.
 
+(PS: Do not move this android project folder individually to other folders, because this android project folder depends on the files of the whole project.)
+
 <img width="300" alt="image" src="https://user-images.githubusercontent.com/1670775/221613663-a17bf770-27ef-45ab-9a46-a5f99ba65d2a.jpg">


### PR DESCRIPTION
add the tip about "Do not move this android project folder individually to other folders", in case of the mistakes about the dependency.