### PR TITLE
Linking issue fix via Makefile when CUBLAS enabled in the WSL #1876

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,7 +224,7 @@ ifdef WHISPER_CUBLAS
 
 	CFLAGS      += -DGGML_USE_CUBLAS -I/usr/local/cuda/include -I/opt/cuda/include -I$(CUDA_PATH)/targets/$(UNAME_M)-linux/include
 	CXXFLAGS    += -DGGML_USE_CUBLAS -I/usr/local/cuda/include -I/opt/cuda/include -I$(CUDA_PATH)/targets/$(UNAME_M)-linux/include
-	LDFLAGS     += -lcuda -lcublas -lculibos -lcudart -lcublasLt -lpthread -ldl -lrt -L/usr/local/cuda/lib64 -L/opt/cuda/lib64 -L$(CUDA_PATH)/targets/$(UNAME_M)-linux/lib
+	LDFLAGS     += -lcuda -lcublas -lculibos -lcudart -lcublasLt -lpthread -ldl -lrt -L/usr/local/cuda/lib64 -L/opt/cuda/lib64 -L$(CUDA_PATH)/targets/$(UNAME_M)-linux/lib -L/usr/lib/wsl/lib
 	WHISPER_OBJ += ggml-cuda.o
 	NVCC        = nvcc
 	NVCCFLAGS   = --forward-unknown-to-host-compiler -arch=$(CUDA_ARCH_FLAG)


### PR DESCRIPTION
When I followed the instruction to compile the project with "WHISPER_CUBLAS=1 make -j" in WSL environment, I couldn't get the project compiled successfully. After reading through the Makefile, I added "-L/usr/lib/wsl/lib" to Makefile if WHISPER_CUBLAS defined.
I think it is a common issue for the users who are using WSL to complie the project with CUBLAS enabled.