### PR TITLE
Make convert-pt-to-ggml.py backwards compatible with older vocab.json tokenizer files

### DIFF
--- a/models/convert-pt-to-ggml.py
+++ b/models/convert-pt-to-ggml.py
@@ -235,7 +235,7 @@ if not tokenizer.is_file():
     tokenizer = dir_whisper / "whisper" / "assets" / (multilingual and "multilingual" or "gpt2") / "vocab.json"
     tokenizer_type = "hf_transformers"
     if not tokenizer.is_file():
-        print("Error: failed to find either tiktoken of hf_transformers tokenizer file:", tokenizer)
+        print("Error: failed to find either tiktoken or hf_transformers tokenizer file:", tokenizer)
         sys.exit(1)
 
 byte_encoder = bytes_to_unicode()

--- a/models/convert-pt-to-ggml.py
+++ b/models/convert-pt-to-ggml.py
@@ -224,15 +224,38 @@ with np.load(dir_whisper / "whisper" / "assets" / "mel_filters.npz") as f:
 
 #code.interact(local=locals())
 
+# load tokenizer
+# for backwards compatibility, also check for older hf_transformers format tokenizer files
+# old format: dir_whisper/whisper/assets/[multilingual/gpt2]/vocab.json
+# new format: dir_whisper/whisper/assets/[multilingual/gpt2].tiktoken
 multilingual = hparams["n_vocab"] == 51865
 tokenizer = dir_whisper / "whisper" / "assets" / (multilingual and "multilingual.tiktoken" or "gpt2.tiktoken")
+tokenizer_type = "tiktoken"
+if not tokenizer.is_file():
+    tokenizer = dir_whisper / "whisper" / "assets" / (multilingual and "multilingual" or "gpt2") / "vocab.json"
+    tokenizer_type = "hf_transformers"
+    if not tokenizer.is_file():
+        print("Error: failed to find either tiktoken of hf_transformers tokenizer file:", tokenizer)
+        sys.exit(1)
+
+byte_encoder = bytes_to_unicode()
+byte_decoder = {v:k for k, v in byte_encoder.items()}
+
+if tokenizer_type == "tiktoken":
+    with open(tokenizer, "rb") as f:
+        contents = f.read()
+        tokens = {base64.b64decode(token): int(rank) for token, rank in (line.split() for line in contents.splitlines() if line)}
+elif tokenizer_type == "hf_transformers":
+    with open(tokenizer, "r", encoding="utf8") as f:
+        _tokens_raw = json.load(f)
+        if '<|endoftext|>' in _tokens_raw:
+            # ensures exact same model as tokenizer_type == tiktoken
+            # details: https://github.com/ggerganov/whisper.cpp/pull/725
+            del _tokens_raw['<|endoftext|>']
+        tokens = {bytes([byte_decoder[c] for c in token]): int(idx) for token, idx in _tokens_raw.items()}
 
 # output in the same directory as the model
 fname_out = dir_out / "ggml-model.bin"
-
-with open(tokenizer, "rb") as f:
-    contents = f.read()
-    tokens = {base64.b64decode(token): int(rank) for token, rank in (line.split() for line in contents.splitlines() if line)}
 
 # use 16-bit or 32-bit floats
 use_f16 = True
@@ -262,9 +285,7 @@ for i in range(filters.shape[0]):
     for j in range(filters.shape[1]):
         fout.write(struct.pack("f", filters[i][j]))
 
-byte_encoder = bytes_to_unicode()
-byte_decoder = {v:k for k, v in byte_encoder.items()}
-
+# write tokenizer
 fout.write(struct.pack("i", len(tokens)))
 
 for key in tokens:


### PR DESCRIPTION
Patches the script to determine what type of tokenizer files are present and convert appropriately.

Mostly borrows from  https://github.com/ggerganov/whisper.cpp/pull/725 as a reference. For the same reason mentioned in that PR, converted multilingual checkpoints will continue to exactly match while `.en` checkpoints have a 17 byte difference compared to ggml files downloaded by whisper.cpp.

The script will also now produce exactly the same files regardless of which type of tokenizer files were used for conversion.

```
-rw-r--r--  1 Akash  staff  487614184 Jun 10 21:30 ggml-small.en.hf.bin
-rw-r--r--  1 Akash  staff  487614184 Jun 10 21:28 ggml-small.en.tiktoken.bin
-rw-r--r--  1 Akash  staff  487601967 Jun 10 21:32 ggml-small.hf.bin
-rw-r--r--  1 Akash  staff  487601967 Jun 10 21:35 ggml-small.tiktoken.bin
```