### PR TITLE
bindings/go : add linker flags to make metal work

### DIFF
--- a/bindings/go/whisper.go
+++ b/bindings/go/whisper.go
@@ -10,7 +10,7 @@ import (
 
 /*
 #cgo LDFLAGS: -lwhisper -lm -lstdc++
-#cgo darwin LDFLAGS: -framework Accelerate
+#cgo darwin LDFLAGS: -framework Accelerate -framework Metal -framework Foundation -framework CoreGraphics
 #include <whisper.h>
 #include <stdlib.h>
 


### PR DESCRIPTION
The first two are required to build.
The last one is to make it actually detect the GPU.

Fixes #1899, at least for me
