### PR TITLE
Fix: some thread safety issues

### DIFF
--- a/whisper.cpp
+++ b/whisper.cpp
@@ -5460,11 +5460,9 @@ int whisper_full_with_state(
                         if (decoder.completed || decoder.failed) {
                             continue;
                         }
-                        kv_mutex.lock();
                         whisper_kv_cache_seq_rm(state->kv_self, j,                           -1, -1);
                         whisper_kv_cache_seq_cp(state->kv_self, WHISPER_MAX_DECODERS + j, j, -1, -1);
                         whisper_kv_cache_seq_rm(state->kv_self, WHISPER_MAX_DECODERS + j,    -1, -1);
-                        kv_mutex.unlock();
                     }
                 }
 


### PR DESCRIPTION
When running the large-v3 model, long recordings seem to have thread safety issues, randomly causing all subsequent texts to be the same sentence.

Build with CoreML:
```
./models/generate-coreml-model.sh large-v3
WHISPER_COREML=1 make -j
```

Running the command:
```
./main -m models/ggml-large-v3.bin -f /home/test.wav  --print-colors --output-txt true --output-file result
```

![Pasted Graphic 12](https://github.com/ggerganov/whisper.cpp/assets/66455008/d3694cc0-77ac-4206-8685-5d836c02a392)
