### PR TITLE
libcuda.so.1 in PATH in Docker Container

### DIFF
--- a/.devops/main-cuda.Dockerfile
+++ b/.devops/main-cuda.Dockerfile
@@ -28,6 +28,8 @@ COPY .. .
 RUN make
 
 FROM ${BASE_CUDA_RUN_CONTAINER} AS runtime
+ENV CUDA_MAIN_VERSION=12.3
+ENV LD_LIBRARY_PATH /usr/local/cuda-${CUDA_MAIN_VERSION}/compat:$LD_LIBRARY_PATH
 WORKDIR /app
 
 RUN apt-get update && \


### PR DESCRIPTION
This fixes issue #1879. 

Turns out the problem was solved by just copying the environment variables so they are present in both stages.

(took me an embarrassingly long amount of time to figure that out)
