### PR TITLE
Pass max-len argument to server wparams

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -589,6 +589,7 @@ int main(int argc, char ** argv) {
             wparams.duration_ms      = params.duration_ms;
 
             wparams.thold_pt         = params.word_thold;
+            wparams.max_len          = params.max_len == 0 ? 60 : params.max_len;
             wparams.split_on_word    = params.split_on_word;
 
             wparams.speed_up         = params.speed_up;


### PR DESCRIPTION
This commit fixes the missing parameter binding for max-len between the input arguments and wparams.

The major difference between examples/main and examples/server is the following:

```c++
// main.cpp
wparams.max_len = params.output_wts && params.max_len == 0 ? 60 : params.max_len;
```
Vs
```c++
// server.cpp
wparams.max_len = params.max_len == 0 ? 60 : params.max_len;
```

I.e. the proposed fix does not take under consideration the `open_wts` flag as it is not backported to the server yet. I'm happy to backport wts if it could be of use, as a separate PR.