### PR TITLE
go bindings: fix context.Process call in examples

### DIFF
--- a/bindings/go/README.md
+++ b/bindings/go/README.md
@@ -31,7 +31,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	if err := context.Process(samples, nil); err != nil {
+	if err := context.Process(samples, nil, nil); err != nil {
 		return err
 	}
 
@@ -71,7 +71,7 @@ The examples are placed in the `build` directory. Once built, you can download a
 And you can then test a model against samples with the following command:
 
 ```bash
-./build/go-whisper -model models/ggml-tiny.en.bin samples/jfk.wav 
+./build/go-whisper -model models/ggml-tiny.en.bin samples/jfk.wav
 ```
 
 ## Using the bindings

--- a/bindings/go/examples/go-whisper/process.go
+++ b/bindings/go/examples/go-whisper/process.go
@@ -67,7 +67,7 @@ func Process(model whisper.Model, path string, flags *Flags) error {
 	// Process the data
 	fmt.Fprintf(flags.Output(), "  ...processing %q\n", path)
 	context.ResetTimings()
-	if err := context.Process(data, cb); err != nil {
+	if err := context.Process(data, cb, nil); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
`context.Process` now expects 2 callbacks: 

https://github.com/ggerganov/whisper.cpp/blob/master/bindings/go/pkg/whisper/interface.go#L54
https://github.com/ggerganov/whisper.cpp/blob/master/bindings/go/pkg/whisper/context.go#L155-L158

The error:

```
~/Development/whisper.cpp/bindings/go $ make                                                                                                                                              (base)
Clean
Mkdir build
Mkdir models
Build whisper
I whisper.cpp build info:
I UNAME_S:  Darwin
I UNAME_P:  arm
I UNAME_M:  arm64
I CFLAGS:   -I.              -O3 -DNDEBUG -std=c11   -fPIC -D_XOPEN_SOURCE=600 -D_DARWIN_C_SOURCE -pthread -DGGML_USE_ACCELERATE
I CXXFLAGS: -I. -I./examples -O3 -DNDEBUG -std=c++11 -fPIC -D_XOPEN_SOURCE=600 -D_DARWIN_C_SOURCE -pthread
I LDFLAGS:   -framework Accelerate
I CC:       Apple clang version 14.0.3 (clang-1403.0.22.14.1)
I CXX:      Apple clang version 14.0.3 (clang-1403.0.22.14.1)

make[1]: `libwhisper.a' is up to date.
Build example go-model-download
Build example go-whisper
# github.com/ggerganov/whisper.cpp/bindings/go/examples/go-whisper
examples/go-whisper/process.go:70:34: not enough arguments in call to context.Process
        have ([]float32, "github.com/ggerganov/whisper.cpp/bindings/go/pkg/whisper".SegmentCallback)
        want ([]float32, "github.com/ggerganov/whisper.cpp/bindings/go/pkg/whisper".SegmentCallback, "github.com/ggerganov/whisper.cpp/bindings/go/pkg/whisper".ProgressCallback)
make: *** [examples/go-whisper] Error 1
```