### PR TITLE
Openvino audio ctx quantize

### DIFF
--- a/models/convert-whisper-to-openvino.py
+++ b/models/convert-whisper-to-openvino.py
@@ -1,16 +1,41 @@
 import argparse
 import torch
 from whisper import load_model
+from whisper.model import AudioEncoder
 import os
-from openvino.tools import mo
+from nncf import compress_weights, CompressWeightsMode
 from openvino.frontend import FrontEndManager
 from openvino.runtime import serialize
 import shutil
+from torch import Tensor
+import torch.nn.functional as F
 
-def convert_encoder(hparams, encoder, mname):
+# Monkey path the whisper AudioEncoder.forward method to accept variable audio context size (n_mels)
+def patched_forward(self, x: Tensor):
+    """
+    x : torch.Tensor, shape = (batch_size, n_mels, n_ctx)
+        the mel spectrogram of the audio
+    """
+    x = F.gelu(self.conv1(x))
+    x = F.gelu(self.conv2(x))
+    x = x.permute(0, 2, 1)
+
+    # Modify positional embedding shape to match the input mel shape
+    x = (x + self.positional_embedding[0:x.shape[1], :]).to(x.dtype)
+
+    for block in self.blocks:
+        x = block(x)
+
+    x = self.ln_post(x)
+    return x
+
+# Patch the method
+AudioEncoder.forward = patched_forward
+
+def convert_encoder(hparams, encoder, mname, n_audio_ctx, quantize_bits = 8):
     encoder.eval()
 
-    mel = torch.zeros((1, hparams.n_mels, 3000))
+    mel = torch.zeros((1, hparams.n_mels, n_audio_ctx*2))
 
     onnx_folder = os.path.join(os.path.dirname(__file__), "onnx_encoder")
 
@@ -35,6 +60,12 @@ def convert_encoder(hparams, encoder, mname):
     onnx_model = onnx_fe.load(onnx_path)
     ov_model = onnx_fe.convert(onnx_model)
 
+    # Quantize the model using OpenVino NNCF (https://github.com/openvinotoolkit/nncf)
+    if quantize_bits == 8:
+        ov_model = compress_weights(ov_model, mode=CompressWeightsMode.INT8)
+    if quantize_bits == 4:
+        ov_model = compress_weights(ov_model, mode=CompressWeightsMode.INT4_SYMM)
+
     # Serialize the OpenVINO model to XML and BIN files
     serialize(ov_model, xml_path=os.path.join(os.path.dirname(__file__), "ggml-" + mname + "-encoder-openvino.xml"))
 
@@ -45,16 +76,21 @@ def convert_encoder(hparams, encoder, mname):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--model", type=str, help="model to convert (e.g. tiny, tiny.en, base, base.en, small, small.en, medium, medium.en, large-v1, large-v2, large-v3)", required=True)
+    parser.add_argument("-m", "--model", type=str, help="model to convert (e.g. tiny, tiny.en, base, base.en, small, small.en, medium, medium.en, large-v1, large-v2, large-v3)", required=True)
+    parser.add_argument("-ac", "--audio_context", type=int, help="number of audio context frames to set when converting the model (fixed value)", required=False, default=1500)
+    parser.add_argument("-qb", "--quantize_bits", type=int, help="quantize model to 8 or 4 bits", required=False, default=None)
     args = parser.parse_args()
 
     if args.model not in ["tiny", "tiny.en", "base", "base.en", "small", "small.en", "medium", "medium.en", "large-v1", "large-v2", "large-v3"]:
         raise ValueError("Invalid model name")
 
+    if args.quantize_bits is not None and args.quantize_bits not in [8, 4]:
+        raise ValueError("Invalid quantization level, only 8 and 4 bit are supported")
+
     whisper = load_model(args.model).cpu()
     hparams = whisper.dims
-
+    hparams.n_audio_ctx = args.audio_context
     encoder = whisper.encoder
 
     # Convert encoder to onnx
-    convert_encoder(hparams, encoder, args.model)
+    convert_encoder(hparams, encoder, args.model, args.audio_context, args.quantize_bits)

--- a/models/requirements-openvino.txt
+++ b/models/requirements-openvino.txt
@@ -1,3 +1,3 @@
 openvino-dev[pytorch,onnx]
-nncf>=2.7.0,<3
+nncf==2.7.0
 openai-whisper

--- a/models/requirements-openvino.txt
+++ b/models/requirements-openvino.txt
@@ -1,2 +1,3 @@
 openvino-dev[pytorch,onnx]
+nncf>=2.7.0,<3
 openai-whisper


### PR DESCRIPTION
Compiling with [OpenVino](https://github.com/ggerganov/whisper.cpp?tab=readme-ov-file#openvino-support) on supported platforms can significantly improve performance, but currently it lacks two other features that can also significantly improve performance:

- Using quantized models (10%+ performance increase)
- Supporting [custom audio context sizes](https://github.com/ggerganov/whisper.cpp/issues/1855) (~3x performance increase for short audio files)

This PR adds both of these as optional arguments to the OpenVino model conversion scripts, enabling performance of quantization, audio context size, and OpenVino to stack.

There are a few important caveats, however:

- The OpenVino encoder (to my knowledge) only supports a fixed audio context size, so the converted model is somewhat more restricted
- This does require monkey patching a method from the `openai-whisper` library in `convert-whisper-to-openvino.py`, which isn't ideal
- Quantization is done with [nncf](https://github.com/openvinotoolkit/nncf) 2.7.0, which currently only supports 4 and 8 bit quantization

Despite these, the performance improvement can be so substantial for certain use cases it may be worth it. For example, on the ~10 second `jfk.wav` file on a Intel(R) Xeon(R) W-2123 CPU:

| Threads | Quant | Model | Encoder Time (s) | Arguments | Build |
| --- | --- | --- | --- | --- | --- |
| 1 | 8 bit | small-en | 8 | -bs 1 -ac 1500 | BLAS = 1 |
| 1 | 8 bit | small-en | 0.8 | -bs 1 -ac 550 | OPENVINO = 1 |

Command to produce the OpenVino model for this PR: `python convert-whisper-to-openvino.py --model small.en -ac 550 -qb 8
`