### PR TITLE
fix: remove hallucinations from silent audio

### DIFF
--- a/whisper.cpp
+++ b/whisper.cpp
@@ -4589,7 +4589,7 @@ static void whisper_process_logits(
 
         // suppress sot and nosp tokens
         logits[vocab.token_sot]  = -INFINITY;
-        logits[vocab.token_nosp] = -INFINITY; // TODO: ignore this token for now
+        // logits[vocab.token_nosp] = -INFINITY; // Uncommenting this would produce hallucinations on silent audio
 
         // [TDRZ] when tinydiarize is disabled, suppress solm token
         if (params.tdrz_enable == false) {


### PR DESCRIPTION
This line is very important since on silent audio it would heavily hallucinate.