### PR TITLE
whisper : replace `tensor->n_dims` with `ggml_n_dims(tensor)`

### DIFF
--- a/openvino/whisper-openvino-encoder.cpp
+++ b/openvino/whisper-openvino-encoder.cpp
@@ -64,15 +64,15 @@ int whisper_openvino_encode(
         return 0;
     }
 
-    if (mel->n_dims != 2) {
+    if (ggml_n_dims(mel) != 2) {
         fprintf(stderr, "%s: Error! mel ggml_tensor expected to have n_dims=2, but it has n_dims=%d\n",
-            __func__, mel->n_dims);
+            __func__, ggml_n_dims(mel));
         return 0;
     }
 
-    if (out->n_dims != 2) {
+    if (ggml_n_dims(out) != 2) {
         fprintf(stderr, "%s: Error! out ggml_tensor expected to have n_dims=2, but it has n_dims=%d\n",
-            __func__, out->n_dims);
+            __func__, ggml_n_dims(out));
         return 0;
     }
 


### PR DESCRIPTION
Since `tensor->n_dims` is now deprecated, we've switched to using `ggml_n_dims` as its replacement.

Even though **slaren** mentioned that `ggml_n_dims` isn't a direct substitute for `tensor::n_dims`, it's not a concern in this case. This is because both `ne[0]` and `ne[1]` should exceed `1` for tensor `mel` and `out`.

Close #1690 