### PR TITLE
Added OpenVino init on state

### DIFF
--- a/include/whisper.h
+++ b/include/whisper.h
@@ -238,6 +238,14 @@ extern "C" {
     //                     GPU, by caching compiled 'blobs' there.
     //                     Set to nullptr if not used.
     // Returns 0 on success. If OpenVINO is not enabled in build, this simply returns 1.
+	
+    WHISPER_API int whisper_ctx_init_openvino_encoder_with_state(
+        struct whisper_context * ctx,
+		  struct whisper_state * state,
+                    const char * model_path,
+                    const char * device,
+                    const char * cache_dir);
+					
     WHISPER_API int whisper_ctx_init_openvino_encoder(
         struct whisper_context * ctx,
                     const char * model_path,

--- a/include/whisper.h
+++ b/include/whisper.h
@@ -240,11 +240,11 @@ extern "C" {
     // Returns 0 on success. If OpenVINO is not enabled in build, this simply returns 1.
     WHISPER_API int whisper_ctx_init_openvino_encoder_with_state(
         struct whisper_context * ctx,
-		  struct whisper_state * state,
+          struct whisper_state * state,
                     const char * model_path,
                     const char * device,
                     const char * cache_dir);
-					
+
     WHISPER_API int whisper_ctx_init_openvino_encoder(
         struct whisper_context * ctx,
                     const char * model_path,

--- a/include/whisper.h
+++ b/include/whisper.h
@@ -238,7 +238,6 @@ extern "C" {
     //                     GPU, by caching compiled 'blobs' there.
     //                     Set to nullptr if not used.
     // Returns 0 on success. If OpenVINO is not enabled in build, this simply returns 1.
-	
     WHISPER_API int whisper_ctx_init_openvino_encoder_with_state(
         struct whisper_context * ctx,
 		  struct whisper_state * state,

--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -3494,7 +3494,7 @@ struct whisper_state * whisper_init_state(whisper_context * ctx) {
 
 int whisper_ctx_init_openvino_encoder_with_state(
         struct whisper_context * ctx,
-		   struct whisper_state * state,
+          struct whisper_state * state,
                     const char * model_path,
                     const char * device,
                     const char * cache_dir) {
@@ -3548,7 +3548,7 @@ int whisper_ctx_init_openvino_encoder(
                     const char * model_path,
                     const char * device,
                     const char * cache_dir) {
-	return whisper_ctx_init_openvino_encoder_with_state(ctx, ctx->state, model_path, device, cache_dir);
+    return whisper_ctx_init_openvino_encoder_with_state(ctx, ctx->state, model_path, device, cache_dir);
 }
 
 struct whisper_context_params whisper_context_default_params() {

--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -3494,7 +3494,7 @@ struct whisper_state * whisper_init_state(whisper_context * ctx) {
 
 int whisper_ctx_init_openvino_encoder_with_state(
         struct whisper_context * ctx,
-		   struct whisper_sate * state,
+		   struct whisper_state * state,
                     const char * model_path,
                     const char * device,
                     const char * cache_dir) {

--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -3492,13 +3492,15 @@ struct whisper_state * whisper_init_state(whisper_context * ctx) {
     return state;
 }
 
-int whisper_ctx_init_openvino_encoder(
+int whisper_ctx_init_openvino_encoder_with_state(
         struct whisper_context * ctx,
+		   struct whisper_sate * state,
                     const char * model_path,
                     const char * device,
                     const char * cache_dir) {
 #ifndef WHISPER_USE_OPENVINO
     (void)(ctx);
+    (void)(state);
     (void)(model_path);
     (void)(device);
     (void)(cache_dir);
@@ -3529,8 +3531,8 @@ int whisper_ctx_init_openvino_encoder(
     WHISPER_LOG_INFO("%s: loading OpenVINO model from '%s'\n", __func__, path_encoder.c_str());
     WHISPER_LOG_INFO("%s: first run on a device may take a while ...\n", __func__);
 
-    ctx->state->ctx_openvino = whisper_openvino_init(path_encoder.c_str(), device, path_cache.c_str());
-    if (!ctx->state->ctx_openvino) {
+    state->ctx_openvino = whisper_openvino_init(path_encoder.c_str(), device, path_cache.c_str());
+    if (!state->ctx_openvino) {
         WHISPER_LOG_ERROR("%s: failed to init OpenVINO encoder from '%s'\n", __func__, path_encoder.c_str());
         return 1;
     } else {
@@ -3539,6 +3541,14 @@ int whisper_ctx_init_openvino_encoder(
 
     return 0;
 #endif
+}
+
+int whisper_ctx_init_openvino_encoder(
+        struct whisper_context * ctx,
+                    const char * model_path,
+                    const char * device,
+                    const char * cache_dir) {
+	return whisper_ctx_init_openvino_encoder_with_state(ctx, ctx->state, model_path, device, cache_dir);
 }
 
 struct whisper_context_params whisper_context_default_params() {


### PR DESCRIPTION
Hello @ggerganov,
I am trying to add support for OpenVino for whisper.net and observed that the init function `whisper_ctx_init_openvino_encoder` can only be called on the default context-owned state which I'm not using as I manage multiple parallel states.

This PR is adding a new API function `whisper_ctx_init_openvino_encoder_with_state` that basically is doing the same thing on the provided state. 