### PR TITLE
WIP Very rough cut of streaming from stdin.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -348,7 +348,7 @@ libwhisper.so: $(WHISPER_OBJ)
 	$(CXX) $(CXXFLAGS) -shared -o libwhisper.so $(WHISPER_OBJ) $(LDFLAGS)
 
 clean:
-	rm -f *.o main stream command talk talk-llama bench quantize server lsp libwhisper.a libwhisper.so
+	rm -f *.o main stream stream-stdin command talk talk-llama bench quantize server lsp libwhisper.a libwhisper.so
 
 #
 # Examples
@@ -374,6 +374,9 @@ server: examples/server/server.cpp $(SRC_COMMON) $(WHISPER_OBJ)
 
 stream: examples/stream/stream.cpp $(SRC_COMMON) $(SRC_COMMON_SDL) $(WHISPER_OBJ)
 	$(CXX) $(CXXFLAGS) examples/stream/stream.cpp $(SRC_COMMON) $(SRC_COMMON_SDL) $(WHISPER_OBJ) -o stream $(CC_SDL) $(LDFLAGS)
+
+stream-stdin: examples/stream-stdin/stream-stdin.cpp $(SRC_COMMON) examples/audio-stdin.h examples/audio-stdin.cpp $(WHISPER_OBJ)
+	$(CXX) $(CXXFLAGS) examples/stream-stdin/stream-stdin.cpp $(SRC_COMMON) examples/audio-stdin.cpp $(WHISPER_OBJ) -o stream-stdin $(LDFLAGS)
 
 command: examples/command/command.cpp examples/grammar-parser.cpp $(SRC_COMMON) $(SRC_COMMON_SDL) $(WHISPER_OBJ)
 	$(CXX) $(CXXFLAGS) examples/command/command.cpp examples/grammar-parser.cpp $(SRC_COMMON) $(SRC_COMMON_SDL) $(WHISPER_OBJ) -o command $(CC_SDL) $(LDFLAGS)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -28,6 +28,8 @@ add_library(${TARGET} STATIC
     common-ggml.h
     common-ggml.cpp
     grammar-parser.cpp
+    audio-stdin.h
+    audio-stdin.cpp
     )
 
 include(DefaultTargetOptions)
@@ -69,6 +71,7 @@ elseif(CMAKE_JS_VERSION)
 else()
     add_subdirectory(main)
     add_subdirectory(stream)
+    add_subdirectory(stream-stdin)
     add_subdirectory(server)
     add_subdirectory(command)
     add_subdirectory(bench)

