### PR TITLE
server: Allow CORS request with authorization headers

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -541,7 +541,7 @@ int main(int argc, char ** argv) {
     Server svr;
     svr.set_default_headers({{"Server", "whisper.cpp"},
                              {"Access-Control-Allow-Origin", "*"},
-                             {"Access-Control-Allow-Headers", "content-type"}});
+                             {"Access-Control-Allow-Headers", "content-type, authorization"}});
 
     std::string const default_content = R"(
     <html>
@@ -621,6 +621,9 @@ int main(int argc, char ** argv) {
     svr.Get(sparams.request_path + "/", [&default_content](const Request &, Response &res){
         res.set_content(default_content, "text/html");
         return false;
+    });
+
+    svr.Options(sparams.request_path + "/inference", [&](const Request &req, Response &res){
     });
 
     svr.Post(sparams.request_path + "/inference", [&](const Request &req, Response &res){


### PR DESCRIPTION
Whisper plugin in [Obsidian](https://obsidian.md/) requires an API key which is then sent as an authorization header.
However, the presence of an authorization header requires a CORS Preflight, so both the OPTIONS method and
the Access-Control-Allow-Headers: authorization must be handled.