### PR TITLE
fix missing reference to "model" variable in actual shell command run in whisper.nvim

### DIFF
--- a/examples/whisper.nvim/whisper.nvim
+++ b/examples/whisper.nvim/whisper.nvim
@@ -45,6 +45,6 @@ if [ ! -f ./models/ggml-${model}.bin ] ; then
 fi
 
 # fine-tune the parameters according to your machine specs
-./stream -t 8 -m models/ggml-base.en.bin --step 350 --length 10000 -f /tmp/whisper.nvim 2> /dev/null
+./stream -t 8 -m models/ggml-${model}.bin --step 350 --length 10000 -f /tmp/whisper.nvim 2> /dev/null
 
 exit 0


### PR DESCRIPTION
There is a small bug in the whisper.nvim script where you use the `model` variable to check the existence of the model, but you don't use it in the actual `stream` command invocation at the bottom of the script. I fixed it.

Thanks for all the hard work. This is an awesome project.