### PR TITLE
Fix `ggml_metal_log` on Intel macs

### DIFF
--- a/ggml-metal.m
+++ b/ggml-metal.m
@@ -177,6 +177,8 @@ static void ggml_metal_log(enum ggml_log_level level, const char * format, ...){
             ggml_metal_log_callback(level, buffer, ggml_metal_log_user_data);
         } else {
             char* buffer2 = malloc(len+1);
+            va_end(args);
+            va_start(args, format);
             vsnprintf(buffer2, len+1, format, args);
             buffer2[len] = 0;
             ggml_metal_log_callback(level, buffer2, ggml_metal_log_user_data);


### PR DESCRIPTION
Currently Intel macs crash at `ggml_metal_log`