--- a/examples/audio-stdin.cpp
+++ b/examples/audio-stdin.cpp
@@ -1,0 +1,185 @@
+#include "audio-stdin.h"
+
+#include <csignal>
+#include <cstring>
+
+// Because the original happened to handle OS signals in the same library as
+// handled the audio, this is implemented here.
+// TODO: split this out to something a bit more coherent
+
+bool should_quit = false;
+
+void quit_signal_handler(int signal) {
+  if (signal == SIGINT || signal == SIGTERM) {
+    should_quit = true;
+  }
+}
+
+void install_signal_handler() {
+    std::signal(SIGINT, quit_signal_handler);
+    std::signal(SIGTERM, quit_signal_handler);
+}
+
+bool should_keep_running() {
+  return !should_quit;
+}
+
+
+
+audio_stdin::audio_stdin(int len_ms) {
+     m_len_ms = len_ms;
+
+     m_running = false;
+}
+
+audio_stdin::~audio_stdin() {
+  // Nothing to do here, we don't own m_fd
+}
+
+/*
+Setup the stdin reader.  For simplicity, let's say that the file descriptor
+passed in needs to already be open, and that the destructor doesn't close it.
+*/
+bool audio_stdin::init(int fd, int sample_rate) {
+  m_fd = fd;
+  m_sample_rate = sample_rate;
+
+  size_t buffer_size = (m_sample_rate*m_len_ms)/1000;
+  m_audio.resize(buffer_size);
+  m_in_buffer.resize(buffer_size);
+
+  return true;
+}
+
+bool audio_stdin::resume() {
+  // In this initial implementation, we're assuming that we don't even have to
+  // do anything in the background.  Getting data off stdin can be assumed to be
+  // fast enough that we can do it synchronously, so `resume` can be a noop.
+  m_running = true;
+  return true;
+}
+
+bool audio_stdin::pause() {
+  // Similarly to `resume`, we don't need to do anything here.  We just never
+  // read from stdin.
+  m_running = false;
+  return true;
+}
+
+bool audio_stdin::clear() {
+
+    if (!m_running) {
+      fprintf(stderr, "%s: not running!\n", __func__);
+      return false;
+    }
+
+    // Now while *we're* not doing anything with threads, that doen't mean
+    // nobody else is
+    {
+      std::lock_guard<std::mutex> lock(m_mutex);
+
+      m_audio_pos = 0;
+      m_audio_len = 0;
+    }
+
+    return true;
+}
+
+// Important: len is a number of bytes
+bool audio_stdin::callback(int len) {
+  // We aren't called by SDL.  Instead we're called whenever whisper runs close enough to
+  // being out of audio that the next iteration would stall.
+    if (!m_running) {
+        return true;
+    }
+
+    size_t n_samples = len / sizeof(float);
+
+    if (n_samples > m_audio.size()) {
+        n_samples = m_audio.size();
+    }
+
+    {
+      //        std::lock_guard<std::mutex> lock(m_mutex);
+
+	// stdin is PCM mono 16khz in s16le format.  Use ffmpeg to make that happen.
+        int nread = read(m_fd, m_in_buffer.data(), m_in_buffer.size());
+	if (nread < 0) { /* TODO then we need to barf, that's a fail */ }
+	else if (nread == 0) { should_quit = true; return false; }
+
+	//Nicked this from drwav.h, we're basically doing the same as drwav_s16_to_f32
+	float scale_factor = 0.000030517578125f;
+
+        if (m_audio_pos + n_samples > m_audio.size()) {
+            const size_t n0 = m_audio.size() - m_audio_pos;
+
+	    // Now we pull as much as we need from stdin, blocking if we have to
+
+	    for(int i = m_audio_pos; i < n0; i+=4) {
+	      m_audio[i] = m_in_buffer[i] * scale_factor;
+ 	    }
+	    for(int i = 0; i < n_samples - n0; i++) {
+	      m_audio[i] = m_in_buffer[i] * scale_factor;
+	    }
+
+            m_audio_pos = (m_audio_pos + n_samples) % m_audio.size();
+            m_audio_len = m_audio.size();
+        } else {
+	    for(int i = 0; i < n_samples; i++) {
+	      m_audio[i] = m_in_buffer[i] * scale_factor;
+	    }
+
+            m_audio_pos = (m_audio_pos + n_samples) % m_audio.size();
+            m_audio_len = std::min(m_audio_len + n_samples, m_audio.size());
+        }
+    }
+    return true;
+}
+
+// Identical to audio_async, except that we can signal that the audio stream is closed
+bool audio_stdin::get(int ms, std::vector<float> & result) {
+
+    if (!m_running) {
+        fprintf(stderr, "%s: not running!\n", __func__);
+        return true;
+    }
+
+    result.clear();
+
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+
+        if (ms <= 0) {
+            ms = m_len_ms;
+        }
+
+        size_t n_samples = (m_sample_rate * ms) / 1000;
+
+	// we're double-buffering here, but I'll take that out if it works.
+	// It's just ungainly, not actually a problem.
+
+	if (!callback(n_samples * sizeof(float))){
+	  return false;
+	}
+
+        if (n_samples > m_audio_len) {
+            n_samples = m_audio_len;
+        }
+        result.resize(n_samples);
+
+        int s0 = m_audio_pos - n_samples;
+        if (s0 < 0) {
+            s0 += m_audio.size();
+        }
+
+        if (s0 + n_samples > m_audio.size()) {
+            const size_t n0 = m_audio.size() - s0;
+
+            memcpy(result.data(), &m_audio[s0], n0 * sizeof(float));
+            memcpy(&result[n0], &m_audio[0], (n_samples - n0) * sizeof(float));
+        } else {
+            memcpy(result.data(), &m_audio[s0], n_samples * sizeof(float));
+        }
+    }
+    return true;
+}

