### PR TITLE
whisper.android : fix cmake multiple libraries build

### DIFF
--- a/examples/whisper.android/app/build.gradle
+++ b/examples/whisper.android/app/build.gradle
@@ -19,7 +19,7 @@ android {
             useSupportLibrary true
         }
         ndk {
-            abiFilters 'arm64-v8a', 'armeabi-v7a'
+            abiFilters 'arm64-v8a', 'armeabi-v7a', 'x86', 'x86_64'
         }
     }
 

--- a/examples/whisper.android/app/src/main/jni/whisper/CMakeLists.txt
+++ b/examples/whisper.android/app/src/main/jni/whisper/CMakeLists.txt
@@ -23,9 +23,9 @@ function(build_library target_name)
     
     target_link_libraries(${target_name} ${LOG_LIB} android)
 
-    if (${ANDROID_ABI} STREQUAL "arm64-v8a")
+    if (${target_name} STREQUAL "whisper_v8fp16_va")
         target_compile_options(${target_name} PRIVATE -march=armv8.2-a+fp16)
-    elseif (${ANDROID_ABI} STREQUAL "armeabi-v7a")
+    elseif (${target_name} STREQUAL "whisper_vfpv4")
         target_compile_options(${target_name} PRIVATE -mfpu=neon-vfpv4)
     endif ()
 

--- a/examples/whisper.android/app/src/main/jni/whisper/CMakeLists.txt
+++ b/examples/whisper.android/app/src/main/jni/whisper/CMakeLists.txt
@@ -12,33 +12,42 @@ set(
         ${CMAKE_SOURCE_DIR}/jni.c
 )
 
-if (${ANDROID_ABI} STREQUAL "arm64-v8a")
-    set(WHISPER_LIBRARY_NAME whisper_v8fp16_va)
-elseif (${ANDROID_ABI} STREQUAL "armeabi-v7a")
-    set(WHISPER_LIBRARY_NAME whisper_vfpv4)
-endif ()
+find_library(LOG_LIB log)
 
-add_library(
-        ${WHISPER_LIBRARY_NAME}
+function(build_library target_name)
+    add_library(
+        ${target_name}
         SHARED
         ${SOURCE_FILES}
-)
+    )
+    
+    target_link_libraries(${target_name} ${LOG_LIB} android)
+
+    if (${ANDROID_ABI} STREQUAL "arm64-v8a")
+        target_compile_options(${target_name} PRIVATE -march=armv8.2-a+fp16)
+    elseif (${ANDROID_ABI} STREQUAL "armeabi-v7a")
+        target_compile_options(${target_name} PRIVATE -mfpu=neon-vfpv4)
+    endif ()
+
+    if (NOT ${CMAKE_BUILD_TYPE} STREQUAL "Debug")
+
+        target_compile_options(${target_name} PRIVATE -O3)
+        target_compile_options(${target_name} PRIVATE -fvisibility=hidden -fvisibility-inlines-hidden)
+        target_compile_options(${target_name} PRIVATE -ffunction-sections -fdata-sections)
+
+        target_link_options(${target_name} PRIVATE -Wl,--gc-sections)
+        target_link_options(${target_name} PRIVATE -Wl,--exclude-libs,ALL)
+        target_link_options(${target_name} PRIVATE -flto)
+
+    endif ()
+endfunction()
+
+build_library("whisper") # Default target
 
 if (${ANDROID_ABI} STREQUAL "arm64-v8a")
-    target_compile_options(${WHISPER_LIBRARY_NAME} PRIVATE -march=armv8.2-a+fp16)
+    build_library("whisper_v8fp16_va")
 elseif (${ANDROID_ABI} STREQUAL "armeabi-v7a")
-    target_compile_options(${WHISPER_LIBRARY_NAME} PRIVATE -mfpu=neon-vfpv4)
+    build_library("whisper_vfpv4")
 endif ()
 
-
-target_link_libraries(${WHISPER_LIBRARY_NAME} log android)
 include_directories(${WHISPER_LIB_DIR})
-
-if (NOT ${CMAKE_BUILD_TYPE} STREQUAL "Debug")
-    target_compile_options(${WHISPER_LIBRARY_NAME} PRIVATE -O3)
-    target_compile_options(${WHISPER_LIBRARY_NAME} PRIVATE -fvisibility=hidden -fvisibility-inlines-hidden)
-    target_compile_options(${WHISPER_LIBRARY_NAME} PRIVATE -ffunction-sections -fdata-sections)
-    target_link_options(${WHISPER_LIBRARY_NAME} PRIVATE -Wl,--gc-sections)
-    target_link_options(${WHISPER_LIBRARY_NAME} PRIVATE -Wl,--exclude-libs,ALL)
-    target_link_options(${WHISPER_LIBRARY_NAME} PRIVATE -flto)
-endif ()


### PR DESCRIPTION

After #1204, the Android build will only generate two shared libraries which it breaks the previous ABI compatibility:

```bash
$ $ANDROID_HOME/cmdline-tools/latest/bin/apkanalyzer files list \
  ~/workspace/whisper.cpp/examples/whisper.android/app/build/outputs/apk/debug/app-debug.apk \
  | grep libwhisper

/lib/armeabi-v7a/libwhisper_vfpv4.so
/lib/arm64-v8a/libwhisper_v8fp16_va.so
```

After this PR, we can see these are restored:

```bash
/lib/x86_64/libwhisper.so
/lib/x86/libwhisper.so
/lib/armeabi-v7a/libwhisper_vfpv4.so
/lib/armeabi-v7a/libwhisper.so
/lib/arm64-v8a/libwhisper_v8fp16_va.so
/lib/arm64-v8a/libwhisper.so
```