### PR TITLE
Allow env variable to override metal resource path

### DIFF
--- a/ggml-metal.m
+++ b/ggml-metal.m
@@ -211,9 +211,9 @@ struct ggml_metal_context * ggml_metal_init(int n_cb) {
             GGML_METAL_LOG_INFO("%s: default.metallib not found, loading from source\n", __func__);
 
             NSString * sourcePath;
-            NSString * whisperMetalPathResources = [[NSProcessInfo processInfo].environment objectForKey:@"WHISPER_METAL_PATH_RESOURCES"];
-            if (whisperMetalPathResources) {
-                sourcePath = [whisperMetalPathResources stringByAppendingPathComponent:@"ggml-metal.metal"];
+            NSString * ggmlMetalPathResources = [[NSProcessInfo processInfo].environment objectForKey:@"GGML_METAL_PATH_RESOURCES"];
+            if (ggmlMetalPathResources) {
+                sourcePath = [ggmlMetalPathResources stringByAppendingPathComponent:@"ggml-metal.metal"];
             } else {
                 sourcePath = [bundle pathForResource:@"ggml-metal" ofType:@"metal"];
             }

--- a/ggml-metal.m
+++ b/ggml-metal.m
@@ -210,7 +210,13 @@ struct ggml_metal_context * ggml_metal_init(int n_cb) {
         } else {
             GGML_METAL_LOG_INFO("%s: default.metallib not found, loading from source\n", __func__);
 
-            NSString * sourcePath = [bundle pathForResource:@"ggml-metal" ofType:@"metal"];
+            NSString * sourcePath;
+            NSString * whisperMetalPathResources = [[NSProcessInfo processInfo].environment objectForKey:@"WHISPER_METAL_PATH_RESOURCES"];
+            if (whisperMetalPathResources) {
+                sourcePath = [whisperMetalPathResources stringByAppendingPathComponent:@"ggml-metal.metal"];
+            } else {
+                sourcePath = [bundle pathForResource:@"ggml-metal" ofType:@"metal"];
+            }
             if (sourcePath == nil) {
                 GGML_METAL_LOG_WARN("%s: error: could not use bundle path to find ggml-metal.metal, falling back to trying cwd\n", __func__);
                 sourcePath = @"ggml-metal.metal";


### PR DESCRIPTION
Implementation for https://github.com/ggerganov/whisper.cpp/issues/1397

If an ENV variable called `WHISPER_METAL_PATH_RESOURCES` is available, then the `ggml-metal.metal` file is loaded from that path instead of using the `bundle#pathForResource` method.

---

### Testing



🟥  Run main and expect a load (null) error.

Use `make` to compile the `main` binary and move it to a folder outside the project root.

```
$ ./main -m models/ggml-base.bin test.wav
...
ggml_metal_init: allocating
ggml_metal_init: found device: Apple M1
ggml_metal_init: picking default device: Apple M1
ggml_metal_init: loading '(null)'
ggml_metal_init: error: Error Domain=NSCocoaErrorDomain Code=258 "The file name is invalid."
whisper_init_state: ggml_metal_init() failed
error: failed to initialize whisper context
```

🟩  Launch again, passing the project root path, where the `ggml-metal.metal` file exists. Success!

```
$ WHISPER_METAL_PATH_RESOURCES=/Users/codesoda/projects/whisper.cpp ./main  -m models/ggml-base.bin test.wav
...
ggml_metal_init: allocating
ggml_metal_init: found device: Apple M1
ggml_metal_init: picking default device: Apple M1
ggml_metal_init: loading '/Users/codesoda/projects/whisper.cpp/ggml-metal.metal'
ggml_metal_init: loaded kernel_add                            0x155707730 | th_max = 1024 | th_width =   32
...
```

