### PR TITLE
ggml:add new member in GGML's internal data structure

### DIFF
--- a/ggml.c
+++ b/ggml.c
@@ -2195,6 +2195,7 @@ struct ggml_context {
     bool   mem_buffer_owned;
     bool   no_alloc;
     bool   no_alloc_save; // this is used to save the no_alloc state when using scratch buffers
+    bool   use_hwaccel;
 
     int    n_objects;
 
@@ -2754,6 +2755,7 @@ struct ggml_context * ggml_init(struct ggml_init_params params) {
         /*.mem_buffer_owned   =*/ params.mem_buffer ? false : true,
         /*.no_alloc           =*/ params.no_alloc,
         /*.no_alloc_save      =*/ params.no_alloc,
+        /*.use_hwaccel        =*/ params.use_hwaccel,
         /*.n_objects          =*/ 0,
         /*.objects_begin      =*/ NULL,
         /*.objects_end        =*/ NULL,

--- a/ggml.c
+++ b/ggml.c
@@ -2987,8 +2987,12 @@ static struct ggml_tensor * ggml_new_tensor_impl(
         /*.data         =*/ obj_alloc_size > 0 ? (void *)(result + 1) : data,
         /*.name         =*/ { 0 },
         /*.extra        =*/ NULL,
+        /*.rank         =*/ n_dims,
         /*.padding      =*/ { 0 },
     };
+
+    if (ctx->use_hwaccel)
+        result->backend = GGML_BACKEND_TYPE_GPU;
 
     // TODO: this should not be needed as long as we don't rely on aligned SIMD loads
     //ggml_assert_aligned(result->data);

--- a/ggml.h
+++ b/ggml.h
@@ -591,7 +591,9 @@ extern "C" {
 
         void * extra; // extra things e.g. for ggml-cuda.cu
 
-        char padding[8];
+        int32_t rank;
+
+        char padding[20];
     };
 
     static const size_t GGML_TENSOR_SIZE = sizeof(struct ggml_tensor);

--- a/ggml.h
+++ b/ggml.h
@@ -657,6 +657,7 @@ extern "C" {
         size_t mem_size;   // bytes
         void * mem_buffer; // if NULL, memory will be allocated internally
         bool   no_alloc;   // don't allocate memory for the tensor data
+        bool   use_hwaccel;
     };
 
 

--- a/whisper.cpp
+++ b/whisper.cpp
@@ -4066,6 +4066,14 @@ static int whisper_has_openvino(void) {
 #endif
 }
 
+static int whisper_has_qnn(void) {
+#ifdef GGML_USE_QNN
+    return 1;
+#else
+    return 0;
+#endif
+}
+
 const char * whisper_print_system_info(void) {
     static std::string s;
 
@@ -4086,7 +4094,9 @@ const char * whisper_print_system_info(void) {
     s += "VSX = "       + std::to_string(ggml_cpu_has_vsx())       + " | ";
     s += "CUDA = "      + std::to_string(ggml_cpu_has_cuda())      + " | ";
     s += "COREML = "    + std::to_string(whisper_has_coreml())     + " | ";
-    s += "OPENVINO = "  + std::to_string(whisper_has_openvino())          ;
+    s += "OPENVINO = "  + std::to_string(whisper_has_openvino())   + " | ";
+    s += "QNN = "       + std::to_string(whisper_has_qnn())               ;
+
 
     return s.c_str();
 }
@@ -6518,6 +6528,9 @@ WHISPER_API const char * whisper_bench_ggml_mul_mat_str(int n_threads) {
                 /*.no_alloc   =*/ false,
             };
 
+#ifdef GGML_USE_QNN
+            gparams.use_hwaccel   = true;
+#endif
             struct ggml_context * ctx0 = ggml_init(gparams);
 
             struct ggml_tensor * a = ggml_new_tensor_2d(ctx0, wtype,         N, N);

--- a/whisper.cpp
+++ b/whisper.cpp
@@ -4066,14 +4066,6 @@ static int whisper_has_openvino(void) {
 #endif
 }
 
-static int whisper_has_qnn(void) {
-#ifdef GGML_USE_QNN
-    return 1;
-#else
-    return 0;
-#endif
-}
-
 const char * whisper_print_system_info(void) {
     static std::string s;
 
@@ -4094,9 +4086,7 @@ const char * whisper_print_system_info(void) {
     s += "VSX = "       + std::to_string(ggml_cpu_has_vsx())       + " | ";
     s += "CUDA = "      + std::to_string(ggml_cpu_has_cuda())      + " | ";
     s += "COREML = "    + std::to_string(whisper_has_coreml())     + " | ";
-    s += "OPENVINO = "  + std::to_string(whisper_has_openvino())   + " | ";
-    s += "QNN = "       + std::to_string(whisper_has_qnn())               ;
-
+    s += "OPENVINO = "  + std::to_string(whisper_has_openvino())          ;
 
     return s.c_str();
 }


### PR DESCRIPTION
<h4>Purpose</h4>

this PR is for multi purpose:

(1) borrow some advantages from Qualcomm's QNN(Qualcomm Neural Network, aka Qualcomm AI Engine Direct) SDK, it's a highly well-designed and concise SDK(the API in QNN SDK is really match with GGML's existing design(including existing backend design)).



this PR borrow the "rank" member from QNN SDK and re-use the existing code as much as possible and not brings side-effect or complexity to existing code

(2) borrow some advantages from PyTorch(the user could specify whether a GGML OP(such as mulmat) is accelerated by a specify backend) 

this PR borrow the "use_hwaccel" member from PyTorch and re-use the existing code as much as possible and not brings side-effect or complexity to existing code

(3) cover more scenarios from upper layer code(see section "Explanation"), not including using multiple backends simultaneously because that's another topic/scenario

(4) (the main purpose is) prepare for submit Qualcomm's QNN(Qualcomm Neural Network, aka Qualcomm AI Engine Direct) backend to upstream GGML community (the first step in whisper.cpp, then in llama.cpp): <a href="https://github.com/zhouwg/kantv/issues/121">PoC: Add Qualcomm mobile SoC native backend for GGML</a>


<h4>Status</h4>

this PR has verified/validated in whisper.cpp + QNN backend on different Android phone(Qualcomm SoC based low-end phone and Qualcomm SoC based high-end phone).


<h4>Explanation</h4>

this PR is useful/helpful/meaningful for some scenarios.


in the fact,  the "gpu_device" in struct whisper_context_params is similar to use_hwaccel <b>semantically</b>. there are 2 * n combinations here: 2(use_gpu:true/false) * n (backend_device:1-n, <b>attention here</b>: a DSP backend is also considered as a "gpu_device", because we should re-use the existing code as much as possible and not brings side-effect or complexity to existing code)


```
   struct whisper_context_params {
        bool  use_gpu;
        int   gpu_device;  // CUDA device

        // [EXPERIMENTAL] Token-level timestamps with DTW
        bool dtw_token_timestamps;
        enum whisper_alignment_heads_preset dtw_aheads_preset;

        int dtw_n_top;
        struct whisper_aheads dtw_aheads;

        size_t dtw_mem_size; // TODO: remove
    };
```

<b>so a special value</b> of "gpu_device" could be considered/assumed non hardware acceleration or <b>fall into</b> the original default GGML CPU backend.

<b>accordingly</b>, we can <b>re-use</b> the existing "backend" member in core data structure with a new member "use_hwaccel" in struct ggml_context. btw, I personally think we should not remove the existing "backend" from "struct ggml_tensor" although there is a plan to remove this member:
```
  // n-dimensional tensor
    struct ggml_tensor {
        enum ggml_type         type;
        enum ggml_backend_type backend;

        struct ggml_backend_buffer * buffer;

        int64_t ne[GGML_MAX_DIMS]; // number of elements
        size_t  nb[GGML_MAX_DIMS]; // stride in bytes:
                                   // nb[0] = ggml_type_size(type)
                                   // nb[1] = nb[0]   * (ne[0] / ggml_blck_size(type)) + padding
                                   // nb[i] = nb[i-1] * ne[i-1]

        // compute data
        enum ggml_op op;

        // op params - allocated as int32_t for alignment
        int32_t op_params[GGML_MAX_OP_PARAMS / sizeof(int32_t)];

        int32_t flags;

        struct ggml_tensor * grad;
        struct ggml_tensor * src[GGML_MAX_SRC];

        // performance
        int     perf_runs;
        int64_t perf_cycles;
        int64_t perf_time_us;

        struct ggml_tensor * view_src;
        size_t               view_offs;

        void * data;

        char name[GGML_MAX_NAME];

        void * extra; // extra things e.g. for ggml-cuda.cu

        int32_t rank;

        char padding[20];
    };

```


<b>the reason for this </b>is that there are some different scenarios(not including using multiple backends simultaneously, that's another topic/scenario) which "use_gpu&gpu_device" cannot cover:  
<ul>
<li>
 the combination of "use_gpu&gpu_device in struct whisper_context_params" is used for whisper.cpp(a specify backend(including the default GGML CPU backend) will be used accordingly) , 
 </li>

<li>
  the combination of "use_hwaccel in struct ggml_context"  & "backend in struct ggml_tensor" is used for other scenarios, 

<ul>
<li>
 for example: <a href="https://github.com/zhouwg/kantv/blob/kantv-poc-with-qnn/core/ggml/llamacpp/ggml.c#L16138">UT for GGML OPs using a specify backend</a>
</li>

<li>
for example: <a href="https://github.com/zhouwg/kantv/blob/kantv-poc-with-qnn/core/ggml/whispercpp/whisper.cpp#L6673">whisper bechmark using a specify backend</a>
</li>

<li>
for example: <a href="https://github.com/zhouwg/kantv/blob/kantv-poc-with-qnn/core/ggml/llamacpp/ggml-qnn.cpp#L3891">delegate all GGML OPs from default GGML CPU backend to a specify backend or toggle between different backend</a>(including the default GGML CPU backend)</a>
</li>

</ul>

</li>

</ul>


I personally think these new members("use_hwaccel" in struct ggml_context & "rank" in struct ggml_tensor) are not redundant and these new members will NOT bring side-effect to existing codes. Of course, I understand we should not bring too much "useful codes" into existing implementation of GGML internal and we should keep GGML as compact/clean as possible, so this PR reuses existing code to the maximum extent or as much as possible:

https://github.com/zhouwg/whisper.cpp/blob/add_hwaccel_in_data_structure/ggml.c#L2995


<h4>PR approval request</h4>


@hey-shashikant, thanks for your time and approval of https://github.com/ggerganov/whisper.cpp/pull/2054 (which is same to this PR), could you help to take a look this PR? thanks so much.


@slaren, I'm sorry to interrupt you, could you help to take a look? thanks

@ggerganov , I'm sorry to interrupt you, could you help to take a look? thanks
