### PR TITLE
ggml : fix compiling when SSE3 is available but not SSSE3

### DIFF
--- a/ggml.c
+++ b/ggml.c
@@ -292,7 +292,7 @@ typedef double ggml_float;
 #if defined(_MSC_VER) || defined(__MINGW32__)
 #include <intrin.h>
 #else
-#if defined(__AVX__) || defined(__AVX2__) || defined(__AVX512F__) || defined(__SSSE3__)
+#if defined(__AVX__) || defined(__AVX2__) || defined(__AVX512F__) || defined(__SSSE3__) || defined(__SSE3__)
 #include <immintrin.h>
 #endif
 #endif


### PR DESCRIPTION
It got broken in commit 3998465721858.