### PR TITLE
fix(compile): fix josn_cpp, INTERFACE library requires no source arguments

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -58,8 +58,8 @@ if (WHISPER_SDL2)
 endif()
 
 # add json lib
-add_library(json_cpp INTERFACE json.hpp)
-set_target_properties(json_cpp PROPERTIES FOLDER "libs")
+add_library(json_cpp INTERFACE)
+target_include_directories(json_cpp INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
 
 # examples
 


### PR DESCRIPTION

build command:

```sh
git clone https://github.com/ggerganov/whisper.cpp.git
cd  whisper.cpp
cmake -B build.2024.04.17 -DCMAKE_BUILD_TYPE=Release -DWHISPER_PERF=ON \
  -DCMAKE_C_COMPILER=/bucket/output/jfs-hdfs/user/xingchen.song/tools/miniconda3/bin/gcc \
  -DCMAKE_CXX_COMPILER=/bucket/output/jfs-hdfs/user/xingchen.song/tools/miniconda3/bin/g++
```

error message:

![image](https://github.com/ggerganov/whisper.cpp/assets/13466943/b36e51c9-4cbc-404f-97b4-1f9842ac1f9b)


This PR try to fix the above error
