### PR TITLE
Added up-to-date repository for Python bindings to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -808,6 +808,7 @@ For more details, see the conversion script [models/convert-pt-to-ggml.py](model
   - [NickDarvey/whisper](https://github.com/NickDarvey/whisper)
 - [x] Python: | [#9](https://github.com/ggerganov/whisper.cpp/issues/9)
   - [stlukey/whispercpp.py](https://github.com/stlukey/whispercpp.py) (Cython)
+  - [AIWintermuteAI/whispercpp](https://github.com/AIWintermuteAI/whispercpp) (Updated fork of aarnphm/whispercpp)
   - [aarnphm/whispercpp](https://github.com/aarnphm/whispercpp) (Pybind11)
 - [x] R: [bnosac/audio.whisper](https://github.com/bnosac/audio.whisper)
 - [x] Unity: [macoron/whisper.unity](https://github.com/Macoron/whisper.unity)


### PR DESCRIPTION
aarnphm/whispercpp seems to be abandoned - the package does not build and there are multiple issues without an answer:
<img width="1577" alt="image" src="https://github.com/ggerganov/whisper.cpp/assets/32562299/b1214d6b-623c-432b-9aad-62f8c4a04182">
I added a link to my fork of the project, which I maintain with reasonable efforts - I set up a CI with integration/unit tests and weekly submodule updates.
It will be beneficial to point users looking for Python bindings to the working fork and save them some time.