--- a/examples/audio-stdin.h
+++ b/examples/audio-stdin.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <vector>
+#include <mutex>
+
+//
+// Stdin wav capture
+//
+
+class audio_stdin {
+public:
+    audio_stdin(int len_ms);
+    ~audio_stdin();
+
+    bool init(int fd, int sample_rate);
+
+  // The sdl version captures to a circular buffer; I think we should assume that we need the same
+    // start capturing audio via the provided SDL callback
+    // keep last len_ms seconds of audio in a circular buffer
+    bool resume();
+    bool pause();
+    bool clear();
+
+    // callback to be called when we run out of data.
+    // This is what will do a read() from stdin, and can block if there isn't
+    // enough data yet.
+    // Returns false if the stream's closed.
+    bool callback(int len);
+
+    // get audio data from the circular buffer
+    // Returns false if the stream's closed.
+    bool get(int ms, std::vector<float> & audio);
+
+private:
+    int m_fd = 0;
+    int m_len_ms = 0;
+    int m_sample_rate = 0;
+
+    std::atomic_bool m_running;
+    std::mutex       m_mutex;
+
+    std::vector<float> m_audio;
+    // Since the data we plan on receiving needs converting, we need somewhere to hold it while we do that
+    std::vector<int16_t> m_in_buffer;
+    size_t             m_audio_pos = 0;
+    size_t             m_audio_len = 0;
+};
+
+// Return false if need to quit - goes false at eof?
+bool should_keep_running();
+// Call this before needing to quit.
+void install_signal_handler();

--- a/examples/stream-stdin/CMakeLists.txt
+++ b/examples/stream-stdin/CMakeLists.txt
@@ -1,0 +1,7 @@
+# stream-stdin
+set(TARGET stream-stdin)
+add_executable(${TARGET} stream-stdin.cpp)
+
+include(DefaultTargetOptions)
+
+target_link_libraries(${TARGET} PRIVATE common audio-stdin whisper ${CMAKE_THREAD_LIBS_INIT})

--- a/examples/stream-stdin/README.md
+++ b/examples/stream-stdin/README.md
@@ -1,0 +1,23 @@
+# stream-stdin
+
+This is a naive example of performing real-time inference on audio
+from your microphone.  The `stream-stdin` tool samples the audio every
+half a second and runs the transcription continously, just like the
+`stream` example.  Only it doesn't need to be compiled with SDL to do
+it.
+
+```shell
+$ ffmpeg -i capture.wav -acodec pcm_s16le -f s16le -ac 1 -ar 16000 - | ./stream -m ./models/ggml-base.en.bin -t 8 --step 500 --length 5000
+```
+
+It expects raw, mono audio on stdin.  Because it's raw it can't tell
+what the format is to convert it from anything else.
+
+## Why this matters
+
+Because you can stream the audio over the network with `ffmpeg`'s
+`rtp` support.  Or you can just use `netcat`.
+
+## Building
+
+$ `make stream-stdin`

