### PR TITLE
fix temperature parameter in http api

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -602,7 +602,7 @@ int main(int argc, char ** argv) {
             wparams.greedy.best_of        = params.best_of;
             wparams.beam_search.beam_size = params.beam_size;
 
-            wparams.temperature_inc  = params.userdef_temp;
+            wparams.temperature  = params.userdef_temp;
             wparams.entropy_thold    = params.entropy_thold;
             wparams.logprob_thold    = params.logprob_thold;
 


### PR DESCRIPTION
Right now 'temperature' in request changes a wrong parameter, which could confuse a lot of people.