### PR TITLE
Clarify doc about where to compile from

### DIFF
--- a/examples/stream/README.md
+++ b/examples/stream/README.md
@@ -40,10 +40,18 @@ make stream
 ```
 
 Ensure you are at the root of the repo when running `make stream`.  Not within the `examples/stream` dir
-
 as the libraries needed like `common-sdl.h` are located within `examples`.  Attempting to compile within
-
 `examples/steam` means your compiler cannot find them and it gives an error it cannot find the file.
+
+```bash
+whisper.cpp/examples/stream$ make stream
+g++     stream.cpp   -o stream
+stream.cpp:6:10: fatal error: common/sdl.h: No such file or directory
+    6 | #include "common/sdl.h"
+      |          ^~~~~~~~~~~~~~
+compilation terminated.
+make: *** [<builtin>: stream] Error 1
+```
 
 ## Web version
 

--- a/examples/stream/README.md
+++ b/examples/stream/README.md
@@ -41,7 +41,8 @@ make stream
 
 Ensure you are at the root of the repo when running `make stream`.  Not within the `examples/stream` dir
 
-as the libraries needed like `common-sdl.h` are located within examples.  Attempting to compile within
+as the libraries needed like `common-sdl.h` are located within `examples`.  Attempting to compile within
+
 `examples/steam` means your compiler cannot find them and it gives an error it cannot find the file.
 
 ## Web version

--- a/examples/stream/README.md
+++ b/examples/stream/README.md
@@ -39,6 +39,10 @@ brew install sdl2
 make stream
 ```
 
+Ensure you are at the root of the repo when running `make stream`.  Not within the examples/stream dir
+as the libraries needed like `common-sdl.h` are located within examples.  Attempting to compile within
+`examples/steam` means your compiler cannot find them and it gives an error it cannot find the file.
+
 ## Web version
 
 This tool can also run in the browser: [examples/stream.wasm](/examples/stream.wasm)

--- a/examples/stream/README.md
+++ b/examples/stream/README.md
@@ -39,7 +39,8 @@ brew install sdl2
 make stream
 ```
 
-Ensure you are at the root of the repo when running `make stream`.  Not within the examples/stream dir
+Ensure you are at the root of the repo when running `make stream`.  Not within the `examples/stream` dir
+
 as the libraries needed like `common-sdl.h` are located within examples.  Attempting to compile within
 `examples/steam` means your compiler cannot find them and it gives an error it cannot find the file.
 


### PR DESCRIPTION
I was confused for a bit as to where some libs were coming from.  I simply had the wrong dir I was attempting to make from.  It [appears others have the same issue](https://github.com/ggerganov/whisper.cpp/issues/1336) so proposing to update the doc to clarify what dir you need to be in and why.