### PR TITLE
cmake: Fix libdir value in pkgconfig file

### DIFF
--- a/cmake/whisper.pc.in
+++ b/cmake/whisper.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${exec_prefix}/lib
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
 includedir=${prefix}/include
 
 Name: whisper


### PR DESCRIPTION
Depending on the OS the lib dir can vary, on Fedora for instance it is "${prefix}/lib64". Instead of hard-coding the directory name, let CMake fill this variable for us.