### PR TITLE
talk-llama: speed up with Metal and CoreML

### DIFF
--- a/examples/talk-llama/CMakeLists.txt
+++ b/examples/talk-llama/CMakeLists.txt
@@ -1,3 +1,11 @@
+function(prefix_all NEW_LIST_NAME LIST_NAME PREFIX)
+    set(NEW_LIST "")
+    foreach(ITEM ${${LIST_NAME}})
+        set(NEW_LIST ${NEW_LIST} "${PREFIX}${ITEM}")
+    endforeach()
+    set(${NEW_LIST_NAME} ${NEW_LIST} PARENT_SCOPE)
+endfunction()
+
 if (WHISPER_SDL2)
     # talk-llama
     set(TARGET talk-llama)
@@ -7,6 +15,12 @@ if (WHISPER_SDL2)
 
     # TODO: this is temporary
     #       need to export ggml symbols for MSVC, but too lazy ..
+
+    # Add ../.. prefix to all the sources
+    prefix_all(GGML_SOURCES_METAL_PREF GGML_SOURCES_METAL "../../")
+    prefix_all(GGML_SOURCES_CUDA_PREF GGML_SOURCES_CUDA "../../")
+    prefix_all(GGML_SOURCES_OPENCL_PREF GGML_SOURCES_OPENCL "../../")
+
     add_executable(${TARGET}
         talk-llama.cpp
         llama.cpp
@@ -16,6 +30,9 @@ if (WHISPER_SDL2)
         ../../ggml-alloc.c
         ../../ggml-backend.c
         ../../ggml-quants.c
+        ${GGML_SOURCES_METAL_PREF}
+        ${GGML_SOURCES_CUDA_PREF}
+        ${GGML_SOURCES_OPENCL_PREF}
         ../../whisper.cpp)
 
     if(WIN32)
@@ -24,7 +41,12 @@ if (WHISPER_SDL2)
     endif()
 
     target_include_directories(${TARGET} PRIVATE ${SDL2_INCLUDE_DIRS} ../../)
-    target_link_libraries(${TARGET} PRIVATE ${SDL2_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+    target_link_libraries(${TARGET} PRIVATE ${SDL2_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${WHISPER_EXTRA_LIBS})
+    target_compile_definitions(${TARGET} PUBLIC ${WHISPER_EXTRA_FLAGS})
+
+    if (WHISPER_COREML)
+        target_link_libraries(${TARGET} PRIVATE whisper.coreml)
+    endif()
 
     include(DefaultTargetOptions)
 endif ()


### PR DESCRIPTION
Previously, talk-llama did not leverage Metal and CoreML functionalities when built with `cmake`, leading to unexpectedly poor performance on Apple Silicon devices.

This pull request addresses the issue by including necessary sources, libraries, and compile flags. As a result, talk-llama has been significantly optimized for performance. On my M2 Ultra Mac Studio, these modifications have notably improved the user experience.

Unfortunately, due to the unavailability of a substantial NVIDIA GPU, I haven't been able to verify if these changes positively impact performance on CUDA PC setups.