### PR TITLE
Reset ctx->t_start_us when calling whisper_reset_timings()

### DIFF
--- a/whisper.cpp
+++ b/whisper.cpp
@@ -3688,6 +3688,7 @@ void whisper_print_timings(struct whisper_context * ctx) {
 }
 
 void whisper_reset_timings(struct whisper_context * ctx) {
+    ctx->t_start_us = ggml_time_us();
     if (ctx->state != nullptr) {
         ctx->state->t_sample_us = 0;
         ctx->state->t_encode_us = 0;


### PR DESCRIPTION
Currently ```ctx->t_start_us``` is not reset when calling whisper_reset_timings(). This leads to an incorrect "total time" when doing consecutive transcription calls. In the SwiftUI example app it also outputs the total time from app startup (which loads the model) to when the transcription finishes.

See below for example log outputs