### PR TITLE
Faster `beam_search` sampling

### DIFF
--- a/whisper.cpp
+++ b/whisper.cpp
@@ -4132,15 +4132,16 @@ static bool whisper_kv_swap_fast(
         // since we modify data sequentially, we only consider decoder indices after current index
         for (int j = i + 1; j < size; j++) {
             if (i == view[j]) {
-                two_copy.insert(i);
-                is_one_copy = false;
                 // detect symmetric diagram
                 if (j == view[i]) {
                     p_swap_set.insert(i);
                     p_swap_set.insert(j);
                     p_swap_vec.emplace_back(i, j);
+                } else {
+                    two_copy.insert(i);
+                    is_one_copy = false;
+                    break;
                 }
-                break;
             }
         }
         if (is_one_copy) {

--- a/whisper.cpp
+++ b/whisper.cpp
@@ -24,7 +24,6 @@
 #include <regex>
 #include <random>
 #include <unordered_set>
-#include <iostream>
 
 #if defined(_MSC_VER)
 #pragma warning(disable: 4244 4267) // possible loss of data

--- a/whisper.cpp
+++ b/whisper.cpp
@@ -4140,8 +4140,8 @@ static bool whisper_kv_swap_fast(
                 } else {
                     two_copy.insert(i);
                     is_one_copy = false;
-                    break;
                 }
+                break;
             }
         }
         if (is_one_copy) {

--- a/whisper.cpp
+++ b/whisper.cpp
@@ -603,7 +603,7 @@ struct whisper_sequence {
 
 // TAGS: WHISPER_DECODER_INIT
 struct whisper_decoder {
-    // each decoders keep its own KV-cache
+    // each decoder keeps its own KV-cache
     whisper_kv_cache kv_self;
 
     // the currently generated sequence of tokens

--- a/whisper.cpp
+++ b/whisper.cpp
@@ -4099,7 +4099,7 @@ static void whisper_sequence_score(
 
 static bool whisper_fast_swap_KV(std::vector<int> & view, whisper_decoder src[], int size) {
     // (decoder->buffer->decoder or decoder->buffer + decoder->decoder)
-    std::unordered_set<int> two_copy; // decoder indices requires two copies to safely modify KV caches
+    std::unordered_set<int> two_copy; // decoder indices require two copies to safely modify KV caches
     two_copy.reserve(size);
 
     // (buffer->decoder or decoder->decoder)

--- a/whisper.cpp
+++ b/whisper.cpp
@@ -4103,7 +4103,7 @@ static bool whisper_fast_swap_KV(std::vector<int> & view, whisper_decoder src[],
     two_copy.reserve(size);
 
     // (buffer->decoder or decoder->decoder)
-    std::unordered_set<int> one_copy; // decoder indices requires one copies to safely modify KV caches
+    std::unordered_set<int> one_copy; // decoder indices require one copy to safely modify KV caches
     one_copy.reserve(size);
 
     for (int i = 0; i < size; i++) {

--- a/whisper.cpp
+++ b/whisper.cpp
@@ -4161,13 +4161,13 @@ static bool whisper_kv_swap_fast(
         memcpy(kv_swap_bufs[i].v.data(), src[i].kv_self.v->data, kv_swap_bufs[i].v.size());
     }
 
-    // since two-copy decoder KV caches are protected by kv_bufs, modify them first
+    // since two-copy decoder KV caches are protected by kv_swap_bufs, modify them first
     for (auto & i : two_copy) {
         // skip the decoder indices that require pointer swapping
         if (p_swap_set.find(i) != p_swap_set.end()) {continue;}
 
         if (two_copy.find(view[i]) != two_copy.end()) {
-            // modify KV caches of decoder using data from kv_bufs
+            // modify KV caches of decoder using data from kv_swap_bufs
             memcpy(src[i].kv_self.k->data, kv_swap_bufs[view[i]].k.data(), kv_swap_bufs[view[i]].k.size());
             memcpy(src[i].kv_self.v->data, kv_swap_bufs[view[i]].v.data(), kv_swap_bufs[view[i]].v.size());
         } else {
@@ -4183,7 +4183,7 @@ static bool whisper_kv_swap_fast(
         if (p_swap_set.find(i) != p_swap_set.end()) {continue;}
 
         if (two_copy.find(view[i]) != two_copy.end()) {
-            // modify KV caches of decoder using data from kv_bufs
+            // modify KV caches of decoder using data from kv_swap_bufs
             memcpy(src[i].kv_self.k->data, kv_swap_bufs[view[i]].k.data(), kv_swap_bufs[view[i]].k.size());
             memcpy(src[i].kv_self.v->data, kv_swap_bufs[view[i]].v.data(), kv_swap_bufs[view[i]].v.size());
         } else {


### PR DESCRIPTION
**PR (v1):** The KV cache update logic in the Master is quite simple and heavy-handed. First, a temporary cache is established, and all the KV cache is stored in this temporary cache. After the beam search is completed, the KV cache is updated based on the results of the beam search, pulling from the temporary cache to replace the old KV cache. If we assume the `beam_size` is `X`, then with the above method we need to read and write the KV cache `2X` times, which is very inefficient. In reality, we often don't need to update the decoder's KV cache (zero-copy), and even if we do need to update, we only need to update a portion and can directly copy without going through the temporary cache (one-copy). Lastly, we can also detect if there are read-write conflicts to reduce the number of times we write to the temporary cache and then copy (two-copy).

**PR (v2):** The calculation of `whisper_sample_token_topk` in Master is highly inefficient. First, it uses `logits_id.clear()` to clear all elements in the vector, and then it uses a loop to extract the logit value from logits. Along with the current index, a new `std::pair` is created and then pushed to the end of `logits_id` using `push_back`. Because the length of logits is determined by `n_vocab`, and `n_vocab` in whisper is `51,865`, each time we calculate `whisper_sample_token_topk` using the method in Master, we need to create (via `logits_id.push_back`) ~~and destroy (via `logits_id.clear`)~~ `51,865` `std::pair` objects, which is highly inefficient. In fact, we can use `logits_id.resize()` to limit the size of `logits_id`. Since the new size is less than or equal to the old capacity, there will be no memory allocation, and we can directly assign values to the old pairs using the index, thus avoiding creation and destruction.

**PR(v3):** Adopted ggerganov's suggestion to make ·kv_bufs· static, avoiding memory allocation and deallocation, thereby significantly improving performance.

**PR(v4):** Added the pointer swapping function, which slightly improved performance.

**PR(v5):** Updated the logic for determining `two-copy`, reducing unnecessary memory copying, slightly improving performance.

This PR optimizes both the KV cache update logic and the calculation of `whisper_sample_token_topk`, significantly reducing memory read-write operations, thereby saving a lot of time. 

The average sample time has decreased from **`1.56 ms/run`** to **`0.69 ms/run`**, reducing the computational time by approximately **`~55%`**. @ggerganov 

**Master:** `i7-12700H` `diffusion2023-07-03.wav` `ggml-model-whisper-base.bin`
| `-bs 1` `-bo 1` | `-bs 2` `-bo 2` | `-bs 3` `-bo 3` | `-bs 4` `-bo 4` | `-bs 5` `-bo 5` |
| :-----: | :----: | :----: | :----: | :----: |
| 0.57 ms/run | 1.56 ms/run | 1.55 ms/run | 1.58 ms/run | 1.55 ms/run |

<details> <summary>Older Versions</summary>

**This PR (v1):** `i7-12700H` `diffusion2023-07-03.wav` `ggml-model-whisper-base.bin`
| `-bs 1` `-bo 1` | `-bs 2` `-bo 2` | `-bs 3` `-bo 3` | `-bs 4` `-bo 4` | `-bs 5` `-bo 5` |
| :-----: | :----: | :----: | :----: | :----: |
| 0.57 ms/run | 0.96 ms/run | 1.01 ms/run | 1.07 ms/run | 1.14 ms/run |

**This PR (v2):** `i7-12700H` `diffusion2023-07-03.wav` `ggml-model-whisper-base.bin`
| `-bs 1` `-bo 1` | `-bs 2` `-bo 2` | `-bs 3` `-bo 3` | `-bs 4` `-bo 4` | `-bs 5` `-bo 5` |
| :-----: | :----: | :----: | :----: | :----: |
| 0.57 ms/run | 0.76 ms/run | 0.81 ms/run | 0.87 ms/run | 0.94 ms/run |

**This PR (v3):** `i7-12700H` `diffusion2023-07-03.wav` `ggml-model-whisper-base.bin`
| `-bs 1` `-bo 1` | `-bs 2` `-bo 2` | `-bs 3` `-bo 3` | `-bs 4` `-bo 4` | `-bs 5` `-bo 5` |
| :-----: | :----: | :----: | :----: | :----: |
| 0.57 ms/run | 0.69 ms/run | 0.72 ms/run | 0.74 ms/run | 0.77 ms/run |

**This PR (v4):** `i7-12700H` `diffusion2023-07-03.wav` `ggml-model-whisper-base.bin`
| `-bs 1` `-bo 1` | `-bs 2` `-bo 2` | `-bs 3` `-bo 3` | `-bs 4` `-bo 4` | `-bs 5` `-bo 5` |
| :-----: | :----: | :----: | :----: | :----: |
| 0.57 ms/run | 0.67 ms/run | 0.70 ms/run | 0.72 ms/run | 0.75 ms/run |

</details>

**This PR (v5):** `i7-12700H` `diffusion2023-07-03.wav` `ggml-model-whisper-base.bin`
| `-bs 1` `-bo 1` | `-bs 2` `-bo 2` | `-bs 3` `-bo 3` | `-bs 4` `-bo 4` | `-bs 5` `-bo 5` |
| :-----: | :----: | :----: | :----: | :----: |
| 0.57 ms/run | 0.64 ms/run | 0.68 ms/run | 0.70 ms/run | 0.73 ms/run |