### PR TITLE
Update elevenlabs example to use official python API

### DIFF
--- a/examples/talk-llama/eleven-labs.py
+++ b/examples/talk-llama/eleven-labs.py
@@ -1,23 +1,20 @@
 import sys
 import importlib.util
 
-api_key = "" #Write your https://beta.elevenlabs.io api key here
-if not api_key:
-    print("To use elevenlabs you have to register to https://beta.elevenlabs.io and add your elevenlabs api key to examples/talk-llama/eleven-labs.py")
-    sys.exit()
-
 if importlib.util.find_spec("elevenlabs") is None:
     print("elevenlabs library is not installed, you can install it to your enviroment using 'pip install elevenlabs'")
     sys.exit()
 
-from elevenlabs import ElevenLabs
-eleven = ElevenLabs(api_key)
+from elevenlabs import generate, play, save
 
 # Get a Voice object, by name or UUID
-voice = eleven.voices["Arnold"] #Possible Voices: Adam Antoni Arnold Bella Domi Elli Josh
+voice = "Arnold" #Possible Voices: Adam Antoni Arnold Bella Domi Elli Josh
 
 # Generate the TTS
-audio = voice.generate(str(sys.argv[2:]))
+audio = generate(
+  text=str(sys.argv[2:]),
+  voice=voice
+)
 
 # Save the TTS to a file
-audio.save("audio") 
+save(audio, "audio.mp3") 

--- a/examples/talk-llama/speak.sh
+++ b/examples/talk-llama/speak.sh
@@ -13,8 +13,11 @@
 say "$2"
 
 # Eleven Labs
-# To use it, install the elevenlabs module from pip (pip install elevenlabs), register to https://beta.elevenlabs.io to get an api key and paste it in /examples/talk-llama/eleven-labs.py 
+# To use it, install the elevenlabs module from pip (pip install elevenlabs)
+# It's possible to use the API for free with limited number of characters. To increase this limit register to https://beta.elevenlabs.io to get an api key and paste it after 'ELEVEN_API_KEY='
+#Keep the line commented to use the free version whitout api key
 #
+#export ELEVEN_API_KEY=your_api_key
 #wd=$(dirname $0)
 #script=$wd/eleven-labs.py
 #python3 $script $1 "$2" >/dev/null 2>&1

--- a/examples/talk/eleven-labs.py
+++ b/examples/talk/eleven-labs.py
@@ -1,23 +1,20 @@
 import sys
 import importlib.util
 
-api_key = "" #Write your https://beta.elevenlabs.io api key here
-if not api_key:
-    print("To use elevenlabs you have to register to https://beta.elevenlabs.io and add your elevenlabs api key to examples/talk/eleven-labs.py")
-    sys.exit()
-
 if importlib.util.find_spec("elevenlabs") is None:
     print("elevenlabs library is not installed, you can install it to your enviroment using 'pip install elevenlabs'")
     sys.exit()
 
-from elevenlabs import ElevenLabs
-eleven = ElevenLabs(api_key)
+from elevenlabs import generate, play, save
 
 # Get a Voice object, by name or UUID
-voice = eleven.voices["Arnold"] #Possible Voices: Adam Antoni Arnold Bella Domi Elli Josh
+voice = "Arnold" #Possible Voices: Adam Antoni Arnold Bella Domi Elli Josh
 
 # Generate the TTS
-audio = voice.generate(str(sys.argv[2:]))
+audio = generate(
+  text=str(sys.argv[2:]),
+  voice=voice
+)
 
 # Save the TTS to a file
-audio.save("audio") 
+save(audio, "audio.mp3") 

--- a/examples/talk/speak.sh
+++ b/examples/talk/speak.sh
@@ -13,8 +13,11 @@
 say "$2"
 
 # Eleven Labs
-# To use it, install the elevenlabs module from pip (pip install elevenlabs), register to https://beta.elevenlabs.io to get an api key and paste it in /examples/talk/eleven-labs.py 
+# To use it, install the elevenlabs module from pip (pip install elevenlabs)
+# It's possible to use the API for free with limited number of characters. To increase this limit register to https://beta.elevenlabs.io to get an api key and paste it after 'ELEVEN_API_KEY='
+#Keep the line commented to use the free version whitout api key
 #
+#export ELEVEN_API_KEY=your_api_key
 #wd=$(dirname $0)
 #script=$wd/eleven-labs.py
 #python3 $script $1 "$2"


### PR DESCRIPTION
Follow-up to #728 
Seems like there was some confusion recently with elevenlabs-related pakages in pip.
A week ago the "elevenlabs" package pointed to the unofficial library from benaptist. Then, an official one was released.
The unofficial package was renamed as benbaptist-elevenlabs and  the official library took it's place.

More info here: https://github.com/benbaptist/elevenlabs/commit/add292a9b61b406e052a268ff351f0a51d9ddbc4

I adapted the example to use the official library.

Also, seems like the official library allows to use the API for free without setting an API key, but with limited character count. i clarified this inside speak.sh script