### PR TITLE
Fix DTW memory access

### DIFF
--- a/whisper.cpp
+++ b/whisper.cpp
@@ -1148,26 +1148,31 @@ static bool aheads_masks_init(
     }
 
     // Set data on mask tensors
-    // Since this must be backend agnostic, we get tensor data with
-    // ggml_backend_tensor_get, copy our desired values and send it back
-    // to backend with ggml_backend_tensor_set
+    // Since this must be backend agnostic, we write our desired values on mask_data,
+    // and send it to backend with ggml_backend_tensor_set.
+    // Each mask in N_HEADS*N_ALIGNMENT_HEADS, one per text layer containing alignment
+    // heads. Each row of the mask "marks" one alignment head. E.g. if some text layer
+    // has a total of 10 heads and of those, heads 0,5,6 are alignment heads, the mask
+    // should read:
+    // 1 0 0 0 0 0 0 0 0 0
+    // 0 0 0 0 0 1 0 0 0 0
+    // 0 0 0 0 0 0 1 0 0 0
     std::vector<float> mask_data;
     for (int64_t il = 0; il < n_text_layer; ++il) {
         if (aheads_masks.m[il] != nullptr) {
             auto aheads = get_alignment_heads_by_layer(cparams, il, n_text_layer, n_head);
 
-            size_t data_size = aheads_masks.m[il]->ne[0] * aheads_masks.m[il]->ne[1] * sizeof(float);
+            size_t data_size = aheads_masks.m[il]->ne[0] * aheads_masks.m[il]->ne[1];
+            size_t data_size_bytes = data_size * sizeof(float);
             mask_data.resize(data_size);
-            ggml_backend_tensor_get(aheads_masks.m[il], mask_data.data(), 0, data_size);
-            memset(mask_data.data(), 0, data_size);
 
+            std::fill(mask_data.begin(), mask_data.end(), 0);
             for (size_t ih = 0; ih < aheads.size(); ++ih) {
-                size_t pos = (aheads[ih] + (ih * aheads_masks.m[il]->ne[0])) * sizeof(float);
-                float v = 1.0f;
-                memcpy(mask_data.data() + pos, &v, sizeof(float));
+                size_t pos = (aheads[ih] + (ih * aheads_masks.m[il]->ne[0]));
+                mask_data[pos] = 1.0f;
             }
 
-            ggml_backend_tensor_set(aheads_masks.m[il], mask_data.data(), 0, data_size);
+            ggml_backend_tensor_set(aheads_masks.m[il], mask_data.data(), 0, data_size_bytes);
         }
     }
 

--- a/whisper.cpp
+++ b/whisper.cpp
@@ -1162,7 +1162,7 @@ static bool aheads_masks_init(
             memset(mask_data.data(), 0, data_size);
 
             for (size_t ih = 0; ih < aheads.size(); ++ih) {
-                size_t pos = (aheads[ih] + (ih * aheads_masks.m[il]->ne[0] * aheads[ih]));
+                size_t pos = (aheads[ih] + (ih * aheads_masks.m[il]->ne[0])) * sizeof(float);
                 float v = 1.0f;
                 memcpy(mask_data.data() + pos, &v, sizeof(float));
             }


### PR DESCRIPTION
The current release with dtw support can result in memory corruption due to out of bounds reading/writing.  This is an attempt to correct this.

To verify the problem, enable address sanitization `-fsanitize=address` in both compilers and linkers and run the `main` example with dtw enabled.  I tested using the small model. `./main -m ggml-small.bin -dtw small samples/jfk.wav`

With no code changes or compiler changes (compiled using `make` on an m1 mbp), the command runs, but ends in a segfault.

With the address sanitizer enabled, execution stops before transcription
```
==74546==ERROR: AddressSanitizer: heap-use-after-free on address 0x000107303bd4 at pc 0x0001030a32a4 bp 0x00016cf944f0 sp 0x00016cf944e8
WRITE of size 4 at 0x000107303bd4 thread T0
    #0 0x1030a32a0 in whisper_init_state+0x2158 (main:arm64+0x10023b2a0)
    #1 0x1030bce34 in whisper_init_from_file_with_params+0xe4 (main:arm64+0x100254e34)
    #2 0x102e7e3c4 in main+0xe30 (main:arm64+0x1000163c4)
    #3 0x1861320dc  (<unknown module>)

0x000107303bd4 is located 20 bytes inside of 340-byte region [0x000107303bc0,0x000107303d14)
```

With this change and the address sanitizer enabled, the transcription completes, and there are no errors

@denersc Can you confirm that this fix matches your intent here?
