### PR TITLE
Add alternative java binding to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -617,6 +617,8 @@ in [models](models).
 - [X] Javascript: [bindings/javascript](bindings/javascript) | [#309](https://github.com/ggerganov/whisper.cpp/discussions/309)
   - React Native (iOS / Android): [whisper.rn](https://github.com/mybigday/whisper.rn)
 - [X] Go: [bindings/go](bindings/go) | [#312](https://github.com/ggerganov/whisper.cpp/discussions/312)
+- [X] Java:
+  - [GiviMAD/whisper-jni](https://github.com/GiviMAD/whisper-jni)
 - [X] Ruby: [bindings/ruby](bindings/ruby) | [#507](https://github.com/ggerganov/whisper.cpp/discussions/507)
 - [X] Objective-C / Swift: [ggerganov/whisper.spm](https://github.com/ggerganov/whisper.spm) | [#313](https://github.com/ggerganov/whisper.cpp/discussions/313)
   - [exPHAT/SwiftWhisper](https://github.com/exPHAT/SwiftWhisper)


### PR DESCRIPTION
Hi, I have written a JNI wrapper for this library, I would like to reference it on the readme so it is easy to found and gets tested by more people.

For now it only have the platform support that I needed, I'm planning on using it to write a Whisper Speech-to-text add-on for [openHAB](https://github.com/openhab).

Hope everything is in place.

Thank you for all the cool stuff you are doing.