### PR TITLE
whisper : quantize encoder only

### DIFF
--- a/examples/quantize/quantize.cpp
+++ b/examples/quantize/quantize.cpp
@@ -162,6 +162,7 @@ bool whisper_model_quantize(const std::string & fname_inp, const std::string & f
         "encoder.conv2.bias",
         "encoder.positional_embedding",
         "decoder.positional_embedding",
+        "decoder.*",
     };
 
     if (!ggml_common_quantize_0(finp, fout, ftype, { ".*" }, to_skip)) {


### PR DESCRIPTION
PoC for quantizing just the Encoder

Can be useful with Distil Whisper models. For example, a distilled medium model with 4-bit Encoder is about 340MB:

<img width="1209" alt="Screenshot 2023-11-16 at 15 06 45" src="https://github.com/ggerganov/whisper.cpp/assets/1991296/9fcad9e6-4067-4010-b87d-aede1e1a4fd5">
