### PR TITLE
Fix typo in source file whisper.cpp

### DIFF
--- a/whisper.cpp
+++ b/whisper.cpp
@@ -3852,7 +3852,7 @@ const char * whisper_print_system_info(void) {
     s += "VSX = "       + std::to_string(ggml_cpu_has_vsx())       + " | ";
     s += "CUDA = "      + std::to_string(ggml_cpu_has_cublas())    + " | ";
     s += "COREML = "    + std::to_string(whisper_has_coreml())     + " | ";
-    s += "OPENVINO = "  + std::to_string(whisper_has_openvino())   + " | ";
+    s += "OPENVINO = "  + std::to_string(whisper_has_openvino())          ;
 
     return s.c_str();
 }


### PR DESCRIPTION
I'm not sure is there a typo in source file whisper.cpp ? If not,this PR should be closed accordingly.Thanks.

https://github.com/ggerganov/whisper.cpp/blob/master/whisper.cpp#L3855

before modification:

![1903270338](https://github.com/ggerganov/whisper.cpp/assets/6889919/9d186080-650a-474a-a525-6b4a7562c8fb)

after modification:

![1068415119](https://github.com/ggerganov/whisper.cpp/assets/6889919/35159db3-54b7-45ab-af49-43f4ce8d4201)
