### PR TITLE
Remove #if arch(arm) check in Swift Package Manager

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2,33 +2,14 @@
 
 import PackageDescription
 
-#if arch(arm) || arch(arm64)
-let platforms: [SupportedPlatform]? = [
-    .macOS(.v12),
-    .iOS(.v14),
-    .watchOS(.v4),
-    .tvOS(.v14)
-]
-let exclude: [String] = []
-let resources: [Resource] = [
-    .process("ggml-metal.metal")
-]
-let additionalSources: [String] = ["ggml-metal.m"]
-let additionalSettings: [CSetting] = [
-    .unsafeFlags(["-fno-objc-arc"]),
-    .define("GGML_USE_METAL")
-]
-#else
-let platforms: [SupportedPlatform]? = nil
-let exclude: [String] = ["ggml-metal.metal"]
-let resources: [Resource] = []
-let additionalSources: [String] = []
-let additionalSettings: [CSetting] = []
-#endif
-
 let package = Package(
     name: "whisper",
-    platforms: platforms,
+    platforms: [
+        .macOS(.v12),
+        .iOS(.v14),
+        .watchOS(.v4),
+        .tvOS(.v14)
+    ],
     products: [
         .library(name: "whisper", targets: ["whisper"]),
     ],
@@ -36,7 +17,7 @@ let package = Package(
         .target(
             name: "whisper",
             path: ".",
-            exclude: exclude + [
+            exclude: [
                "bindings",
                "cmake",
                "coreml",
@@ -55,19 +36,22 @@ let package = Package(
                 "whisper.cpp",
                 "ggml-alloc.c",
                 "ggml-backend.c",
-                "ggml-quants.c"
-            ] + additionalSources,
-            resources: resources,
+                "ggml-quants.c",
+                "ggml-metal.m"
+            ],
+            resources: [.process("ggml-metal.metal")],
             publicHeadersPath: "spm-headers",
             cSettings: [
                 .unsafeFlags(["-Wno-shorten-64-to-32", "-O3", "-DNDEBUG"]),
-                .define("GGML_USE_ACCELERATE")
+                .define("GGML_USE_ACCELERATE"),
+                .unsafeFlags(["-fno-objc-arc"]),
+                .define("GGML_USE_METAL")
                 // NOTE: NEW_LAPACK will required iOS version 16.4+
                 // We should consider add this in the future when we drop support for iOS 14
                 // (ref: ref: https://developer.apple.com/documentation/accelerate/1513264-cblas_sgemm?language=objc)
                 // .define("ACCELERATE_NEW_LAPACK"),
                 // .define("ACCELERATE_LAPACK_ILP64")
-            ] + additionalSettings,
+            ],
             linkerSettings: [
                 .linkedFramework("Accelerate")
             ]


### PR DESCRIPTION
I assume the `#if arch(arm) || arch(arm64)` is meant to prevent older Intel macs from using Metal, however checking this here doesn't really work.  This check is executed on the machine compiling the package, and it is very likely that the machine compiling the package is not the machine that a compiled app will run on.  

### Current Behaviour:
- iOS app compiled on an Apple Silicon mac == uses Metal
- iOS app compiled on an Intel mac == won't use Metal
- macOS universal app compiled on Apple Silicon mac == both Intel and Apple Silicon will use metal
- macOS universal app compiled on Intel mac == neither Intel nor Apple Silicon will use metal
This is especially problematic for me as [Xcode Cloud](https://developer.apple.com/xcode-cloud/) builds are currently done on Intel machines, so Metal will not be used in built apps.

This PR enables Metal no matter what the compiling architecture is.  In the case of running a universal app on an Intel mac, there is still the issue that Metal will be enabled when it probably shouldn't be (maybe a runtime check should be added?), however I think it is much more likely that you will want Metal enabled when using SPM (all iOS devices are Apple Silicon, and more and more macs are Apple Silicon)