### PR TITLE
Added a bool fold_lowercase to whisper_context_params

### DIFF
--- a/whisper.cpp
+++ b/whisper.cpp
@@ -1383,6 +1383,11 @@ static bool whisper_model_load(struct whisper_model_loader * loader, whisper_con
                 word = "";
             }
 
+            // If requested, output all text as lowercase.
+            if (wctx.params.fold_lowercase)
+                std::transform(word.begin(), word.end(), word.begin(),
+                    [](unsigned char c) { return std::tolower(c); });
+
             vocab.token_to_id[word] = i;
             vocab.id_to_token[i] = word;
 
@@ -3374,7 +3379,7 @@ struct whisper_context_params whisper_context_default_params() {
     struct whisper_context_params result = {
         /*.use_gpu              =*/ true,
         /*.gpu_device           =*/ 0,
-
+        /*.fold_lowercase       =*/ false,
         /*.dtw_token_timestamps =*/ false,
         /*.dtw_aheads_preset    =*/ WHISPER_AHEADS_NONE,
         /*.dtw_n_top            =*/ -1,

--- a/whisper.h
+++ b/whisper.h
@@ -115,6 +115,9 @@ extern "C" {
         bool  use_gpu;
         int   gpu_device;  // CUDA device
 
+        // Fold language tokens to lowercase
+        bool fold_lowercase;
+
         // [EXPERIMENTAL] Token-level timestamps with DTW
         bool dtw_token_timestamps;
         enum whisper_alignment_heads_preset dtw_aheads_preset;


### PR DESCRIPTION
If true, it folds language-model tokens to lowercase. By default, it's false.
This is intended to make grammar matching more predictable, e.g. no need to account for case in the grammar.