### PR TITLE
Swift: Updating Swift package for linux configuration

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2,6 +2,46 @@
 
 import PackageDescription
 
+var sources = [
+  "ggml.c",
+  "whisper.cpp",
+  "ggml-alloc.c",
+  "ggml-backend.c",
+  "ggml-quants.c",
+]
+var resources: [Resource] = []
+
+var cSettings: [CSetting] = [
+  .unsafeFlags(["-Wno-shorten-64-to-32", "-O3", "-DNDEBUG"]),
+  .unsafeFlags(["-fno-objc-arc"]),
+]
+
+var linkerSettings: [LinkerSetting] = [.linkedFramework("Accelerate")]
+
+#if os(Linux)
+  // .define("_GNU_SOURCE"),
+  cSettings.append(.define("WHISPER_NO_ACCELERATE"))
+  cSettings.append(.define("_GNU_SOURCE"))
+
+#else
+  resources.append(
+    .process("ggml-metal.metal")
+  )
+  // Adding metal source if the target is an Apple platform.
+  sources.append("ggml-metal.m")
+
+  cSettings.append([
+    .define("GGML_USE_ACCELERATE"),
+    .define("GGML_USE_METAL"),
+    // NOTE: NEW_LAPACK will required iOS version 16.4+
+    // We should consider add this in the future when we drop support for iOS 14
+    // (ref: ref: https://developer.apple.com/documentation/accelerate/1513264-cblas_sgemm?language=objc)
+    // .define("ACCELERATE_NEW_LAPACK"),
+    // .define("ACCELERATE_LAPACK_ILP64")
+  ])
+
+#endif
+
 let package = Package(
     name: "whisper",
     platforms: [
@@ -31,30 +71,11 @@ let package = Package(
                "ggml-cuda.h",
                "Makefile"
             ],
-            sources: [
-                "ggml.c",
-                "whisper.cpp",
-                "ggml-alloc.c",
-                "ggml-backend.c",
-                "ggml-quants.c",
-                "ggml-metal.m"
-            ],
-            resources: [.process("ggml-metal.metal")],
+            sources: sources,
+            resources: resources,
             publicHeadersPath: "spm-headers",
-            cSettings: [
-                .unsafeFlags(["-Wno-shorten-64-to-32", "-O3", "-DNDEBUG"]),
-                .define("GGML_USE_ACCELERATE"),
-                .unsafeFlags(["-fno-objc-arc"]),
-                .define("GGML_USE_METAL")
-                // NOTE: NEW_LAPACK will required iOS version 16.4+
-                // We should consider add this in the future when we drop support for iOS 14
-                // (ref: ref: https://developer.apple.com/documentation/accelerate/1513264-cblas_sgemm?language=objc)
-                // .define("ACCELERATE_NEW_LAPACK"),
-                // .define("ACCELERATE_LAPACK_ILP64")
-            ],
-            linkerSettings: [
-                .linkedFramework("Accelerate")
-            ]
+            cSettings: cSettings,
+            linkerSettings: linkerSettings
         )
     ],
     cxxLanguageStandard: .cxx11


### PR DESCRIPTION
- We need to ignore Apple platforms frameworks (Accelerate and Metal) when building the project on Linux
- We need to define `_GNU_SOURCE` for certains function declaration (in `sched.h`)