### PR TITLE
chore: add missing large-v2 variant to scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ ifdef WHISPER_CLBLAST
 	CFLAGS 		+= -DGGML_USE_CLBLAST
 	LDFLAGS	 	+= -lclblast -lOpenCL
 	WHISPER_OBJ	+= ggml-opencl.o
-	
+
 ggml-opencl.o: ggml-opencl.c ggml-opencl.h
 	$(CC) $(CFLAGS) -c $< -o $@
 endif
@@ -324,9 +324,10 @@ samples:
 .PHONY: medium.en
 .PHONY: medium
 .PHONY: large-v1
+.PHONY: large-v2
 .PHONY: large
 
-tiny.en tiny base.en base small.en small medium.en medium large-v1 large: main
+tiny.en tiny base.en base small.en small medium.en medium large-v1 large-v2 large: main
 	bash ./models/download-ggml-model.sh $@
 	@echo ""
 	@echo "==============================================="

--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ make small
 make medium.en
 make medium
 make large-v1
+make large-v2
 make large
 ```
 

--- a/bindings/go/examples/go-model-download/main.go
+++ b/bindings/go/examples/go-model-download/main.go
@@ -24,7 +24,7 @@ const (
 
 var (
 	// The models which will be downloaded, if no model is specified as an argument
-	modelNames = []string{"ggml-tiny.en", "ggml-tiny", "ggml-base.en", "ggml-base", "ggml-small.en", "ggml-small", "ggml-medium.en", "ggml-medium", "ggml-large-v1", "ggml-large"}
+	modelNames = []string{"ggml-tiny.en", "ggml-tiny", "ggml-base.en", "ggml-base", "ggml-small.en", "ggml-small", "ggml-medium.en", "ggml-medium", "ggml-large-v1", "ggml-large-v2", "ggml-large"}
 )
 
 var (

--- a/examples/livestream.sh
+++ b/examples/livestream.sh
@@ -48,7 +48,7 @@ if [ -n "$3" ]; then
 fi
 
 # Whisper models
-models=( "tiny.en" "tiny" "base.en" "base" "small.en" "small" "medium.en" "medium" "large-v1" "large" )
+models=( "tiny.en" "tiny" "base.en" "base" "small.en" "small" "medium.en" "medium" "large-v1" "large-v2" "large" )
 
 # list available models
 function list_models {

--- a/examples/twitch.sh
+++ b/examples/twitch.sh
@@ -21,7 +21,7 @@ help()
     echo "Usage: ./twitch.sh -s [step] -m [model] -t [threads] [url]"
     echo "options:"
     echo "-s       Step in seconds (default is $step)."
-    echo "-m       Choose model, options are: 'tiny.en' 'tiny' 'base.en' 'base' 'small.en' 'small' 'medium.en' 'medium' 'large-v1' 'large' (default is '$model')."
+    echo "-m       Choose model, options are: 'tiny.en' 'tiny' 'base.en' 'base' 'small.en' 'small' 'medium.en' 'medium' 'large-v1' 'large-v2' 'large' (default is '$model')."
     echo "-t       Number of threads to use."
     echo "-h       Print this help page."
     echo

--- a/extra/bench-wts.sh
+++ b/extra/bench-wts.sh
@@ -13,8 +13,8 @@ fi
 
 #TODO: Make this a command line parameter
 #models="base small large"
-#models="tiny.en tiny base.en base small.en small medium.en medium large-v1 large"
-models="tiny.en base.en small.en medium.en large"
+#models="tiny.en tiny base.en base small.en small medium.en medium large-v1 large-v2 large"
+models="tiny.en base.en small.en medium.en large-v1 large-v2 large"
 
 DURATION=$(ffprobe -i $1 -show_entries format=duration -v quiet -of csv="p=0")
 DURATION=$(printf "%.2f" $DURATION)

--- a/extra/convert-all.sh
+++ b/extra/convert-all.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-models=( "tiny.en" "tiny" "base.en" "base" "small.en" "small" "medium.en" "medium" "large-v1" "large" )
+models=( "tiny.en" "tiny" "base.en" "base" "small.en" "small" "medium.en" "medium" "large-v1" "large-v2" "large" )
 
 for model in "${models[@]}"; do
     python3 models/convert-pt-to-ggml.py ~/.cache/whisper/$model.pt ../whisper models/

--- a/extra/quantize-all.sh
+++ b/extra/quantize-all.sh
@@ -26,6 +26,10 @@ cd ../
 ./quantize ./models/ggml-medium.en.bin ./models/ggml-medium.en-${qtype0}.bin ${qtype0}
 ./quantize ./models/ggml-medium.bin    ./models/ggml-medium-${qtype0}.bin    ${qtype0}
 
+./quantize ./models/ggml-large-v1.bin  ./models/ggml-large-v1-${qtype0}.bin ${qtype0}
+
+./quantize ./models/ggml-large-v2.bin  ./models/ggml-large-v2-${qtype0}.bin ${qtype0}
+
 ./quantize ./models/ggml-large.bin     ./models/ggml-large-${qtype0}.bin ${qtype0}
 
 if [ "$upload" == "1" ]; then
@@ -40,6 +44,10 @@ if [ "$upload" == "1" ]; then
 
     scp ./models/ggml-medium.en-${qtype0}.bin root@linode0:/mnt/Data/ggml/ggml-model-whisper-medium.en-${qtype0}.bin
     scp ./models/ggml-medium-${qtype0}.bin    root@linode0:/mnt/Data/ggml/ggml-model-whisper-medium-${qtype0}.bin
+
+    scp ./models/ggml-large-v1-${qtype0}.bin  root@linode0:/mnt/Data/ggml/ggml-model-whisper-large-v1-${qtype0}.bin
+
+    scp ./models/ggml-large-v2-${qtype0}.bin  root@linode0:/mnt/Data/ggml/ggml-model-whisper-large-v2-${qtype0}.bin
 
     scp ./models/ggml-large-${qtype0}.bin     root@linode0:/mnt/Data/ggml/ggml-model-whisper-large-${qtype0}.bin
 fi

--- a/models/convert-whisper-to-coreml.py
+++ b/models/convert-whisper-to-coreml.py
@@ -296,13 +296,13 @@ def convert_decoder(hparams, model, quantize=False):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--model", type=str, help="model to convert (e.g. tiny, tiny.en, base, base.en, small, small.en, medium, medium.en, large, large-v1)", required=True)
+    parser.add_argument("--model", type=str, help="model to convert (e.g. tiny, tiny.en, base, base.en, small, small.en, medium, medium.en, large, large-v1, large-v2)", required=True)
     parser.add_argument("--encoder-only", type=bool, help="only convert encoder", default=False)
     parser.add_argument("--quantize",     type=bool, help="quantize weights to F16", default=False)
     parser.add_argument("--optimize-ane", type=bool, help="optimize for ANE execution (currently broken)", default=False)
     args = parser.parse_args()
 
-    if args.model not in ["tiny", "tiny.en", "base", "base.en", "small", "small.en", "medium", "medium.en", "large", "large-v1"]:
+    if args.model not in ["tiny", "tiny.en", "base", "base.en", "small", "small.en", "medium", "medium.en", "large-v1", "large-v2", "large"]:
         raise ValueError("Invalid model name")
 
     whisper = load_model(args.model).cpu()

--- a/models/download-coreml-model.sh
+++ b/models/download-coreml-model.sh
@@ -19,7 +19,7 @@ function get_script_path() {
 models_path="$(get_script_path)"
 
 # Whisper models
-models=( "tiny.en" "tiny" "base.en" "base" "small.en" "small" "medium.en" "medium" "large-v1" "large" )
+models=( "tiny.en" "tiny" "base.en" "base" "small.en" "small" "medium.en" "medium" "large-v1" "large-v2" "large" )
 
 # list available models
 function list_models {

--- a/models/download-ggml-model.cmd
+++ b/models/download-ggml-model.cmd
@@ -8,7 +8,7 @@ popd
 set argc=0
 for %%x in (%*) do set /A argc+=1
 
-set models=tiny.en tiny base.en base small.en small medium.en medium large-v1 large
+set models=tiny.en tiny base.en base small.en small medium.en medium large-v1 large-v2 large
 
 if %argc% neq 1 (
   echo.
@@ -57,8 +57,8 @@ goto :eof
 :list_models
   echo.
   echo Available models:
-  (for %%a in (%models%) do ( 
-    echo %%a 
+  (for %%a in (%models%) do (
+    echo %%a
   ))
   echo.
   exit /b

--- a/models/download-ggml-model.sh
+++ b/models/download-ggml-model.sh
@@ -22,7 +22,7 @@ function get_script_path() {
 models_path="$(get_script_path)"
 
 # Whisper models
-models=( "tiny.en" "tiny" "base.en" "base" "small.en" "small" "medium.en" "medium" "large-v1" "large" )
+models=( "tiny.en" "tiny" "base.en" "base" "small.en" "small" "medium.en" "medium" "large-v1" "large-v2" "large" )
 
 # list available models
 function list_models {

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -19,7 +19,7 @@
 cd `dirname $0`
 
 # Whisper models
-models=( "tiny.en" "tiny" "base.en" "base" "small.en" "small" "medium.en" "medium" "large-v1" "large" )
+models=( "tiny.en" "tiny" "base.en" "base" "small.en" "small" "medium.en" "medium" "large-v1" "large-v2" "large" )
 
 # list available models
 function list_models {


### PR DESCRIPTION
As `large` variant became the default for `large-v3` model, `large-v2` variant was missing in a number of scripts.
This PR adds `large-v2` to missing places.
