### PR TITLE
cuda : fix bounds check for src0 rows in MMVQ kernel

### DIFF
--- a/ggml-cuda/mmvq.cu
+++ b/ggml-cuda/mmvq.cu
@@ -75,7 +75,7 @@ static __global__ void mul_mat_vec_q(
             tmp[j][i] = warp_reduce_sum(tmp[j][i]);
         }
 
-        if (threadIdx.x < rows_per_cuda_block && row0 + threadIdx.x < nrows_dst) {
+        if (threadIdx.x < rows_per_cuda_block && (rows_per_cuda_block == 1 || row0 + threadIdx.x < nrows_dst)) {
             dst[j*nrows_dst + row0 + threadIdx.x] = tmp[j][threadIdx.x];
         }
     }

--- a/ggml-cuda/mmvq.cu
+++ b/ggml-cuda/mmvq.cu
@@ -75,7 +75,7 @@ static __global__ void mul_mat_vec_q(
             tmp[j][i] = warp_reduce_sum(tmp[j][i]);
         }
 
-        if (threadIdx.x < rows_per_cuda_block) {
+        if (threadIdx.x < rows_per_cuda_block && row0 + threadIdx.x < nrows_dst) {
             dst[j*nrows_dst + row0 + threadIdx.x] = tmp[j][threadIdx.x];
         }
     }


### PR DESCRIPTION
The non-EN models have a tensor with odd number of rows: 

```
decoder.token_embedding.weight - [ 1024, 51865,     1]
```

With BS > 1 and since https://github.com/ggerganov/whisper.cpp/commit/d7e9f58f7f286b1eea478d54b17360344d1214ba we have been doing out-of-bound writes with quantum models because `rows_per_cuda_block` can be equal to `2`, leading to significantly poor transcription quality:

https://github.com/ggerganov/whisper.cpp/blob/20c542c71334b3e6c422789093a19157b110ca81/ggml-cuda/mmvq.cu#L92-L123

Repro on RTX 2060:

```bash
# any quantum model would reproduce the problem
rm models/ggml-base-q5_1.bin
./models/download-ggml-model.sh base-q5_1

make clean
WHISPER_CUDA=1 make -j && ./main -m models/ggml-base-q5_1.bin -f samples/gb0.wav
```