### PR TITLE
Add Installation Instructions for Conan to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,6 +502,16 @@ docker run -it --rm \
   whisper.cpp:main "./main -m /models/ggml-base.bin -f ./samples/jfk.wav"
 ```
 
+## Installing with Conan
+
+You can install pre-built binaries for whisper.cpp or build it from source using [Conan](https://conan.io/). Use the following command:
+
+```
+conan install --requires="whisper-cpp/[*]" --build=missing
+```
+
+For detailed instructions on how to use Conan, please refer to the [Conan documentation](https://docs.conan.io/2/).
+
 ## Limitations
 
 - Inference only


### PR DESCRIPTION
Hi!

We have just added the latest version of `whisper.cpp` to [Conan Center](https://conan.io/center/recipes/whisper-cpp?version=1.6.2) and thought it would be a nice addition to include instructions on how to install `whisper.cpp` via Conan in the README. 

Please let me know if this is okay, or if you would prefer it placed elsewhere.

Thank you so much for considering this PR.
