### PR TITLE
whisper.wasm : fix typo in readme

### DIFF
--- a/examples/whisper.wasm/README.md
+++ b/examples/whisper.wasm/README.md
@@ -38,5 +38,5 @@ make -j
 
 # copy the produced page to your HTTP path
 cp bin/whisper.wasm/*       /path/to/html/
-cp bin/libwhisper.worker.js /path/to/html/
+cp bin/libmain.worker.js /path/to/html/
 ```


### PR DESCRIPTION
`libwhisper.worker.js` should be `libmain.worker.js`