### PR TITLE
Remove un-needed request header from fetchRemote

### DIFF
--- a/examples/helpers.js
+++ b/examples/helpers.js
@@ -34,9 +34,6 @@ async function fetchRemote(url, cbProgress, cbPrint) {
         url,
         {
             method: 'GET',
-            headers: {
-                'Content-Type': 'application/octet-stream',
-            },
         }
     );
 


### PR DESCRIPTION
fetch() should not add that `Content-Type: application/octet-stream` to the request, as it makes no sense (and may end being blocked by CORS).
