### PR TITLE
ci : try to fix gradle action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -428,7 +428,7 @@ jobs:
 
       - name: Publish package
         if: ${{ github.ref == 'refs/heads/master' }}
-        uses: gradle/gradle-build-action@2.4.2
+        uses: gradle/gradle-build-action@v2.4.2
         with:
           arguments: publish
           build-root-directory: bindings/java


### PR DESCRIPTION
I broke this in https://github.com/ggerganov/whisper.cpp/pull/1263

Trying to fix some security issue reported by Github:

![image](https://github.com/ggerganov/whisper.cpp/assets/1991296/c81b3d2c-1b30-43c0-81e4-a5f3bcc1b9c8)
