### PR TITLE
Makefile : Fix unknown type name `__fp16` when `UNAME_M` is `aarch64`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -261,8 +261,8 @@ ifdef WHISPER_GPROF
 endif
 
 ifneq ($(filter aarch64%,$(UNAME_M)),)
-	CFLAGS   += -mcpu=native
-	CXXFLAGS += -mcpu=native
+	CFLAGS   += -mcpu=native -mfp16-format=ieee
+	CXXFLAGS += -mcpu=native -mfp16-format=ieee
 endif
 
 ifneq ($(filter armv6%,$(UNAME_M)),)

--- a/Makefile
+++ b/Makefile
@@ -261,8 +261,8 @@ ifdef WHISPER_GPROF
 endif
 
 ifneq ($(filter aarch64%,$(UNAME_M)),)
-	CFLAGS   += -mcpu=native -mfp16-format=ieee
-	CXXFLAGS += -mcpu=native -mfp16-format=ieee
+	CFLAGS   += -march=native
+	CXXFLAGS += -march=native
 endif
 
 ifneq ($(filter armv6%,$(UNAME_M)),)


### PR DESCRIPTION
I'm not certain why we didn't add `-mfp16-format=ieee` in our `CFLAGS` and `CXXFLAGS`.