### PR TITLE
Add support for wget2 for fedora

### DIFF
--- a/models/download-ggml-model.sh
+++ b/models/download-ggml-model.sh
@@ -101,7 +101,9 @@ if [ -f "ggml-$model.bin" ]; then
     exit 0
 fi
 
-if [ -x "$(command -v wget)" ]; then
+if [ -x "$(command -v wget2)" ]; then
+    wget2 --no-config --progress bar -O ggml-"$model".bin $src/$pfx-"$model".bin
+elif [ -x "$(command -v wget)" ]; then
     wget --no-config --quiet --show-progress -O ggml-"$model".bin $src/$pfx-"$model".bin
 elif [ -x "$(command -v curl)" ]; then
     curl -L --output ggml-"$model".bin $src/$pfx-"$model".bin


### PR DESCRIPTION
A quick fix to add support for wget2. Replaces `--show-progress` with `--progress bar` when wget2 is detected.

resolves #2374