### PR TITLE
fix coreml ANE optimized encoder

### DIFF
--- a/coreml/whisper-encoder.mm
+++ b/coreml/whisper-encoder.mm
@@ -24,9 +24,9 @@ struct whisper_coreml_context * whisper_coreml_init(const char * path_model) {
 
     // select which device to run the Core ML model on
     MLModelConfiguration *config = [[MLModelConfiguration alloc] init];
-    config.computeUnits = MLComputeUnitsCPUAndGPU;
+    // config.computeUnits = MLComputeUnitsCPUAndGPU;
     //config.computeUnits = MLComputeUnitsCPUAndNeuralEngine;
-    //config.computeUnits = MLComputeUnitsAll;
+    config.computeUnits = MLComputeUnitsAll;
 
     const void * data = CFBridgingRetain([[whisper_encoder_impl alloc] initWithContentsOfURL:url_model configuration:config error:nil]);
 

--- a/models/convert-whisper-to-coreml.py
+++ b/models/convert-whisper-to-coreml.py
@@ -143,20 +143,7 @@ class AudioEncoderANE(AudioEncoder):
             x = block(x)
 
         x = self.ln_post(x)
-
-        # """
-        # TODO:
-        # I think we need to transpose the result here to make it fit whisper.cpp memory order.
-        # However, even doing this, the results are still wrong. Kind of less wrong compared to
-        # not transposing, but still wrong.
-
-        # Also, I don't know why the original OpenAI implementation does not need to transpose
-
-        # transpose to (batch_size, n_ctx, n_state)
-        # x : torch.Tensor, shape = (batch_size, n_state, 1, n_ctx)
-
-        # """
-        # x = x.transpose(1,3)
+        x = x.squeeze(2).transpose(1, 2)
 
         return x
 

--- a/models/generate-coreml-model.sh
+++ b/models/generate-coreml-model.sh
@@ -23,7 +23,7 @@ if [[ $mname == "-h5" ]]; then
   echo $mpath
   python3 models/convert-h5-to-coreml.py --model-name $mname --model-path $mpath --encoder-only True
 else
-  python3 models/convert-whisper-to-coreml.py --model $mname --encoder-only True
+  python3 models/convert-whisper-to-coreml.py --model $mname --encoder-only True  --optimize-ane True
 fi
 
 xcrun coremlc compile models/coreml-encoder-${mname}.mlpackage models/


### PR DESCRIPTION
Transpose the result back to the format that's accepted by the decoder. 
I tested with tiny, small, and base models, and ran `./tests/run-tests.sh`, result all looks good. @ggerganov  I am not sure why your previous attempt didn't work,  can you double-check?

Performance-wise, this is my result on M3 pro with a 30min audio and the base model(I used a longer audio to get a better average encode time per segment so you can ignore the inital coreml model load overhead). The encode time is ~2x faster than metal.
With ANE optimized model:
```
whisper_print_timings:     load time =    93.50 ms
whisper_print_timings:     fallbacks =   0 p /   0 h
whisper_print_timings:      mel time =   678.59 ms
whisper_print_timings:   sample time =  6985.69 ms / 36729 runs (    0.19 ms per run)
whisper_print_timings:   encode time =  1985.48 ms /    67 runs (   29.63 ms per run)
whisper_print_timings:   decode time =   210.62 ms /    86 runs (    2.45 ms per run)
whisper_print_timings:   batchd time = 29357.13 ms / 36314 runs (    0.81 ms per run)
whisper_print_timings:   prompt time =   857.84 ms / 14712 runs (    0.06 ms per run)
whisper_print_timings:    total time = 42247.07 ms
```

With vanilla openai whisper model:
```
whisper_print_timings:     load time =    97.97 ms
whisper_print_timings:     fallbacks =   0 p /   0 h
whisper_print_timings:      mel time =   671.39 ms
whisper_print_timings:   sample time =  7039.62 ms / 36803 runs (    0.19 ms per run)
whisper_print_timings:   encode time =  2792.66 ms /    67 runs (   41.68 ms per run)
whisper_print_timings:   decode time =   202.56 ms /    84 runs (    2.41 ms per run)
whisper_print_timings:   batchd time = 29273.17 ms / 36390 runs (    0.80 ms per run)
whisper_print_timings:   prompt time =   845.34 ms / 14712 runs (    0.06 ms per run)
whisper_print_timings:    total time = 42520.91 ms
```
Metal:
```
whisper_print_timings:     load time =   103.68 ms
whisper_print_timings:     fallbacks =   0 p /   0 h
whisper_print_timings:      mel time =   678.44 ms
whisper_print_timings:   sample time =  6981.09 ms / 36940 runs (    0.19 ms per run)
whisper_print_timings:   encode time =  3958.86 ms /    66 runs (   59.98 ms per run)
whisper_print_timings:   decode time =   164.65 ms /    67 runs (    2.46 ms per run)
whisper_print_timings:   batchd time = 29736.41 ms / 36546 runs (    0.81 ms per run)
whisper_print_timings:   prompt time =   844.35 ms / 14712 runs (    0.06 ms per run)
whisper_print_timings:    total time = 42517.96 ms
```