### PR TITLE
Request to add a new function to get the full language name

### DIFF
--- a/whisper.cpp
+++ b/whisper.cpp
@@ -3593,6 +3593,17 @@ const char * whisper_lang_str(int id) {
     return nullptr;
 }
 
+const char * whisper_lang_fullstr(int id) {
+   for (const auto & kv : g_lang) {
+        if (kv.second.first == id) {
+            return kv.second.second.c_str();
+        }
+    }
+
+    WHISPER_LOG_ERROR("%s: unknown language id %d\n", __func__, id);
+    return nullptr;
+}
+
 int whisper_lang_auto_detect_with_state(
         struct whisper_context * ctx,
           struct whisper_state * state,

--- a/whisper.cpp
+++ b/whisper.cpp
@@ -3593,7 +3593,7 @@ const char * whisper_lang_str(int id) {
     return nullptr;
 }
 
-const char * whisper_lang_fullstr(int id) {
+const char * whisper_lang_str_full(int id) {
    for (const auto & kv : g_lang) {
         if (kv.second.first == id) {
             return kv.second.second.c_str();

--- a/whisper.h
+++ b/whisper.h
@@ -316,7 +316,7 @@ extern "C" {
     WHISPER_API const char * whisper_lang_str(int id);
 
     // Return the short string of the specified language name (e.g. 2 -> "german"), returns nullptr if not found
-    WHISPER_API const char * whisper_lang_fullstr(int id); 
+    WHISPER_API const char * whisper_lang_str_full(int id); 
 
     // Use mel data at offset_ms to try and auto-detect the spoken language
     // Make sure to call whisper_pcm_to_mel() or whisper_set_mel() first

--- a/whisper.h
+++ b/whisper.h
@@ -315,6 +315,9 @@ extern "C" {
     // Return the short string of the specified language id (e.g. 2 -> "de"), returns nullptr if not found
     WHISPER_API const char * whisper_lang_str(int id);
 
+    // Return the short string of the specified language name (e.g. 2 -> "german"), returns nullptr if not found
+    WHISPER_API const char * whisper_lang_fullstr(int id); 
+
     // Use mel data at offset_ms to try and auto-detect the spoken language
     // Make sure to call whisper_pcm_to_mel() or whisper_set_mel() first
     // Returns the top language id or negative on failure


### PR DESCRIPTION
There is already a function there that retrieves the language id, but I'd like to also retrieve the full language name as well.  I've added a separate function which is a basic copy of the existing one except it returns kv.second.second.c_str()