### PR TITLE
models : Fix `n_mel` mismatch in convert-whisper-to-coreml.py

### DIFF
--- a/models/convert-whisper-to-coreml.py
+++ b/models/convert-whisper-to-coreml.py
@@ -252,7 +252,7 @@ class WhisperANE(Whisper):
 def convert_encoder(hparams, model, quantize=False):
     model.eval()
 
-    input_shape = (1, 80, 3000)
+    input_shape = (1, hparams.n_mels, 3000)
     input_data = torch.randn(input_shape)
     traced_model = torch.jit.trace(model, input_data)
 


### PR DESCRIPTION
Because `whisper-large-v3` uses `n_mel=128`, we cannot hardcode the `input_shape = (1, 80, 3000)` into the script.