### PR TITLE
examples: Move wav_writer from stream.cpp to common.h

### DIFF
--- a/examples/common.h
+++ b/examples/common.h
@@ -222,10 +222,6 @@ public:
         return true;
     }
 
-    bool open(const std::string & filename) {
-        return open_wav(filename);
-    }
-
     bool close() {
         file.close();
         return true;

--- a/examples/common.h
+++ b/examples/common.h
@@ -202,6 +202,7 @@ private:
         if (!file.is_open()) {
             file.open(filename, std::ios::binary);
             wav_filename = filename;
+            dataSize = 0;
         }
         return file.is_open();
     }

--- a/examples/common.h
+++ b/examples/common.h
@@ -7,6 +7,8 @@
 #include <vector>
 #include <random>
 #include <thread>
+#include <ctime>
+#include <fstream>
 
 #define COMMON_SAMPLE_RATE 16000
 
@@ -138,6 +140,106 @@ bool read_wav(
         std::vector<float> & pcmf32,
         std::vector<std::vector<float>> & pcmf32s,
         bool stereo);
+
+// Write PCM data into WAV audio file
+class wav_writer {
+private:
+    std::ofstream file;
+    uint32_t dataSize = 0;
+    std::string wav_filename;
+
+    bool write_header(const uint32_t sample_rate,
+                      const uint16_t bits_per_sample,
+                      const uint16_t channels) {
+
+        file.write("RIFF", 4);
+        file.write("\0\0\0\0", 4);    // Placeholder for file size
+        file.write("WAVE", 4);
+        file.write("fmt ", 4);
+
+        const uint32_t sub_chunk_size = 16;
+        const uint16_t audio_format = 1;      // PCM format
+        const uint32_t byte_rate = sample_rate * channels * bits_per_sample / 8;
+        const uint16_t block_align = channels * bits_per_sample / 8;
+
+        file.write(reinterpret_cast<const char *>(&sub_chunk_size), 4);
+        file.write(reinterpret_cast<const char *>(&audio_format), 2);
+        file.write(reinterpret_cast<const char *>(&channels), 2);
+        file.write(reinterpret_cast<const char *>(&sample_rate), 4);
+        file.write(reinterpret_cast<const char *>(&byte_rate), 4);
+        file.write(reinterpret_cast<const char *>(&block_align), 2);
+        file.write(reinterpret_cast<const char *>(&bits_per_sample), 2);
+        file.write("data", 4);
+        file.write("\0\0\0\0", 4);    // Placeholder for data size
+
+        return true;
+    }
+
+    // It is assumed that PCM data is normalized to a range from -1 to 1
+    bool write_audio(const float * data, size_t length) {
+        for (size_t i = 0; i < length; ++i) {
+            const auto intSample = static_cast<const int16_t>(data[i] * 32767);
+            file.write(reinterpret_cast<const char *>(&intSample), sizeof(int16_t));
+            dataSize += sizeof(int16_t);
+        }
+        if (file.is_open()) {
+            file.seekp(4, std::ios::beg);
+            uint32_t fileSize = 36 + dataSize;
+            file.write(reinterpret_cast<char *>(&fileSize), 4);
+            file.seekp(40, std::ios::beg);
+            file.write(reinterpret_cast<char *>(&dataSize), 4);
+            file.seekp(0, std::ios::end);
+        }
+        return true;
+    }
+
+    bool open_wav(const std::string & filename) {
+        if (filename != wav_filename) {
+            if (file.is_open()) {
+                file.close();
+            }
+        }
+        if (!file.is_open()) {
+            file.open(filename, std::ios::binary);
+        }
+        return file.is_open();
+    }
+
+public:
+    bool open(const std::string & filename,
+              const    uint32_t   sample_rate,
+              const    uint16_t   bits_per_sample,
+              const    uint16_t   channels) {
+
+        if (open_wav(filename)) {
+            write_header(sample_rate, bits_per_sample, channels);
+        } else {
+            return false;
+        }
+
+        return true;
+    }
+
+    bool open(const std::string & filename) {
+        return open_wav(filename);
+    }
+
+    bool close() {
+        file.close();
+        return true;
+    }
+
+    bool write(const float * data, size_t length) {
+        return write_audio(data, length);
+    }
+
+    ~wav_writer() {
+        if (file.is_open()) {
+            file.close();
+        }
+    }
+};
+
 
 // Apply a high-pass frequency filter to PCM audio
 // Suppresses frequencies below cutoff Hz

--- a/examples/common.h
+++ b/examples/common.h
@@ -201,6 +201,7 @@ private:
         }
         if (!file.is_open()) {
             file.open(filename, std::ios::binary);
+            wav_filename = filename;
         }
         return file.is_open();
     }


### PR DESCRIPTION
> - The naming convention is to use snake case, so this should be class `wav_writer`
> - Move to common.h / common.cpp
> - API should be: `open()`, `write()`, `close()`
> - Allocate on the stack instead of on the heap with new and forgetting to deallocate it
> - If `params.save_audio` is true, call `init()`