### PR TITLE
Don't compute timestamps when not printing them.

### DIFF
--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -982,6 +982,8 @@ int main(int argc, char ** argv) {
             wparams.entropy_thold    = params.entropy_thold;
             wparams.logprob_thold    = params.logprob_thold;
 
+            wparams.no_timestamps    = params.no_timestamps;
+
             whisper_print_user_data user_data = { &params, &pcmf32s, 0 };
 
             // this callback is called on each new segment

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -614,6 +614,8 @@ int main(int argc, char ** argv) {
             wparams.entropy_thold    = params.entropy_thold;
             wparams.logprob_thold    = params.logprob_thold;
 
+            wparams.no_timestamps    = params.no_timestamps;
+
             whisper_print_user_data user_data = { &params, &pcmf32s, 0 };
 
             // this callback is called on each new segment


### PR DESCRIPTION
> Also: maybe it's a good idea to make it so that `-nt` in [main.cpp](https://github.com/ggerganov/whisper.cpp/blob/master/examples/main/main.cpp?rgh-link-date=2024-01-07T19%3A07%3A23Z#L161) not only does not print timestamps, _but also does not compute them_:
> 
> `wparams.no_timestamps = params.no_timestamps;`

Yes, this should be updated. The reason is that "not computing timestamps" option was added just recently and before that, they were always computed but not being displayed. Now we can disable them properly

_Originally posted by @ggerganov in https://github.com/ggerganov/whisper.cpp/issues/1724#issuecomment-1880167869_

Implements the above comment