### PR TITLE
Improve support for distil-large-v3

### DIFF
--- a/whisper.cpp
+++ b/whisper.cpp
@@ -5349,11 +5349,11 @@ int whisper_full_with_state(
         }
     }
 
-    // distilled models require the "no_timestamps" token
+    // first release distilled models require the "no_timestamps" token
     {
-        const bool is_distil = ctx->model.hparams.n_text_layer == 2;
+        const bool is_distil = ctx->model.hparams.n_text_layer == 2 && ctx->model.hparams.n_vocab != 51866;
         if (is_distil && !params.no_timestamps) {
-            WHISPER_LOG_WARN("%s: using distilled model - forcing no_timestamps\n", __func__);
+            WHISPER_LOG_WARN("%s: using first release distilled models - forcing no_timestamps\n", __func__);
             params.no_timestamps = true;
         }
     }


### PR DESCRIPTION
While the original Distil-Whisper models were trained on timestamps, they degraded significantly after 15-seconds of audio (due to the shorter distribution of audio we trained on). The implementation in Whisper cpp thus deactivated timestamps entirely for these checkpoints.

The latest Distil-Whisper release, distil-large-v3, addresses this problem, giving a model that accurately predicts timestamps in full 30-second windows, much like the original Whisper models.

To improve support for this new checkpoint, we allow timestamp prediction for the new checkpoint in this PR.