### PR TITLE
make : change GNU make default CXX from g++ to c++

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,17 @@ ifndef NVCC_VERSION
 	endif
 endif
 
+# In GNU make default CXX is g++ instead of c++.  Let's fix that so that users
+# of non-gcc compilers don't have to provide g++ alias or wrapper.
+DEFCC  := cc
+DEFCXX := c++
+ifeq ($(origin CC),default)
+CC  := $(DEFCC)
+endif
+ifeq ($(origin CXX),default)
+CXX := $(DEFCXX)
+endif
+
 CCV  := $(shell $(CC) --version | head -n 1)
 CXXV := $(shell $(CXX) --version | head -n 1)
 


### PR DESCRIPTION
Fixes:

- ggerganov/whisper.cpp/issues/2098

as already tested in checker in my branch.

FreeBSD checker seems to be generally flaky recently (or maybe `macos-12` that it runs on, to be specific), but I tested build on my FreeBSD VM and I don't see any issues there, so it should be good to merge.

With this change (which I somehow forgot to do in the past) building whisper.cpp on OpenBSD using `gmake` does not require overriding CXX by the user anymore.