### PR TITLE
Add ability to extract encoder embedding.

### DIFF
--- a/whisper.cpp
+++ b/whisper.cpp
@@ -6055,6 +6055,16 @@ float whisper_full_get_token_p(struct whisper_context * ctx, int i_segment, int 
     return ctx->state->result_all[i_segment].tokens[i_token].p;
 }
 
+struct ggml_tensor * whisper_get_encoder_embedding(struct whisper_context * ctx)
+{
+    return ctx->state->embd_enc;
+}
+
+struct ggml_tensor * whisper_get_encoder_embedding_from_state(struct whisper_state * state)
+{
+    return state->embd_enc;
+}
+
 // =================================================================================================
 
 //

--- a/whisper.h
+++ b/whisper.h
@@ -605,6 +605,10 @@ extern "C" {
     WHISPER_API float whisper_full_get_token_p           (struct whisper_context * ctx, int i_segment, int i_token);
     WHISPER_API float whisper_full_get_token_p_from_state(struct whisper_state * state, int i_segment, int i_token);
 
+    // Get the tensor representing the encoder output
+    WHISPER_API struct ggml_tensor * whisper_get_encoder_embedding           (struct whisper_context * ctx);
+    WHISPER_API struct ggml_tensor * whisper_get_encoder_embedding_from_state(struct whisper_state * state);
+        
     ////////////////////////////////////////////////////////////////////////////
 
     // Temporary helpers needed for exposing ggml interface


### PR DESCRIPTION
Adds the ability to get the encoder output. No other top-level methods expose ggml_tensors though - I'm not sure that's cool. It seemed the quickest way. What I'm doing, eventually, is this:

```
ggml_tensor * tensor = whisper_get_encoder_embedding(ctx);
std::vector<float> tensor_data(ggml_nelements(tensor));
ggml_backend_tensor_get(tensor, tensor_data.data(), 0, ggml_nbytes(tensor))
```
        
 ... so maybe it should expose a method that returns or populates a vector, instead of returning a ggml_tensor? What do you think?