### PR TITLE
Fix cd statements to allow spaces in model path

### DIFF
--- a/examples/whisper.nvim/whisper.nvim
+++ b/examples/whisper.nvim/whisper.nvim
@@ -32,7 +32,7 @@ model="base.en"
 
 # export the path to the whisper.cpp repo in the WHISPER_CPP_HOME env variable
 # https://github.com/ggerganov/whisper.cpp
-cd ${WHISPER_CPP_HOME}
+cd "${WHISPER_CPP_HOME}"
 
 if [ ! -f ./stream ] ; then
     echo "whisper.nvim: the 'stream' executable was not found! WHISPER_CPP_HOME=${WHISPER_CPP_HOME}" > /tmp/whisper.nvim

--- a/models/download-ggml-model.cmd
+++ b/models/download-ggml-model.cmd
@@ -33,7 +33,7 @@ goto :eof
 :download_model
 echo Downloading ggml model %model%...
 
-cd %models_path%
+cd "%models_path%"
 
 if exist "ggml-%model%.bin" (
   echo Model %model% already exists. Skipping download.

--- a/models/download-ggml-model.sh
+++ b/models/download-ggml-model.sh
@@ -54,7 +54,7 @@ fi
 
 printf "Downloading ggml model $model from '$src' ...\n"
 
-cd $models_path
+cd "$models_path"
 
 if [ -f "ggml-$model.bin" ]; then
     printf "Model $model already exists. Skipping download.\n"


### PR DESCRIPTION
Hi @ggerganov, 

`download-ggml-model.sh` and a couple other files currently do not quote `cd` statements, leading to issues when working in directories with spaces in the path:

<img width="738" alt="whisperbug" src="https://github.com/ggerganov/whisper.cpp/assets/30129802/a44ef316-d677-4b18-af95-5233cee433e2">

<img width="608" alt="whisperfix" src="https://github.com/ggerganov/whisper.cpp/assets/30129802/131a746b-7041-403a-a4a4-d47e7d0d3d1a">

I've fixed this issue.