### PR TITLE
Add fields to `verbose_json` response and show examples on the home page

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -543,7 +543,36 @@ int main(int argc, char ** argv) {
                              {"Access-Control-Allow-Origin", "*"},
                              {"Access-Control-Allow-Headers", "content-type"}});
 
-    std::string const default_content = "<html>hello</html>";
+    std::string const default_content = R"(
+    <html>
+    <head>
+        <title>Whisper.cpp Server</title>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width">
+        <style> body { font-family: sans-serif; } </style>
+    </head>
+    <body>
+        <h1>Whisper.cpp Server</h1>
+
+        <h2>/inference</h2>
+        <pre>
+    curl 127.0.0.1:)" + std::to_string(sparams.port) + R"(/inference \
+    -H "Content-Type: multipart/form-data" \
+    -F file="@&lt;file-path&gt;" \
+    -F temperature="0.0" \
+    -F temperature_inc="0.2" \
+    -F response_format="json"
+        </pre>
+
+        <h2>/load</h2>
+        <pre>
+    curl 127.0.0.1:)" + std::to_string(sparams.port) + R"(/load \
+    -H "Content-Type: multipart/form-data" \
+    -F model="&lt;path-to-model-file&gt;"
+        </pre>
+    </body>
+    </html>
+    )";
 
     // store default params so we can reset after each inference request
     whisper_params default_params = params;

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -858,6 +858,10 @@ int main(int argc, char ** argv) {
                 segment["temperature"] = params.temperature;
                 segment["avg_logprob"] = total_logprob / n_tokens;
 
+                // TODO compression_ratio and no_speech_prob are not implemented yet
+                // segment["compression_ratio"] = 0;
+                // segment["no_speech_prob"] = 0;
+
                 jres["segments"].push_back(segment);
             }
             res.set_content(jres.dump(-1, ' ', false, json::error_handler_t::replace),

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -549,7 +549,25 @@ int main(int argc, char ** argv) {
         <title>Whisper.cpp Server</title>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width">
-        <style> body { font-family: sans-serif; } </style>
+        <style>
+        body {
+            font-family: sans-serif;
+        }
+        form {
+            display: flex;
+            flex-direction: column;
+            align-items: flex-start;
+        }
+        label {
+            margin-bottom: 0.5rem;
+        }
+        input, select {
+            margin-bottom: 1rem;
+        }
+        button {
+            margin-top: 1rem;
+        }
+        </style>
     </head>
     <body>
         <h1>Whisper.cpp Server</h1>
@@ -570,6 +588,28 @@ int main(int argc, char ** argv) {
     -H "Content-Type: multipart/form-data" \
     -F model="&lt;path-to-model-file&gt;"
         </pre>
+
+        <div>
+            <h2>Try it out</h2>
+            <form action="/inference" method="POST" enctype="multipart/form-data">
+                <label for="file">Choose an audio file:</label>
+                <input type="file" id="file" name="file" accept="audio/*" required><br>
+
+                <label for="temperature">Temperature:</label>
+                <input type="number" id="temperature" name="temperature" value="0.0" step="0.01" placeholder="e.g., 0.0"><br>
+
+                <label for="response_format">Response Format:</label>
+                <select id="response_format" name="response_format">
+                    <option value="verbose_json">Verbose JSON</option>
+                    <option value="json">JSON</option>
+                    <option value="text">Text</option>
+                    <option value="srt">SRT</option>
+                    <option value="vtt">VTT</option>
+                </select><br>
+
+                <button type="submit">Submit</button>
+            </form>
+        </div>
     </body>
     </html>
     )";


### PR DESCRIPTION
The `verbose_json` format seems to aim to match the same format as OpenAI's, but it is currently missing several fields.
- I tried to include `task`, `language`, `duration`, `temperature`, and `avg_logprob`.

Some observations:
- The current `segment.words` do not match OpenAI's (OpenAI does not provide this one), but I think that's okay; it can be an extension to showcase the capabilities of whisper.cpp at the word level.
- It seems that OpenAI also includes non-speech tokens.
- For `compression_ratio` and `no_speech_prob`, if I have not missed anything, currently, they cannot be obtained from whisper.cpp?

<details>
<summary>

OpenAI's `verbose_json`

</summary>

```json
{
  "task": "transcribe",
  "language": "english",
  "duration": 4.440000057220459,
  "text": "This is my voice sample for research purpose only.",
  "segments": [
    {
      "id": 0,
      "seek": 0,
      "start": 0.0,
      "end": 4.0,
      "text": " This is my voice sample for research purpose only.",
      "tokens": [
        50364,
        639,
        307,
        452,
        3177,
        6889,
        337,
        2132,
        4334,
        787,
        13,
        50564
      ],
      "temperature": 0.0,
      "avg_logprob": -0.4242081940174103,
      "compression_ratio": 0.8928571343421936,
      "no_speech_prob": 0.0008698556339368224
    }
  ]
}
```

</details>

<details>
<summary>

whisper.cpp's `verbose_json`

</summary>

```json
{
  "task": "transcribe",
  "language": "english",
  "duration": 4.440000057220459,
  "text": " This is my voice sample for research purpose only.\n",
  "segments": [
    {
      "id": 0,
      "text": " This is my voice sample for research purpose only.",
      "start": 0.0,
      "end": 4.0,
      "tokens": [
        770,
        318,
        616,
        3809,
        6291,
        329,
        2267,
        4007,
        691,
        13
      ],
      "words": [
        {
          "word": " This",
          "start": 0.16,
          "end": 0.42,
          "probability": 0.8665725588798523
        },
        {
          "word": " is",
          "start": 0.42,
          "end": 0.63,
          "probability": 0.9934033751487732
        },
        ...,
        {
          "word": ".",
          "start": 4.0,
          "end": 4.0,
          "probability": 0.8532010316848755
        }
      ],
      "temperature": 0.0,
      "avg_logprob": -0.1288750171661377
    }
  ]
}
```

</details>

I also replaced the `hello` on the homepage with request examples. I think the first action after running the server with `./server` is to open the URL in the terminal and check out the homepage. It may be easier for users to try the server this way. (A web interface for direct interaction would be better, but it requires some time to design...)