### PR TITLE
Fix MSVC compile error C3688 on non-unicode Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,6 +240,7 @@ if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm" OR ${CMAKE_SYSTEM_PROCESSOR} MATCHES
 else()
     message(STATUS "x86 detected")
     if (MSVC)
+            add_compile_options(/utf-8)
             if(NOT WHISPER_NO_AVX2)
                 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /arch:AVX2")
                 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /arch:AVX2")


### PR DESCRIPTION
This fix has been merged in #721 , but lost in commit d458fcbc15da5a19a8e32faf77b1cb628aef1dd3 .

So this pull request fix it again.