### PR TITLE
ggml : expose SSE3 and SSSE3 for MSVC when AVX is available

### DIFF
--- a/ggml-impl.h
+++ b/ggml-impl.h
@@ -37,8 +37,15 @@ extern "C" {
 #ifndef __F16C__
 #define __F16C__
 #endif
+#endif
+
+// __SSE3__ and __SSSE3__ are not defined in MSVC, but SSE3/SSSE3 are present when AVX/AVX2/AVX512 are available
+#if defined(_MSC_VER) && (defined(__AVX__) || defined(__AVX2__) || defined(__AVX512F__))
 #ifndef __SSE3__
 #define __SSE3__
+#endif
+#ifndef __SSSE3__
+#define __SSSE3__
 #endif
 #endif
 


### PR DESCRIPTION
Previously only SSE3 was exposed and only when AVX2 was available, but AVX is sufficient to expect presence of SSE3 and SSSE3.