### PR TITLE
examples/server: implement "verbose_json" format with token details

### DIFF
--- a/examples/common.cpp
+++ b/examples/common.cpp
@@ -639,6 +639,12 @@ bool read_wav(const std::string & fname, std::vector<float>& pcmf32, std::vector
 
         fprintf(stderr, "%s: read %zu bytes from stdin\n", __func__, wav_data.size());
     }
+    else if (fname.size() > 256 || fname.size() > 40 && fname.substr(0, 4) == "RIFF" && fname.substr(8, 4) == "WAVE") {
+        if (drwav_init_memory(&wav, fname.c_str(), fname.size(), nullptr) == false) {
+            fprintf(stderr, "error: failed to open WAV file from fname buffer\n");
+            return false;
+        }
+    }
     else if (drwav_init_file(&wav, fname.c_str(), nullptr) == false) {
         fprintf(stderr, "error: failed to open '%s' as WAV file\n", fname.c_str());
         return false;

--- a/examples/common.h
+++ b/examples/common.h
@@ -136,6 +136,7 @@ gpt_vocab::id gpt_sample_top_k_top_p_repeat(
 //
 
 // Read WAV audio file and store the PCM data into pcmf32
+// fname can be a buffer of WAV data instead of a filename
 // The sample rate of the audio must be equal to COMMON_SAMPLE_RATE
 // If stereo flag is set and the audio has 2 channels, the pcmf32s will contain 2 channel PCM
 bool read_wav(


### PR DESCRIPTION
This is intended to mirror the format of openai's Python whisper.transcribe() output.

Sample usage and output:
```
$ curl 127.0.0.1:8080/inference -H "Content-Type: multipart/form-data" -F file="@smallstep.wav" -F response_format="verbose_json" | jq .
{
  "text": " That's one small step for man.\n One giant leap for mankind.\n",
  "segments": [
    {
      "id": 0,
      "text": " That's one small step for man.",
      "start": 0,
      "end": 5,
      "tokens": [
        1320,
        338,
        530,
        1402,
        2239,
        329,
        582,
        13
      ],
      "words": [
        {
          "word": " That",
          "start": 0.16,
          "end": 0.31,
          "probability": 0.31418749690055847
        },
        {
          "word": "'s",
          "start": 0.38,
          "end": 0.49,
          "probability": 0.8378852009773254
        },
...
```