### PR TITLE
Fix for issue #876

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,7 @@ ifdef WHISPER_CUBLAS
 	LDFLAGS     += -lcublas -lculibos -lcudart -lcublasLt -lpthread -ldl -lrt -L/usr/local/cuda/lib64 -L/opt/cuda/lib64 -L$(CUDA_PATH)/targets/x86_64-linux/lib
 	WHISPER_OBJ += ggml-cuda.o
 	NVCC        = nvcc
-	NVCCFLAGS   = --forward-unknown-to-host-compiler -arch=native
+	NVCCFLAGS   = --forward-unknown-to-host-compiler -arch=any
 
 ggml-cuda.o: ggml-cuda.cu ggml-cuda.h
 	$(NVCC) $(NVCCFLAGS) $(CXXFLAGS) -Wno-pedantic -c $< -o $@


### PR DESCRIPTION
For the following issue:

https://github.com/ggerganov/whisper.cpp/issues/876#issue-1696896105

GPU support won't build without the change from `native` to `any`. Confirmed working with a 4090.