### PR TITLE
cmake : use WHISPER_EXTRA_FLAGS

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -123,6 +123,10 @@ set_target_properties(whisper PROPERTIES
 target_include_directories(whisper PUBLIC . ../include)
 target_compile_features   (whisper PUBLIC cxx_std_11) # don't bump
 
+if (WHISPER_EXTRA_FLAGS)
+    target_compile_options(whisper PRIVATE ${WHISPER_EXTRA_FLAGS})
+endif()
+
 target_link_libraries(whisper PUBLIC ggml)
 
 if (WHISPER_COREML)


### PR DESCRIPTION
fix #2281 