### PR TITLE
Fix 32-bit compiler warning

### DIFF
--- a/ggml-backend.c
+++ b/ggml-backend.c
@@ -872,7 +872,7 @@ ggml_backend_sched_t ggml_backend_sched_new(ggml_backend_t * backends, int n_bac
     struct ggml_backend_sched * sched = malloc(sizeof(struct ggml_backend_sched));
     memset(sched, 0, sizeof(struct ggml_backend_sched));
 
-    fprintf(stderr, "ggml_backend_sched size: %lu KB\n", sizeof(struct ggml_backend_sched)/1024);
+    fprintf(stderr, "ggml_backend_sched size: %zu KB\n", sizeof(struct ggml_backend_sched)/1024);
 
     sched->n_backends = n_backends;
     for (int i = 0; i < n_backends; i++) {


### PR DESCRIPTION
Fixes:
/C++: /Volumes/DEV/projects/easy-transcription/android/src/whisper/src/main/cpp/whisper/ggml-backend.c:875:58: warning: format specifies type 'unsigned long' but the argument has type 'unsigned int' [-Wformat]
C/C++:     fprintf(stderr, "ggml_backend_sched size: %lu KB\n", sizeof(struct ggml_backend_sched)/1024);
C/C++:                                               ~~~        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
C/C++:                                               %u