### PR TITLE
Update of Hebrew Language Code: 'iw' to 'he'

### DIFF
--- a/whisper.cpp
+++ b/whisper.cpp
@@ -139,7 +139,7 @@ static const std::map<std::string, std::pair<int, std::string>> g_lang = {
     { "hi",  { 17,  "hindi",          } },
     { "fi",  { 18,  "finnish",        } },
     { "vi",  { 19,  "vietnamese",     } },
-    { "iw",  { 20,  "hebrew",         } },
+    { "he",  { 20,  "hebrew",         } },
     { "uk",  { 21,  "ukrainian",      } },
     { "el",  { 22,  "greek",          } },
     { "ms",  { 23,  "malay",          } },


### PR DESCRIPTION
Previously, 'iw' was used instead of 'he'.
Open AI whisper use 'he' and the ISO 639-1 have been using 'he' instead of 'iw' since 1989.