### PR TITLE
bench: fix typo in examples/bench/bench.cpp

### DIFF
--- a/examples/bench/bench.cpp
+++ b/examples/bench/bench.cpp
@@ -48,10 +48,10 @@ void whisper_print_usage(int /*argc*/, char ** argv, const whisper_params & para
     fprintf(stderr, "  -t N,     --threads N   [%-7d] number of threads to use during computation\n", params.n_threads);
     fprintf(stderr, "  -m FNAME, --model FNAME [%-7s] model path\n",                                  params.model.c_str());
     fprintf(stderr, "  -w N,     --what N      [%-7d] what to benchmark:\n",                          params.what);
-    fprintf(stderr, "  -ng,      --no-gpu      [%-7s] disable GPU\n",                                 params.use_gpu ? "false" : "true");
     fprintf(stderr, "                           %-7s  0 - whisper\n",                                 "");
     fprintf(stderr, "                           %-7s  1 - memcpy\n",                                  "");
     fprintf(stderr, "                           %-7s  2 - ggml_mul_mat\n",                            "");
+    fprintf(stderr, "  -ng,      --no-gpu      [%-7s] disable GPU\n",                                 params.use_gpu ? "false" : "true");
     fprintf(stderr, "\n");
 }
 


### PR DESCRIPTION
I'm not sure is there a typo in examples/bench/bench.cpp

before modification:
![Screenshot from 2024-03-09 09-01-36](https://github.com/ggerganov/whisper.cpp/assets/6889919/4e51acd6-67e0-4e3a-8989-9826f824f2f0)


after modification:
![Screenshot from 2024-03-09 09-01-06](https://github.com/ggerganov/whisper.cpp/assets/6889919/7913f841-c621-4dd7-ac2d-57eb2564a1b9)

