### PR TITLE
main : pass nullptr when regex is empty

### DIFF
--- a/examples/main/main.cpp
+++ b/examples/main/main.cpp
@@ -1068,7 +1068,7 @@ int main(int argc, char ** argv) {
 
             wparams.tdrz_enable      = params.tinydiarize; // [TDRZ]
 
-            wparams.suppress_regex   = params.suppress_regex.c_str();
+            wparams.suppress_regex   = params.suppress_regex.empty() ? nullptr : params.suppress_regex.c_str();
 
             wparams.initial_prompt   = params.prompt.c_str();
 


### PR DESCRIPTION
fix #2066 

Pass `nullptr` when the regex is empty. This avoids unnecessary regex matches during decoding, which would cause CPU overhead