### PR TITLE
Support CUDA versions < 11.1

### DIFF
--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -2797,6 +2797,7 @@ GGML_CALL bool ggml_backend_cuda_register_host_buffer(void * buffer, size_t size
         return false;
     }
 
+#if CUDART_VERSION >= 11100
     cudaError_t err = cudaHostRegister(buffer, size, cudaHostRegisterPortable | cudaHostRegisterReadOnly);
     if (err != cudaSuccess) {
         // clear the error
@@ -2807,6 +2808,9 @@ GGML_CALL bool ggml_backend_cuda_register_host_buffer(void * buffer, size_t size
         return false;
     }
     return true;
+#else
+    return false;
+#endif
 }
 
 GGML_CALL void ggml_backend_cuda_unregister_host_buffer(void * buffer) {


### PR DESCRIPTION
`cudaHostRegisterReadOnly` parameter that is used in ggml-cuda.cu, was only introduced in CUDA 11.1: https://github.com/ggerganov/whisper.cpp/issues/2007

This fix simply bypasses the part of the code that is incompatible with CUDA < 11.1. Not sure if there is a way to replicate the original functionality more precisely without relying on `cudaHostRegisterReadOnly`.