--- a/examples/stream-stdin/stream-stdin.cpp
+++ b/examples/stream-stdin/stream-stdin.cpp
@@ -1,0 +1,443 @@
+// Real-time speech recognition of input of a wav file from stdin.
+//
+// A very quick-n-dirty implementation copied from stream.cpp, but without the sdl requirement.
+//
+#include "audio-stdin.h"
+#include "common.h"
+#include "whisper.h"
+
+#include <unistd.h>
+#include <cassert>
+#include <cstdio>
+#include <string>
+#include <thread>
+#include <vector>
+#include <fstream>
+#include <cstring>
+
+//  500 -> 00:05.000
+// 6000 -> 01:00.000
+std::string to_timestamp(int64_t t) {
+    int64_t sec = t/100;
+    int64_t msec = t - sec*100;
+    int64_t min = sec/60;
+    sec = sec - min*60;
+
+    char buf[32];
+    snprintf(buf, sizeof(buf), "%02d:%02d.%03d", (int) min, (int) sec, (int) msec);
+
+    return std::string(buf);
+}
+
+// command-line parameters
+struct whisper_params {
+    int32_t n_threads  = std::min(4, (int32_t) std::thread::hardware_concurrency());
+    int32_t step_ms    = 3000;
+    int32_t length_ms  = 10000;
+    int32_t keep_ms    = 200;
+    int32_t max_tokens = 32;
+    int32_t audio_ctx  = 0;
+
+    float vad_thold    = 0.6f;
+    float freq_thold   = 100.0f;
+
+    bool speed_up      = false;
+    bool translate     = false;
+    bool no_fallback   = false;
+    bool print_special = false;
+    bool no_context    = true;
+    bool no_timestamps = false;
+    bool tinydiarize   = false;
+    bool save_audio    = false; // save audio to wav file
+    bool use_gpu       = true;
+
+    std::string language  = "en";
+    std::string model     = "models/ggml-base.en.bin";
+    std::string fname_out;
+};
+
+void whisper_print_usage(int argc, char ** argv, const whisper_params & params);
+
+bool whisper_params_parse(int argc, char ** argv, whisper_params & params) {
+    for (int i = 1; i < argc; i++) {
+        std::string arg = argv[i];
+
+        if (arg == "-h" || arg == "--help") {
+            whisper_print_usage(argc, argv, params);
+            exit(0);
+        }
+        else if (arg == "-t"    || arg == "--threads")       { params.n_threads     = std::stoi(argv[++i]); }
+        else if (                  arg == "--step")          { params.step_ms       = std::stoi(argv[++i]); }
+        else if (                  arg == "--length")        { params.length_ms     = std::stoi(argv[++i]); }
+        else if (                  arg == "--keep")          { params.keep_ms       = std::stoi(argv[++i]); }
+        else if (arg == "-mt"   || arg == "--max-tokens")    { params.max_tokens    = std::stoi(argv[++i]); }
+        else if (arg == "-ac"   || arg == "--audio-ctx")     { params.audio_ctx     = std::stoi(argv[++i]); }
+        else if (arg == "-vth"  || arg == "--vad-thold")     { params.vad_thold     = std::stof(argv[++i]); }
+        else if (arg == "-fth"  || arg == "--freq-thold")    { params.freq_thold    = std::stof(argv[++i]); }
+        else if (arg == "-su"   || arg == "--speed-up")      { params.speed_up      = true; }
+        else if (arg == "-tr"   || arg == "--translate")     { params.translate     = true; }
+        else if (arg == "-nf"   || arg == "--no-fallback")   { params.no_fallback   = true; }
+        else if (arg == "-ps"   || arg == "--print-special") { params.print_special = true; }
+        else if (arg == "-kc"   || arg == "--keep-context")  { params.no_context    = false; }
+        else if (arg == "-l"    || arg == "--language")      { params.language      = argv[++i]; }
+        else if (arg == "-m"    || arg == "--model")         { params.model         = argv[++i]; }
+        else if (arg == "-f"    || arg == "--file")          { params.fname_out     = argv[++i]; }
+        else if (arg == "-tdrz" || arg == "--tinydiarize")   { params.tinydiarize   = true; }
+        else if (arg == "-sa"   || arg == "--save-audio")    { params.save_audio    = true; }
+        else if (arg == "-ng"   || arg == "--no-gpu")        { params.use_gpu       = false; }
+
+        else {
+            fprintf(stderr, "error: unknown argument: %s\n", arg.c_str());
+            whisper_print_usage(argc, argv, params);
+            exit(0);
+        }
+    }
+
+    return true;
+}
+
+void whisper_print_usage(int /*argc*/, char ** argv, const whisper_params & params) {
+    fprintf(stderr, "\n");
+    fprintf(stderr, "usage: %s [options]\n", argv[0]);
+    fprintf(stderr, "\n");
+    fprintf(stderr, "options:\n");
+    fprintf(stderr, "  -h,       --help          [default] show this help message and exit\n");
+    fprintf(stderr, "  -t N,     --threads N     [%-7d] number of threads to use during computation\n",    params.n_threads);
+    fprintf(stderr, "            --step N        [%-7d] audio step size in milliseconds\n",                params.step_ms);
+    fprintf(stderr, "            --length N      [%-7d] audio length in milliseconds\n",                   params.length_ms);
+    fprintf(stderr, "            --keep N        [%-7d] audio to keep from previous step in ms\n",         params.keep_ms);
+    fprintf(stderr, "  -mt N,    --max-tokens N  [%-7d] maximum number of tokens per audio chunk\n",       params.max_tokens);
+    fprintf(stderr, "  -ac N,    --audio-ctx N   [%-7d] audio context size (0 - all)\n",                   params.audio_ctx);
+    fprintf(stderr, "  -vth N,   --vad-thold N   [%-7.2f] voice activity detection threshold\n",           params.vad_thold);
+    fprintf(stderr, "  -fth N,   --freq-thold N  [%-7.2f] high-pass frequency cutoff\n",                   params.freq_thold);
+    fprintf(stderr, "  -su,      --speed-up      [%-7s] speed up audio by x2 (reduced accuracy)\n",        params.speed_up ? "true" : "false");
+    fprintf(stderr, "  -tr,      --translate     [%-7s] translate from source language to english\n",      params.translate ? "true" : "false");
+    fprintf(stderr, "  -nf,      --no-fallback   [%-7s] do not use temperature fallback while decoding\n", params.no_fallback ? "true" : "false");
+    fprintf(stderr, "  -ps,      --print-special [%-7s] print special tokens\n",                           params.print_special ? "true" : "false");
+    fprintf(stderr, "  -kc,      --keep-context  [%-7s] keep context between audio chunks\n",              params.no_context ? "false" : "true");
+    fprintf(stderr, "  -l LANG,  --language LANG [%-7s] spoken language\n",                                params.language.c_str());
+    fprintf(stderr, "  -m FNAME, --model FNAME   [%-7s] model path\n",                                     params.model.c_str());
+    fprintf(stderr, "  -f FNAME, --file FNAME    [%-7s] text output file name\n",                          params.fname_out.c_str());
+    fprintf(stderr, "  -tdrz,    --tinydiarize   [%-7s] enable tinydiarize (requires a tdrz model)\n",     params.tinydiarize ? "true" : "false");
+    fprintf(stderr, "  -sa,      --save-audio    [%-7s] save the recorded audio to a file\n",              params.save_audio ? "true" : "false");
+    fprintf(stderr, "  -ng,      --no-gpu        [%-7s] disable GPU inference\n",                          params.use_gpu ? "false" : "true");
+    fprintf(stderr, "\n");
+}
+
+
+
+int main(int argc, char ** argv) {
+    install_signal_handler();
+
+    whisper_params params;
+
+    if (whisper_params_parse(argc, argv, params) == false) {
+        return 1;
+    }
+
+    params.keep_ms   = std::min(params.keep_ms,   params.step_ms);
+    params.length_ms = std::max(params.length_ms, params.step_ms);
+
+    const int n_samples_step = (1e-3*params.step_ms  )*WHISPER_SAMPLE_RATE;
+    const int n_samples_len  = (1e-3*params.length_ms)*WHISPER_SAMPLE_RATE;
+    const int n_samples_keep = (1e-3*params.keep_ms  )*WHISPER_SAMPLE_RATE;
+    const int n_samples_30s  = (1e-3*30000.0         )*WHISPER_SAMPLE_RATE;
+
+    const bool use_vad = n_samples_step <= 0; // sliding window mode uses VAD
+
+    const int n_new_line = !use_vad ? std::max(1, params.length_ms / params.step_ms - 1) : 1; // number of steps to print new line
+
+    params.no_timestamps  = !use_vad;
+    params.no_context    |= use_vad;
+    params.max_tokens     = 0;
+
+    // init audio
+
+    audio_stdin audio(params.length_ms);
+    if (!audio.init(STDIN_FILENO, WHISPER_SAMPLE_RATE)) {
+      fprintf(stderr, "%s: audio.init() failed!\n", __func__);
+      return 1;
+    }
+
+    audio.resume();
+
+    // whisper init
+    if (params.language != "auto" && whisper_lang_id(params.language.c_str()) == -1){
+        fprintf(stderr, "error: unknown language '%s'\n", params.language.c_str());
+        whisper_print_usage(argc, argv, params);
+        exit(0);
+    }
+
+    struct whisper_context_params cparams;
+    cparams.use_gpu = params.use_gpu;
+
+    struct whisper_context * ctx = whisper_init_from_file_with_params(params.model.c_str(), cparams);
+
+    std::vector<float> pcmf32    (n_samples_30s, 0.0f);
+    std::vector<float> pcmf32_old;
+    std::vector<float> pcmf32_new(n_samples_30s, 0.0f);
+
+    std::vector<whisper_token> prompt_tokens;
+
+    // print some info about the processing
+    {
+        fprintf(stderr, "\n");
+        if (!whisper_is_multilingual(ctx)) {
+            if (params.language != "en" || params.translate) {
+                params.language = "en";
+                params.translate = false;
+                fprintf(stderr, "%s: WARNING: model is not multilingual, ignoring language and translation options\n", __func__);
+            }
+        }
+        fprintf(stderr, "%s: processing %d samples (step = %.1f sec / len = %.1f sec / keep = %.1f sec), %d threads, lang = %s, task = %s, timestamps = %d ...\n",
+                __func__,
+                n_samples_step,
+                float(n_samples_step)/WHISPER_SAMPLE_RATE,
+                float(n_samples_len )/WHISPER_SAMPLE_RATE,
+                float(n_samples_keep)/WHISPER_SAMPLE_RATE,
+                params.n_threads,
+                params.language.c_str(),
+                params.translate ? "translate" : "transcribe",
+                params.no_timestamps ? 0 : 1);
+
+        if (!use_vad) {
+            fprintf(stderr, "%s: n_new_line = %d, no_context = %d\n", __func__, n_new_line, params.no_context);
+        } else {
+            fprintf(stderr, "%s: using VAD, will transcribe on speech activity\n", __func__);
+        }
+
+        fprintf(stderr, "\n");
+    }
+
+    int n_iter = 0;
+
+    bool is_running = true;
+
+    std::ofstream fout;
+    if (params.fname_out.length() > 0) {
+        fout.open(params.fname_out);
+        if (!fout.is_open()) {
+            fprintf(stderr, "%s: failed to open output file '%s'!\n", __func__, params.fname_out.c_str());
+            return 1;
+        }
+    }
+
+    wav_writer wavWriter;
+    // save wav file
+    if (params.save_audio) {
+        // Get current date/time for filename
+        time_t now = time(0);
+        char buffer[80];
+        strftime(buffer, sizeof(buffer), "%Y%m%d%H%M%S", localtime(&now));
+        std::string filename = std::string(buffer) + ".wav";
+
+        wavWriter.open(filename, WHISPER_SAMPLE_RATE, 16, 1);
+    }
+    printf("[Start speaking]\n");
+    fflush(stdout);
+
+    auto t_last  = std::chrono::high_resolution_clock::now();
+    const auto t_start = t_last;
+
+    // main audio loop
+    while (is_running) {
+        if (params.save_audio) {
+            wavWriter.write(pcmf32_new.data(), pcmf32_new.size());
+        }
+        // handle Ctrl + C
+        is_running = should_keep_running();
+
+        if (!is_running) {
+            break;
+        }
+
+        // process new audio
+
+        if (!use_vad) {
+            while (true) {
+		if (!audio.get(params.step_ms, pcmf32_new)) {
+		  break; //eof, so just break out of the loop.
+		}
+
+                if ((int) pcmf32_new.size() > 2*n_samples_step) {
+                    fprintf(stderr, "\n\n%s: WARNING: cannot process audio fast enough, dropping audio ...\n\n", __func__);
+                    audio.clear();
+                    continue;
+                }
+
+                if ((int) pcmf32_new.size() >= n_samples_step) {
+                    audio.clear();
+                    break;
+                }
+
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            }
+
+            const int n_samples_new = pcmf32_new.size();
+
+            // take up to params.length_ms audio from previous iteration
+            const int n_samples_take = std::min((int) pcmf32_old.size(), std::max(0, n_samples_keep + n_samples_len - n_samples_new));
+
+            //printf("processing: take = %d, new = %d, old = %d\n", n_samples_take, n_samples_new, (int) pcmf32_old.size());
+
+            pcmf32.resize(n_samples_new + n_samples_take);
+
+            for (int i = 0; i < n_samples_take; i++) {
+                pcmf32[i] = pcmf32_old[pcmf32_old.size() - n_samples_take + i];
+            }
+
+            memcpy(pcmf32.data() + n_samples_take, pcmf32_new.data(), n_samples_new*sizeof(float));
+
+            pcmf32_old = pcmf32;
+        } else {
+	  const auto t_now  = std::chrono::high_resolution_clock::now();
+            const auto t_diff = std::chrono::duration_cast<std::chrono::milliseconds>(t_now - t_last).count();
+
+            if (t_diff < 2000) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+                continue;
+            }
+
+	    // TODO handle false returned here
+            audio.get(2000, pcmf32_new);
+
+            if (::vad_simple(pcmf32_new, WHISPER_SAMPLE_RATE, 1000, params.vad_thold, params.freq_thold, false)) {
+	      // TODO handle false returned here
+                audio.get(params.length_ms, pcmf32);
+            } else {
+                std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+                continue;
+            }
+
+            t_last = t_now;
+        }
+
+	if (!is_running) {
+	  return 0;
+	}
+
+        // run the inference
+        {
+	    whisper_full_params wparams = whisper_full_default_params(WHISPER_SAMPLING_GREEDY);
+
+            wparams.print_progress   = false;
+            wparams.print_special    = params.print_special;
+            wparams.print_realtime   = false;
+            wparams.print_timestamps = !params.no_timestamps;
+            wparams.translate        = params.translate;
+            wparams.single_segment   = !use_vad;
+            wparams.max_tokens       = params.max_tokens;
+            wparams.language         = params.language.c_str();
+            wparams.n_threads        = params.n_threads;
+
+            wparams.audio_ctx        = params.audio_ctx;
+            wparams.speed_up         = params.speed_up;
+
+            wparams.tdrz_enable      = params.tinydiarize; // [TDRZ]
+
+            // disable temperature fallback
+            //wparams.temperature_inc  = -1.0f;
+            wparams.temperature_inc  = params.no_fallback ? 0.0f : wparams.temperature_inc;
+
+            wparams.prompt_tokens    = params.no_context ? nullptr : prompt_tokens.data();
+            wparams.prompt_n_tokens  = params.no_context ? 0       : prompt_tokens.size();
+
+            if (whisper_full(ctx, wparams, pcmf32.data(), pcmf32.size()) != 0) {
+                fprintf(stderr, "%s: failed to process audio\n", argv[0]);
+                return 6;
+            }
+
+            // print result;
+            {
+                if (!use_vad) {
+                    printf("\33[2K\r");
+
+                    // print long empty line to clear the previous line
+                    printf("%s", std::string(100, ' ').c_str());
+
+                    printf("\33[2K\r");
+                } else {
+                    const int64_t t1 = (t_last - t_start).count()/1000000;
+                    const int64_t t0 = std::max(0.0, t1 - pcmf32.size()*1000.0/WHISPER_SAMPLE_RATE);
+
+                    printf("\n");
+                    printf("### Transcription %d START | t0 = %d ms | t1 = %d ms\n", n_iter, (int) t0, (int) t1);
+                    printf("\n");
+                }
+
+                const int n_segments = whisper_full_n_segments(ctx);
+                for (int i = 0; i < n_segments; ++i) {
+                    const char * text = whisper_full_get_segment_text(ctx, i);
+
+                    if (params.no_timestamps) {
+                        printf("%s", text);
+                        fflush(stdout);
+
+                        if (params.fname_out.length() > 0) {
+                            fout << text;
+                        }
+                    } else {
+                        const int64_t t0 = whisper_full_get_segment_t0(ctx, i);
+                        const int64_t t1 = whisper_full_get_segment_t1(ctx, i);
+
+                        std::string output = "[" + to_timestamp(t0) + " --> " + to_timestamp(t1) + "]  " + text;
+
+                        if (whisper_full_get_segment_speaker_turn_next(ctx, i)) {
+                            output += " [SPEAKER_TURN]";
+                        }
+
+                        output += "\n";
+
+                        printf("%s", output.c_str());
+                        fflush(stdout);
+
+                        if (params.fname_out.length() > 0) {
+                            fout << output;
+                        }
+                    }
+                }
+
+                if (params.fname_out.length() > 0) {
+                    fout << std::endl;
+                }
+
+                if (use_vad) {
+                    printf("\n");
+                    printf("### Transcription %d END\n", n_iter);
+                }
+            }
+
+            ++n_iter;
+
+            if (!use_vad && (n_iter % n_new_line) == 0) {
+                printf("\n");
+
+                // keep part of the audio for next iteration to try to mitigate word boundary issues
+                pcmf32_old = std::vector<float>(pcmf32.end() - n_samples_keep, pcmf32.end());
+
+                // Add tokens of the last full length segment as the prompt
+                if (!params.no_context) {
+                    prompt_tokens.clear();
+
+                    const int n_segments = whisper_full_n_segments(ctx);
+                    for (int i = 0; i < n_segments; ++i) {
+                        const int token_count = whisper_full_n_tokens(ctx, i);
+                        for (int j = 0; j < token_count; ++j) {
+                            prompt_tokens.push_back(whisper_full_get_token_id(ctx, i, j));
+                        }
+                    }
+                }
+            }
+            fflush(stdout);
+        }
+    }
+
+    audio.pause();
+
+    whisper_print_timings(ctx);
+    whisper_free(ctx);
+
+    return 0;
+}


