### PR TITLE
Fix Vulkan build failing due to missing shader 

### DIFF
--- a/ggml/src/vulkan-shaders/cos.comp
+++ b/ggml/src/vulkan-shaders/cos.comp
@@ -10,6 +10,6 @@ void main() {
         return;
     }
 
-    const FLOAT_TYPE val = FLOAT_TYPE(data_a[src0_idx(idx)]);
+    const float val = float(data_a[src0_idx(idx)]);
     data_d[p.d_offset + dst_idx(idx)] = D_TYPE(cos(val));
 }

--- a/ggml/src/vulkan-shaders/sin.comp
+++ b/ggml/src/vulkan-shaders/sin.comp
@@ -10,6 +10,6 @@ void main() {
         return;
     }
 
-    const FLOAT_TYPE val = FLOAT_TYPE(data_a[src0_idx(idx)]);
+    const float val = float(data_a[src0_idx(idx)]);
     data_d[p.d_offset + dst_idx(idx)] = D_TYPE(sin(val));
 }

--- a/ggml/src/vulkan-shaders/vulkan-shaders-gen.cpp
+++ b/ggml/src/vulkan-shaders/vulkan-shaders-gen.cpp
@@ -428,6 +428,12 @@ void process_shaders(std::vector<std::future<void>>& tasks) {
         string_to_spv("silu_f32", "silu.comp", {{"A_TYPE", "float"}, {"D_TYPE", "float"}});
     }));
     tasks.push_back(std::async(std::launch::async, [] {
+        string_to_spv("sin_f32", "sin.comp", {{"A_TYPE", "float"}, {"D_TYPE", "float"}});
+    }));
+    tasks.push_back(std::async(std::launch::async, [] {
+        string_to_spv("cos_f32", "cos.comp", {{"A_TYPE", "float"}, {"D_TYPE", "float"}});
+    }));
+    tasks.push_back(std::async(std::launch::async, [] {
         string_to_spv("relu_f32", "relu.comp", {{"A_TYPE", "float"}, {"D_TYPE", "float"}});
     }));
     tasks.push_back(std::async(std::launch::async, [] {


### PR DESCRIPTION
This PR fixes the errors described below when I was trying to build with Vulkan enabled on Linux with

```bash
cmake -B build/ -DGGML_VULKAN=1
```
but ran into errors of the form
```
ggml/src/ggml-vulkan.cpp:1707:87: error: ‘sin_f32_data’ was not declared in this scope; did you mean ‘sqr_f32_data’?
ggml/src/ggml-vulkan.cpp:1708:74: error: ‘cos_f32_len’ was not declared in this scope; did you mean ‘pad_f32_len’?
```
Turns out the sine and cosine shaders weren't even being compiled. I modified `vulkan-shaders-gen.cpp` to add tasks to compile them, but after that, I got these shader compilation errors for sin and cos:
```
ggml/src/vulkan-shaders/cos.comp:13: error: '' :  syntax error, unexpected IDENTIFIER, expecting LEFT_BRACE or COMMA or SEMICOLON
1 error generated.

cannot compile sin_f32
```

They were fixed once I removed references to `FLOAT_TYPE` from the shaders and used `float` instead, following the pattern in other unary op shaders like SiLU. I am now able to use whisper.cpp with my Ryzen APU and various Whisper models!