### PR TITLE
CI : Add CUDA 11.8.0 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -285,7 +285,7 @@ jobs:
         arch: [x64]
         cublas: [ON]
         sdl2: [ON]
-        cuda-toolkit: [12.2.0, 11.8.0, 10.2.89]
+        cuda-toolkit: [12.2.0, 11.8.0]
         include:
           - arch: x64
             s2arc: x64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -301,9 +301,9 @@ jobs:
 
       - name: Install CUDA Toolkit
         id: cuda-toolkit
-        uses: Jimver/cuda-toolkit@v0.2.10
+        uses: Jimver/cuda-toolkit@v0.2.11
         with:
-          cuda: ${{ matrix.cuda-toolkit }}
+          cuda: '${{ matrix.cuda-toolkit }}'
 
       - name: Fetch SDL2 and set SDL2_DIR
         if: matrix.sdl2 == 'ON'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -318,7 +318,7 @@ jobs:
       - name: Build
         run: |
           cd ./build
-          msbuild ALL_BUILD.vcxproj -t:build -p:configuration=${{ matrix.build }} -p:platform=${{ matrix.arch }}
+          cmake --build . --config ${{ matrix.build }}
 
       - name: Copy CUDA DLLs
         run: >

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -285,6 +285,7 @@ jobs:
         arch: [x64]
         cublas: [ON]
         sdl2: [ON]
+        cuda-toolkit: [12.2.0, 11.8.0, 10.2.89]
         include:
           - arch: x64
             s2arc: x64
@@ -301,6 +302,8 @@ jobs:
       - name: Install CUDA Toolkit
         id: cuda-toolkit
         uses: Jimver/cuda-toolkit@v0.2.10
+        with:
+          cuda: ${{ matrix.cuda-toolkit }}
 
       - name: Fetch SDL2 and set SDL2_DIR
         if: matrix.sdl2 == 'ON'
@@ -315,7 +318,7 @@ jobs:
           -DCMAKE_BUILD_TYPE=${{ matrix.build }}
           -DWHISPER_CUBLAS=1
 
-      - name: Build
+      - name: Build ${{ matrix.cuda-toolkit }}
         run: |
           cd ./build
           cmake --build . --config ${{ matrix.build }}
@@ -335,7 +338,7 @@ jobs:
         if: matrix.sdl2 == 'ON'
         uses: actions/upload-artifact@v1
         with:
-          name: whisper-cublas-bin-${{ matrix.arch }}
+          name: whisper-cublas-${{ matrix.cuda-toolkit }}-bin-${{ matrix.arch }}
           path: build/bin/${{ matrix.build }}
 
   emscripten:


### PR DESCRIPTION
The reason for the inability to run is due to the incompatibility between the CUDA driver and CUDA toolkit. Previously, the CI for CUDA used version 12.1.0 of the CUDA toolkit, which requires a driver of at least version `>=527.41` on Windows. The file `whisper.cpp` will dynamically link with the runtime in the CUDA toolkit, and the runtime will in turn dynamically link with the driver. The incompatibility causes it to fail to run. The solution is simple: adding a Windows binary compiled with version 11.X of the CUDA toolkit can solve the problem.

![image](https://github.com/ggerganov/whisper.cpp/assets/129547291/84bfc8fd-8a7b-4558-aa85-639ebb1d9346)


![image](https://github.com/ggerganov/whisper.cpp/assets/129547291/90c849f9-329f-49b5-9b00-cee3514e9bc8)

Reference: [here](https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__DRIVER.html#:~:text=CUDA%20Runtime%20API%20calls%20operate,current%20to%20the%20calling%20thread.)

Closes #1552 