### PR TITLE
models : Fix `n_mel` mismatch in convert-whisper-to-openvino.py 

### DIFF
--- a/models/convert-whisper-to-openvino.py
+++ b/models/convert-whisper-to-openvino.py
@@ -9,7 +9,7 @@ import shutil
 def convert_encoder(hparams, encoder, mname):
     encoder.eval()
 
-    mel = torch.zeros((1, 80, 3000))
+    mel = torch.zeros((1, hparams.n_mels, 3000))
 
     onnx_folder=os.path.join(os.path.dirname(__file__),"onnx_encoder")
 


### PR DESCRIPTION
Because `whisper-large-v3` uses `n_mel=128`, we cannot hardcode the `input_shape = (1, 80, 3000)` into the script.

Same as #1457 #1458 