### PR TITLE
Fixed a failure to free context resulting in a segfault

### DIFF
--- a/whisper.cpp
+++ b/whisper.cpp
@@ -3781,6 +3781,7 @@ void whisper_free_params(struct whisper_full_params * params) {
 int whisper_pcm_to_mel_with_state(struct whisper_context * /*ctx*/, struct whisper_state * state, const float * samples, int n_samples, int n_threads) {
     const int64_t t_start_us = ggml_time_us();
 
+    ggml_free(state->mel.ctx);
     state->mel = state->mel_calc->calculate({samples, n_samples}, n_threads);
 
     state->t_mel_us += ggml_time_us() - t_start_us;


### PR DESCRIPTION
Prior to this change, on my machine, after about 30 seconds or so of running the stream example, the program would segfault. Upon investigation, I found that the segfaulting was happening because the program calls state->mel_calc->calculate which eventually calls ggml_init, which uses a context from the global state. However, that context is never freed. This change frees that context whenever it is about to be replaced. It fixes the segfault, but I don't understand the code enough to say whether it's the right approach.