### PR TITLE
main : check if input files exist before proceeding

### DIFF
--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -10,6 +10,8 @@
 #include <vector>
 #include <cstring>
 
+#include <sys/stat.h>
+
 #if defined(_MSC_VER)
 #pragma warning(disable: 4244 4267) // possible loss of data
 #endif
@@ -867,6 +869,20 @@ int main(int argc, char ** argv) {
     if (whisper_params_parse(argc, argv, params) == false) {
         whisper_print_usage(argc, argv, params);
         return 1;
+    }
+
+    // remove non-existent files
+    for (auto it = params.fname_inp.begin(); it != params.fname_inp.end();) {
+        struct stat st;
+        const auto fname_inp = it->c_str();
+
+        if (stat(fname_inp, &st) == -1) {
+            fprintf(stderr, "error: input file not found '%s'\n", fname_inp);
+            it = params.fname_inp.erase(it);
+            continue;
+        }
+
+        it++;
     }
 
     if (params.fname_inp.empty()) {


### PR DESCRIPTION
Until the most recent commit (3d42463), the main.cpp sample file does not check whether the input files exist or not. Consequently, the model is loaded first before reporting whether there was a failure or not when processing a file. In environments with HDD, this can take about 50 seconds or more, depending on the loaded model.

This PR addresses this by checking in advance whether the input files exist or not.