### PR TITLE
common: fix wav buffer detection

### DIFF
--- a/examples/common.h
+++ b/examples/common.h
@@ -135,6 +135,9 @@ gpt_vocab::id gpt_sample_top_k_top_p_repeat(
 // Audio utils
 //
 
+// Check if a buffer is a WAV audio file
+bool is_wav_buffer(const std::string buf);
+
 // Read WAV audio file and store the PCM data into pcmf32
 // fname can be a buffer of WAV data instead of a filename
 // The sample rate of the audio must be equal to COMMON_SAMPLE_RATE


### PR DESCRIPTION
For edge cases, WAV files can be smaller than 256 bytes, although I doubt that Whisper can transcribe anything from them...

The specification states that both `RIFF` and `WAVE` should exist for WAV files.
Then, I also check the file size based on the RIFF specification.
