### PR TITLE
Abort callback improvements

### DIFF
--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -944,8 +944,9 @@ int main(int argc, char ** argv) {
                 wparams.progress_callback_user_data = &user_data;
             }
 
-            // example for abort mechanism
-            // in this example, we do not abort the processing, but we could if the flag is set to true
+            // examples for abort mechanism
+            // in examples below, we do not abort the processing, but we could if the flag is set to true
+
             // the callback is called before every encoder run - if it returns false, the processing is aborted
             {
                 static bool is_aborted = false; // NOTE: this should be atomic to avoid data race
@@ -955,6 +956,17 @@ int main(int argc, char ** argv) {
                     return !is_aborted;
                 };
                 wparams.encoder_begin_callback_user_data = &is_aborted;
+            }
+
+            // the callback is called before every computation - if it returns true, the computation is aborted
+            {
+                static bool is_aborted = false; // NOTE: this should be atomic to avoid data race
+
+                wparams.abort_callback = [](void * user_data) {
+                    bool is_aborted = *(bool*)user_data;
+                    return is_aborted;
+                };
+                wparams.abort_callback_user_data = &is_aborted;
             }
 
             if (whisper_full_parallel(ctx, wparams, pcmf32.data(), pcmf32.size(), params.n_processors) != 0) {

--- a/whisper.cpp
+++ b/whisper.cpp
@@ -3773,6 +3773,9 @@ struct whisper_full_params whisper_full_default_params(enum whisper_sampling_str
         /*.encoder_begin_callback           =*/ nullptr,
         /*.encoder_begin_callback_user_data =*/ nullptr,
 
+        /*.abort_callback           =*/ nullptr,
+        /*.abort_callback_user_data =*/ nullptr,
+
         /*.logits_filter_callback           =*/ nullptr,
         /*.logits_filter_callback_user_data =*/ nullptr,
     };


### PR DESCRIPTION
This PR improves `abort_callback` in the following way:

- adds missing initialization to `nullptr` (sorry, I missed that in 2f668c330e979ff7995e0f42e800a7795a32ec16)
- adds the example in `main.cpp` explaining how to use it

Additionally I have few questions:

- Is there any reason to keep `encoder_begin_callback`? Having two callbacks is quite confusing. Maybe both should be merged? I would be pleased to prepare such change.
- There are many bindings to other langs. Should I expose `abort_callback` to these bindings as well?