### PR DESCRIPTION
This is a feature I've been wanting for a while, but haven't seen go past anywhere else.  It allows streaming raw audio from `stdin`. It's different from the `stdin` support in `main` because it doesn't need to slurp the entire stream before processing it. That means you can (for instance) use `ffmpeg` to pipe audio from the network straight into `stream-stdin` without knowing how long the stream is going to be.

There are naturally a couple of trade-offs to this. Because it's raw audio, there's no metadata to tell it what the audio format is.  Right now it *must* be 16kHz mono `pcm_s16le`.  The trade-off is that it doesn't need to be compiled against SDL, and it doesn't need to know anything about the `wav` file format so `dr_wav.h` isn't needed either.

Given an input wav file, you might want to try it with a command like:
```
$ ffmpeg -i capture.wav -acodec pcm_s16le -f s16le -ac 1 -ar 16000 - | ./stream-stdin -m ./models/ggml-base.en.bin
```

Implementation-wise this is very rough: I've basically copy and pasted `examples/stream.cpp`, and written something that's got a similar enough interface to `audio_async` to not need too many changes.  I'm very much aware that it's not exactly in a state where it would want to be merged, so what I would like is some indication either way as to whether it's worth my doing the refactoring work to share the streaming consumption code and get rid of the copy/paste duplication.