### PR TITLE
Updates Package.swift to use ggml as package dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,9 +13,13 @@ let package = Package(
     products: [
         .library(name: "whisper", targets: ["whisper"]),
     ],
+    dependencies: [
+        .package(url: "https://github.com/1-ashraful-islam/ggml.git", .branch("master"))
+    ],
     targets: [
         .target(
             name: "whisper",
+            dependencies: ["ggml"],
             path: ".",
             exclude: [
                "bindings",
@@ -32,14 +36,16 @@ let package = Package(
                "Makefile"
             ],
             sources: [
-                "ggml.c",
+                // "ggml.c",
                 "whisper.cpp",
-                "ggml-alloc.c",
-                "ggml-backend.c",
-                "ggml-quants.c",
-                "ggml-metal.m"
+                // "ggml-alloc.c",
+                // "ggml-backend.c",
+                // "ggml-quants.c",
+                // "ggml-metal.m"
             ],
-            resources: [.process("ggml-metal.metal")],
+            resources: [
+                // .process("ggml-metal.metal")
+                ],
             publicHeadersPath: "spm-headers",
             cSettings: [
                 .unsafeFlags(["-Wno-shorten-64-to-32", "-O3", "-DNDEBUG"]),

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .library(name: "whisper", targets: ["whisper"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/1-ashraful-islam/ggml.git", .branch("master"))
+        .package(url: "https://github.com/ggerganov/ggml.git", .branch("master"))
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -36,16 +36,8 @@ let package = Package(
                "Makefile"
             ],
             sources: [
-                // "ggml.c",
                 "whisper.cpp",
-                // "ggml-alloc.c",
-                // "ggml-backend.c",
-                // "ggml-quants.c",
-                // "ggml-metal.m"
             ],
-            resources: [
-                // .process("ggml-metal.metal")
-                ],
             publicHeadersPath: "spm-headers",
             cSettings: [
                 .unsafeFlags(["-Wno-shorten-64-to-32", "-O3", "-DNDEBUG"]),


### PR DESCRIPTION
When adding both whisper.cpp and llama.cpp as package dependency in Xcode - we run into "duplicate declarations of symbols" issue as both of these package uses the same source files for ggml.

Adding a swift package declaration to ggml (ggerganov/ggml/pull/674) and importing it as a dependency to both whisper.cpp and llama.cpp solves the issue.

Once the pull request (ggerganov/ggml/pull/674) is merged, merge this pull requests to whisper.cpp that use ggml as dependency.

Related: (llama.cpp/pull/4691)