### PR TITLE
command: make use of the `--file` option

### DIFF
--- a/examples/command/command.cpp
+++ b/examples/command/command.cpp
@@ -336,6 +336,15 @@ int process_command_list(struct whisper_context * ctx, audio_async &audio, const
 
     std::vector<float> pcmf32_cur;
     std::vector<float> pcmf32_prompt;
+    FILE *out_stream = NULL;
+    if (!params.fname_out.empty()) {
+      out_stream = fopen(params.fname_out.c_str(), "a");
+      if (out_stream == NULL) {
+        fprintf(stderr, "%s: error: opening of \"%s\" failed!\n", __func__, params.fname_out.c_str());
+        perror(NULL);
+        return 5;
+      }
+    }
 
     // main loop
     while (is_running) {
@@ -451,6 +460,11 @@ int process_command_list(struct whisper_context * ctx, audio_async &audio, const
                             "\033[1m", allowed_commands[index].c_str(), "\033[0m", prob,
                             (int) std::chrono::duration_cast<std::chrono::milliseconds>(t_end - t_start).count());
                     fprintf(stdout, "\n");
+
+                    if (out_stream != NULL) {
+                        fprintf(out_stream, "%f\t%s\n", prob, allowed_commands[index].c_str());
+                        fflush(out_stream);
+                    }
                 }
             }
 
@@ -458,6 +472,9 @@ int process_command_list(struct whisper_context * ctx, audio_async &audio, const
         }
     }
 
+    if (out_stream != NULL) {
+        fclose(out_stream);
+    }
     return 0;
 }
 
@@ -559,6 +576,15 @@ int process_general_transcription(struct whisper_context * ctx, audio_async & au
 
     std::vector<float> pcmf32_cur;
     std::vector<float> pcmf32_prompt;
+    FILE *out_stream = NULL;
+    if (!params.fname_out.empty()) {
+      out_stream = fopen(params.fname_out.c_str(), "a");
+      if (out_stream == NULL) {
+        fprintf(stderr, "%s: error: opening of \"%s\" failed!\n", __func__, params.fname_out.c_str());
+        perror(NULL);
+        return 1;
+      }
+    }
 
     std::string k_prompt = "Ok Whisper, start listening for commands.";
     if (!params.prompt.empty()) {
@@ -665,6 +691,10 @@ int process_general_transcription(struct whisper_context * ctx, audio_async & au
                         const std::string command = ::trim(txt.substr(best_len));
 
                         fprintf(stdout, "%s: Command '%s%s%s', (t = %d ms)\n", __func__, "\033[1m", command.c_str(), "\033[0m", (int) t_ms);
+                        if (out_stream != NULL) {
+                          fprintf(out_stream, "%f\t%s\n", p/100.0, command.c_str());
+                          fflush(out_stream);
+                        }
                     }
 
                     fprintf(stdout, "\n");
@@ -674,6 +704,10 @@ int process_general_transcription(struct whisper_context * ctx, audio_async & au
             }
         }
     }
+    if (out_stream != NULL) {
+        fclose(out_stream);
+    }
+
 
     return 0;
 }


### PR DESCRIPTION
Append the recognized commands to the output file (option `--file`). One command per line in the format "probability<TAB>command".

With this you are able to do things like the following:

  # Create a named pipe for later usage
  mkfifo ./myfifo
  # Let awk read from the named pipe and if the probability is > 0.9 execute the command in bash
  awk -F'\t' '{if ($1 > 0.9) { printf("%s &\n", $2) | "bash" }}' ./myfifo
  # Run ./command and let it write the recognized commands to the named pipe
  ./command --commands <(echo -e "emacs\nfirefox\nfoot\n") -m ./ggml-base.bin --file ./myfifo

A word of warning, I only know enough C++ to be dangerous. 