### PR TITLE
whisper : fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -498,7 +498,7 @@ jobs:
         run: >
           cmake -S . -B ./build -A ${{ matrix.arch }}
           -DCMAKE_BUILD_TYPE=${{ matrix.build }}
-          -DWHISPER_CUBLAS=${{ matrix.cublas }}
+          -DWHISPER_CUDA=${{ matrix.cublas }}
           -DWHISPER_SDL2=${{ matrix.sdl2 }}
 
       - name: Build ${{ matrix.cuda-toolkit }}

--- a/whisper-mel-cuda.cu
+++ b/whisper-mel-cuda.cu
@@ -194,7 +194,7 @@ class mel_calc_cuda : public whisper_mel_calc {
     size_t m_log_mel_temp_storage_size = 0;
     void * m_log_mel_temp_storage = nullptr;
 public:
-    mel_calc_cuda(ggml_backend_t backend, const whisper_filters& filters)
+    mel_calc_cuda(ggml_backend_t backend, const whisper_filters & filters)
         : m_n_mel(filters.n_mel)
         , m_backend(backend)
     {
@@ -305,7 +305,7 @@ public:
         whisper_mel ret;
         // Calculate semi-padded sample length to ensure compatibility
         int n_len_org = 1 + int(samples.len + mirror_pad - WHISPER_N_FFT) / WHISPER_HOP_LENGTH;
-        ret.init(m_backend, int(n_mag_frames), n_len_org, m_n_mel);
+        whisper_mel_init(ret, m_backend, int(n_mag_frames), n_len_org, m_n_mel);
         assert(ggml_nbytes(ret.tensor) == m_n_mel * n_mag_frames * sizeof(float));
 
         float* log_mels = reinterpret_cast<float*>(ret.tensor->data);

--- a/whisper-mel.hpp
+++ b/whisper-mel.hpp
@@ -5,22 +5,14 @@
 struct whisper_mel {
     int n_len_org = 0;
 
-    ggml_tensor * tensor = nullptr;
     ggml_context * ctx = nullptr;
+    ggml_tensor * tensor = nullptr;
     ggml_backend_buffer_t buffer = nullptr;
-
-    whisper_mel() = default;
-    ~whisper_mel();
-
-    whisper_mel(const whisper_mel &) = delete;
-    whisper_mel & operator=(const whisper_mel &) = delete;
-    whisper_mel(whisper_mel &&) noexcept;
-    whisper_mel & operator=(whisper_mel &&) noexcept;
-
-    void init(ggml_backend_t backend, int n_len, int n_len_org, int n_mel);
-    void reset();
-    void take(whisper_mel & other) noexcept;
 };
+
+void whisper_mel_init(whisper_mel & mel, ggml_backend_t backend, int n_len, int n_len_org, int n_mel);
+
+void whisper_mel_free(whisper_mel & mel);
 
 struct whisper_filters {
     int32_t n_mel;
@@ -40,6 +32,3 @@ struct whisper_mel_calc {
     virtual whisper_mel calculate(whisper_span<const float> samples, int n_threads) const = 0;
     static whisper_span<const float> hann_window();
 };
-
-// returns a new pointer which needs to be freed with delete
-whisper_mel_calc * whisper_mel_calc_create(ggml_backend_t backend, const whisper_filters & filters);


### PR DESCRIPTION
- move `mel_calc` to `whisper_state`
- `mel_calc` uses `backend` of `whisper_state` instead of `whisper_context`
- alloc kv caches using backend of `whisper_state` instead of `whisper_context`
- less C++ in `struct whisper_mel`