### PR TITLE
Add buffer overrun detection to ./stream

### DIFF
--- a/examples/common-sdl.cpp
+++ b/examples/common-sdl.cpp
@@ -133,6 +133,20 @@ bool audio_async::clear() {
     return true;
 }
 
+bool detect_overrun(size_t old_audio_pos,
+                    size_t new_audio_pos,
+                    size_t read_cursor_pos,
+                    size_t buffer_len) {
+  // We expect new_audio_pos to be the offset into the buffer of the
+  // next sample that will be overridden when new audio comes in,
+  // and read_cursor_pos is the offset of the oldest unread sample.
+  int offset = old_audio_pos;
+  int cursor_point = (read_cursor_pos - offset) % buffer_len;
+  int new_point = (new_audio_pos - offset) % buffer_len;
+
+  return new_point > cursor_point;
+}
+
 // callback to be called by SDL
 void audio_async::callback(uint8_t * stream, int len) {
     if (!m_running) {
@@ -149,6 +163,7 @@ void audio_async::callback(uint8_t * stream, int len) {
     {
         std::lock_guard<std::mutex> lock(m_mutex);
 
+        size_t prior_audio_pos = m_audio_pos;
         if (m_audio_pos + n_samples > m_audio.size()) {
             const size_t n0 = m_audio.size() - m_audio_pos;
 
@@ -163,7 +178,24 @@ void audio_async::callback(uint8_t * stream, int len) {
             m_audio_pos = (m_audio_pos + n_samples) % m_audio.size();
             m_audio_len = std::min(m_audio_len + n_samples, m_audio.size());
         }
+
+        // m_audio_pos, after the above, is the offset of the first
+        // entry in the samples array that the next callback will
+        // overwrite.  It is OK if the m_audio_read_cursor has the same
+        // value at this point, because the client still has a chance
+	// to read the sample.
+
+        overran_flag = overran_flag || detect_overrun(prior_audio_pos,
+                                          m_audio_pos,
+                                          m_audio_read_cursor,
+                                          m_audio.size());
     }
+}
+
+bool audio_async::overran() {
+  bool result = overran_flag;
+  overran_flag = false;
+  return result;
 }
 
 void audio_async::get(int ms, std::vector<float> & result) {
@@ -203,8 +235,11 @@ void audio_async::get(int ms, std::vector<float> & result) {
 
             memcpy(result.data(), &m_audio[s0], n0 * sizeof(float));
             memcpy(&result[n0], &m_audio[0], (n_samples - n0) * sizeof(float));
+            m_audio_read_cursor = (n_samples - n0) % m_audio.size();
         } else {
             memcpy(result.data(), &m_audio[s0], n_samples * sizeof(float));
+            m_audio_read_cursor =
+              (m_audio_read_cursor + n_samples) % m_audio.size();
         }
     }
 }

--- a/examples/common-sdl.h
+++ b/examples/common-sdl.h
@@ -31,6 +31,11 @@ public:
     // get audio data from the circular buffer
     void get(int ms, std::vector<float> & audio);
 
+    // check if the audio input has overwritten audio data we haven't
+    // yet read from the circular buffer since the last time we called
+    // overran()
+    bool overran();
+
 private:
     SDL_AudioDeviceID m_dev_id_in = 0;
 
@@ -44,6 +49,10 @@ private:
     std::vector<float> m_audio_new;
     size_t             m_audio_pos = 0;
     size_t             m_audio_len = 0;
+    // m_audio_read_cursor is the offset into the samples array of the
+    // oldest sample that has not yet been read by a call to get()
+    size_t             m_audio_read_cursor = -1;
+    bool               overran_flag = false;
 };
 
 // Return false if need to quit

--- a/examples/stream/stream.cpp
+++ b/examples/stream/stream.cpp
@@ -231,6 +231,9 @@ int main(int argc, char ** argv) {
 
         if (!use_vad) {
             while (true) {
+                if (audio.overran()) {
+                    fprintf(stderr, "\n\n%s: WARNING: cannot process audio fast enough, audio dropped ...\n\n", __func__);
+                }
                 audio.get(params.step_ms, pcmf32_new);
 
                 if ((int) pcmf32_new.size() > 2*n_samples_step) {
@@ -273,9 +276,15 @@ int main(int argc, char ** argv) {
                 continue;
             }
 
+            if (audio.overran()) {
+                fprintf(stderr, "\n\n%s: WARNING: cannot process audio fast enough, audio dropped...\n\n", __func__);
+            }
             audio.get(2000, pcmf32_new);
 
             if (::vad_simple(pcmf32_new, WHISPER_SAMPLE_RATE, 1000, params.vad_thold, params.freq_thold, false)) {
+                if (audio.overran()) {
+                    fprintf(stderr, "\n\n%s: WARNING: cannot process audio fast enough, audio dropped...\n\n", __func__);
+                }
                 audio.get(params.length_ms, pcmf32);
             } else {
                 std::this_thread::sleep_for(std::chrono::milliseconds(100));


### PR DESCRIPTION
When working on lower-capacity devices, it becomes more important to understand when the inference time is taking long enough that the inbound audio is overwriting samples which the inference process hasn't yet had a chance to process.

This patch adds a basic detection scheme to the audio class which maintains a record of where the client has read up to in the buffer.  If the async process writes a span into the buffer which overlaps that cursor, it sets a flag that the client can use to detect whether an overrun has happened.

This mechanism is then used in `examples/stream/stream.cpp` to signal when audio data has been lost.
