### PR TITLE
Fix MKL build issue by correctly finding and linking MKL libraries

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,6 +28,12 @@ if (WHISPER_OPENVINO)
     find_package(OpenVINO REQUIRED COMPONENTS Runtime)
 endif()
 
+if (WHISPER_MKL)
+    find_package(MKL REQUIRED)
+    set(MKL_INCLUDE_DIRS "${MKLROOT}/include")
+    set(MKL_LIBRARIES "${MKLROOT}/lib/intel64")
+endif()
+
 #
 # libraries
 #
@@ -134,7 +140,9 @@ if (WHISPER_OPENVINO)
 endif()
 
 if (WHISPER_MKL)
-    target_link_libraries(whisper PRIVATE MKL::MKL)
+    include_directories(${MKL_INCLUDE_DIRS})
+    link_directories(${MKL_LIBRARIES})
+    target_link_libraries(whisper PRIVATE mkl_rt)
 endif()
 
 if (BUILD_SHARED_LIBS)


### PR DESCRIPTION
# Fix MKL Build Issue

## Description

This pull request fixes an issue with building whisper.cpp using Intel MKL. The changes ensure that CMake correctly finds and links the MKL libraries.

## Changes Made

- Added `find_package(MKL REQUIRED)` to locate MKL.
- Set `MKL_INCLUDE_DIRS` and `MKL_LIBRARIES` to ensure proper include and link paths.
- Included `MKL` headers and libraries only if `WHISPER_MKL` is enabled.

## Testing

Successfully built whisper.cpp with the MKL option enabled on an Intel Xeon CPU without GPU.

## Related Issues

Fixes #<issue-number> (if applicable)