### PR TITLE
Return with error from whisper_encode_internal and whisper_decode_int…

### DIFF
--- a/whisper.cpp
+++ b/whisper.cpp
@@ -2027,7 +2027,7 @@ static bool whisper_encode_internal(
     wstate.t_encode_us += ggml_time_us() - t_start_us;
     wstate.n_encode++;
 
-    return true;
+    return !(abort_callback && abort_callback(abort_callback_data));
 }
 
 static struct ggml_cgraph * whisper_build_graph_decoder(
@@ -2447,7 +2447,7 @@ static bool whisper_decode_internal(
         wstate.n_prompt++;
     }
 
-    return true;
+    return !(abort_callback && abort_callback(abort_callback_data));
 }
 
 


### PR DESCRIPTION
When adding an abort callback the main transcribe function ```whisper_full_with_state``` aborts the GGML but still continues the main transcription workflow.

This pull request will return false from ```whisper_encode_internal``` and ```whisper_decode_internal``` so an abort will return from the main workflow with an error value.

