### PR TITLE
Optional Piper TTS support for talk-llama example.

### DIFF
--- a/examples/talk-llama/speak
+++ b/examples/talk-llama/speak
@@ -9,6 +9,14 @@
 #
 #espeak -v en-us+m$1 -s 225 -p 50 -a 200 -g 5 -k 5 "$2"
 
+# piper
+#
+# https://github.com/rhasspy/piper
+#
+# Tested with Linux:
+#
+#echo "$2" | piper --model ~/en_US-lessac-medium.onnx --output-raw | aplay -q -r 22050 -f S16_LE -t raw -
+
 # for Mac
 say "$2"
 


### PR DESCRIPTION
Add commented-out command to optionally use Piper (https://github.com/rhasspy/piper) as text-to-speech solution for the talk-llama example. Piper voices sound almost like real people which is a big improvement (e.g.) from something like espeak.