### PR TITLE
Add Swift Package Manager manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 *.o
 *.a
+.build/
 .cache/
 .coreml/
+.swiftpm/
 .test/
 .vs/
 .vscode/

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,48 @@
+// swift-tools-version:5.3
+import PackageDescription
+
+let package = Package(
+    name: "whisper.cpp",
+    platforms: [
+        .iOS(.v11),
+        .macOS(.v10_13),
+        .watchOS(.v4),
+        .tvOS(.v11)
+    ],
+    products: [
+        .library(
+            name: "whispercpp",
+            targets: ["whispercpp"]
+        )
+    ],
+    targets: [
+        .target(
+            name: "whispercpp",
+            dependencies: [],
+            path: ".",
+            exclude: [
+                "bindings",
+                "cmake",
+                "coreml",
+                "examples",
+                "extra",
+                "models",
+                "samples",
+                "tests",
+                "CMakeLists.txt",
+                "ggml-cuda.cu",
+                "ggml-cuda.h",
+                "ggml-opencl.c",
+                "ggml-opencl.h",
+                "Makefile"
+            ],
+            sources: [
+                "whisper.cpp",
+                "ggml.c"
+            ],
+            publicHeadersPath: "swiftpm"
+        ),
+
+    ],
+    cxxLanguageStandard: .cxx11
+)

--- a/swiftpm/whisper-wrapper.h
+++ b/swiftpm/whisper-wrapper.h
@@ -1,0 +1,15 @@
+//
+//  whisper-wrapper.h
+//  
+//
+//  Created by Aaron Farnham on 5/19/23.
+//
+
+
+/*
+ Swift Package Manager recursively searchers for headers in it's
+ public headers path. Create a segregated path so only necessary
+ headers are included in the Swift Package.
+ */
+
+#include "../whisper.h"


### PR DESCRIPTION
This PR add a manifest so this repo can be targeted from Swift projects and Xcode using Swift Package Manager.

In order to expose only whisper.h outside the package I've added a new directory, `swiftpm` with a shim header. If the publicHeadersPath were specified as the root of the repo then all headers in all directories become public as Swift Package manager recurses its public headers directory without any option to turn that off, nor is there an option to specify specific headers. 

I've also updated .gitignore prevent check in of any artifacts Swift Package Manager introduces when building and editing.