### PR TITLE
Fixing Accidental 'exit(0)' and Ensuring Proper 'return 1' in  `examples/main/main.cpp` `whisper_params_parse`

### DIFF
--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -108,7 +108,8 @@ bool whisper_params_parse(int argc, char ** argv, whisper_params & params) {
         }
 
         if (arg == "-h" || arg == "--help") {
-            return false;
+            whisper_print_usage(argc, argv, params);
+            exit(0);
         }
         else if (arg == "-t"    || arg == "--threads")        { params.n_threads      = std::stoi(argv[++i]); }
         else if (arg == "-p"    || arg == "--processors")     { params.n_processors   = std::stoi(argv[++i]); }

--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -108,8 +108,7 @@ bool whisper_params_parse(int argc, char ** argv, whisper_params & params) {
         }
 
         if (arg == "-h" || arg == "--help") {
-            whisper_print_usage(argc, argv, params);
-            exit(0);
+            return false;
         }
         else if (arg == "-t"    || arg == "--threads")        { params.n_threads      = std::stoi(argv[++i]); }
         else if (arg == "-p"    || arg == "--processors")     { params.n_processors   = std::stoi(argv[++i]); }
@@ -148,8 +147,7 @@ bool whisper_params_parse(int argc, char ** argv, whisper_params & params) {
         else if (arg == "-f"    || arg == "--file")           { params.fname_inp.emplace_back(argv[++i]); }
         else {
             fprintf(stderr, "error: unknown argument: %s\n", arg.c_str());
-            whisper_print_usage(argc, argv, params);
-            exit(0);
+            return false;
         }
     }
 
@@ -689,6 +687,7 @@ int main(int argc, char ** argv) {
     whisper_params params;
 
     if (whisper_params_parse(argc, argv, params) == false) {
+        whisper_print_usage(argc, argv, params);
         return 1;
     }
 


### PR DESCRIPTION
Fix what appears to be an inadvertent mistake of 'exit(0)'. It should likely return 'false' here to remain consistent with the following code, otherwise the program will never return '1', making the 'if' statement on line [691](https://github.com/ggerganov/whisper.cpp/pull/1002/files#diff-2d3599a9fad195f2c3c60bd06691bc1815325b3560b5feda41a91fa71194e805L691) meaningless.

