### PR TITLE
Fix DTW assert

### DIFF
--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -7220,9 +7220,10 @@ struct median_filter_user_data {
 };
 
 static void median_filter(struct ggml_tensor * dst , const struct ggml_tensor * a, int ith, int nth, void * userdata) {
+    if (ith != 0) {
+        return;
+    }
     int filter_width = ((median_filter_user_data *) userdata)->filter_width;
-    WHISPER_ASSERT(nth == 1);
-    WHISPER_ASSERT(ith == 0);
     WHISPER_ASSERT(filter_width < a->ne[2]);
     WHISPER_ASSERT(filter_width % 2);
     WHISPER_ASSERT(ggml_n_dims(a) == 3);


### PR DESCRIPTION
This commit https://github.com/ggerganov/whisper.cpp/commit/e30c6799283225e1dcf574924b79cb49ebc2a209 contains a lot of places in ggml.c where following code

```c
assert(params->ith == 0);
```
was replaced by 

```c
if (params->ith != 0) {
    return;
}
```

As far as I understand from the code, DTW requires the same. Right now on the master with DTW enabled I'm getting error about wrong thread count and thread number.