### PR TITLE
nix: add flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1683207485,
+        "narHash": "sha256-gs+PHt/y/XQB7S8+YyBLAM8LjgYpPZUVFQBwpFSmJro=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "cc45a3f8c98e1c33ca996e3504adefbf660a72d1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,60 @@
+{
+  description = "Port of OpenAI's Whisper model in C/C++";
+
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.11";
+  };
+
+  outputs = { self, flake-utils, nixpkgs }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+      in
+      {
+        formatter = pkgs.nixpkgs-fmt;
+        packages.default = with pkgs; stdenv.mkDerivation rec {
+          name = "whisper-cpp";
+          src = ./.;
+          nativeBuildInputs = [ makeWrapper ];
+          buildInputs = [ SDL2 ] ++ lib.optionals stdenv.isDarwin [ Accelerate CoreGraphics CoreVideo ];
+
+          makeFlags = [ "main" "stream" ];
+
+          installPhase = ''
+            runHook preInstall
+
+            mkdir -p $out/bin
+            cp ./main $out/bin/whisper-cpp
+            cp ./stream $out/bin/whisper-cpp-stream
+
+            cp models/download-ggml-model.sh $out/bin/whisper-cpp-download-ggml-model
+
+            wrapProgram $out/bin/whisper-cpp-download-ggml-model \
+              --prefix PATH : ${lib.makeBinPath [wget]}
+
+            runHook postInstall
+          '';
+
+          meta = with lib; {
+            description = "Port of OpenAI's Whisper model in C/C++";
+            longDescription = ''
+              To download the models as described in the project's readme, you may
+              use the `whisper-cpp-download-ggml-model` binary from this package.
+            '';
+            homepage = "https://github.com/ggerganov/whisper.cpp";
+            license = licenses.mit;
+            platforms = platforms.all;
+          };
+        };
+        apps.default = {
+          type = "app";
+          program = "${self.packages.${system}.default}/bin/whisper-cpp";
+        };
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [ cmake ] ++ lib.optionals stdenv.isDarwin [
+            darwin.apple_sdk.frameworks.Accelerate
+          ];
+        };
+      });
+}

--- a/models/download-ggml-model.sh
+++ b/models/download-ggml-model.sh
@@ -9,18 +9,6 @@
 src="https://huggingface.co/ggerganov/whisper.cpp"
 pfx="resolve/main/ggml"
 
-# get the path of this script
-function get_script_path() {
-    if [ -x "$(command -v realpath)" ]; then
-        echo "$(dirname "$(realpath "$0")")"
-    else
-        local ret="$(cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)"
-        echo "$ret"
-    fi
-}
-
-models_path="$(get_script_path)"
-
 # Whisper models
 models=( "tiny.en" "tiny" "base.en" "base" "small.en" "small" "medium.en" "medium" "large-v1" "large" )
 
@@ -54,8 +42,6 @@ fi
 
 printf "Downloading ggml model $model from '$src' ...\n"
 
-cd $models_path
-
 if [ -f "ggml-$model.bin" ]; then
     printf "Model $model already exists. Skipping download.\n"
     exit 0
@@ -77,7 +63,7 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-printf "Done! Model '$model' saved in 'models/ggml-$model.bin'\n"
+printf "Done! Model '$model' saved in 'ggml-$model.bin'\n"
 printf "You can now use it like this:\n\n"
-printf "  $ ./main -m models/ggml-$model.bin -f samples/jfk.wav\n"
+printf "  $ whisper-cpp -m ggml-$model.bin -f samples/jfk.wav\n"
 printf "\n"


### PR DESCRIPTION
This PR adds a Nix Flake for building and distributing the binary.

Derivation adapted from [nixpkgs-unstable](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/tools/audio/openai-whisper-cpp/default.nix).

### Example

```
$ nix run github:ggerganov/whisper.cpp -- --help

usage: /nix/store/z4zqr5nklvf8n80bxqxaphc3a3j9xddb-whisper-cpp/bin/whisper-cpp [options] file0.wav file1.wav ...

options:
  -h,        --help              [default] show this help message and exit
  -t N,      --threads N         [4      ] number of threads to use during computation
  -p N,      --processors N      [1      ] number of processors to use during computation
  -ot N,     --offset-t N        [0      ] time offset in milliseconds
  -on N,     --offset-n N        [0      ] segment index offset
  -d  N,     --duration N        [0      ] duration of audio to process in milliseconds
  -mc N,     --max-context N     [-1     ] maximum number of text context tokens to store
  -ml N,     --max-len N         [0      ] maximum segment length in characters
.......
```