### PR TITLE
download: Fix large q5 model name

### DIFF
--- a/models/download-ggml-model.sh
+++ b/models/download-ggml-model.sh
@@ -43,7 +43,7 @@ models=(
     "large-v1"
     "large-v2"
     "large-v3"
-    "large-q5_0"
+    "large-v3-q5_0"
 )
 
 # list available models


### PR DESCRIPTION
fixed typo in large-v3-q5-0 model name to match HF link