### PR TITLE
main : fix file existence check in main.cpp

### DIFF
--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -10,8 +10,6 @@
 #include <vector>
 #include <cstring>
 
-#include <sys/stat.h>
-
 #if defined(_MSC_VER)
 #pragma warning(disable: 4244 4267) // possible loss of data
 #endif
@@ -845,10 +843,9 @@ int main(int argc, char ** argv) {
 
     // remove non-existent files
     for (auto it = params.fname_inp.begin(); it != params.fname_inp.end();) {
-        struct stat st;
         const auto fname_inp = it->c_str();
 
-        if (stat(fname_inp, &st) == -1) {
+        if (*it != "-" && !is_file_exist(fname_inp)) {
             fprintf(stderr, "error: input file not found '%s'\n", fname_inp);
             it = params.fname_inp.erase(it);
             continue;


### PR DESCRIPTION
In commit dda4b0e of PR #1872, I've introduced a check for the existence of files before loading the model. However, I haven't considered the case where whisper.cpp might read from stdin as well, and in such cases, the checks should ignore the "-" argument as it does not represent a regular file.

Additionally, this commit removes the usage of 'stat()' in favor of the recently introduced function 'is_file_exist()' in common.cpp from PR #1871.

Apologies for the bug introduced in the previous PR and any inconvenience it may have caused.