### PR TITLE
whisper : fix visibility warning of struct whisper_full_params by declaring in advance

### DIFF
--- a/whisper.h
+++ b/whisper.h
@@ -67,6 +67,7 @@ extern "C" {
 
     struct whisper_context;
     struct whisper_state;
+    struct whisper_full_params;
 
     typedef int whisper_token;
 


### PR DESCRIPTION
This issue occurs when calling `whisper_free_params(struct whisper_full_params*)`.