### PR TITLE
Clean cmake warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,7 @@ jobs:
             -w /workspace ${{ env.ubuntu_image }} /bin/sh -c '
             apt update
             apt install -y build-essential cmake libsdl2-dev
-            cmake . -DWHISPER_SUPPORT_SDL2=ON -DCMAKE_BUILD_TYPE=${{ matrix.build }}
+            cmake . -DCMAKE_BUILD_TYPE=${{ matrix.build }}
             make
             ctest -L gh --output-on-failure'
 
@@ -115,7 +115,7 @@ jobs:
             -w /workspace ${{ env.ubuntu_image }} /bin/sh -c '
             apt update
             apt install -y build-essential cmake libsdl2-dev
-            cmake . -DWHISPER_SUPPORT_SDL2=ON -DCMAKE_BUILD_TYPE=${{ matrix.build }} -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+            cmake . -DCMAKE_BUILD_TYPE=${{ matrix.build }} -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
             make
             ctest -L gh --output-on-failure'
 
@@ -182,7 +182,6 @@ jobs:
         run: >
           cmake -S . -B ./build -A ${{ matrix.arch }}
           -DCMAKE_BUILD_TYPE=${{ matrix.build }}
-          -DWHISPER_SUPPORT_SDL2=${{ matrix.sdl2 }}
 
       - name: Build
         run: |
@@ -254,7 +253,6 @@ jobs:
           -DCMAKE_BUILD_TYPE=${{ matrix.build }}
           -DWHISPER_SUPPORT_OPENBLAS=${{ matrix.blas }}
           -DCMAKE_LIBRARY_PATH="$env:blasdir/lib"
-          -DWHISPER_SUPPORT_SDL2=${{ matrix.sdl2 }}
 
       - name: Build
         run: |

--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -255,6 +255,7 @@ std::string estimate_diarization_speaker(std::vector<std::vector<float>> pcmf32s
     return speaker;
 }
 void whisper_print_progress_callback(struct whisper_context * ctx, struct whisper_state * /*state*/, int progress, void * user_data) {
+    (void)ctx;
     int progress_step = ((whisper_print_user_data *) user_data)->params->progress_step;
     int * progress_prev  = &(((whisper_print_user_data *) user_data)->progress_prev);
     if (progress >= *progress_prev + progress_step) {

--- a/ggml.c
+++ b/ggml.c
@@ -1140,7 +1140,7 @@ static void quantize_row_q8_0_reference(const float * restrict x, block_q8_0 * r
 static void quantize_row_q8_0(const float * restrict x, void * restrict vy, int k) {
     assert(QK8_0 == 32);
     assert(k % QK8_0 == 0);
-    const int nb = k / QK8_0;
+    const int nb = k / QK8_0; UNUSED(nb);
 
     block_q8_0 * restrict y = vy;
 
@@ -1335,7 +1335,7 @@ static void quantize_row_q8_1_reference(const float * restrict x, block_q8_1 * r
 
 static void quantize_row_q8_1(const float * restrict x, void * restrict vy, int k) {
     assert(k % QK8_1 == 0);
-    const int nb = k / QK8_1;
+    const int nb = k / QK8_1; UNUSED(nb);
 
     block_q8_1 * restrict y = vy;
 


### PR DESCRIPTION
- Clean CMAKE unused-parameter warnings
- remove unused `WHISPER_SUPPORT_SDL2` cmake flag from CI