### PR TITLE
WIP: ruby: New segment callback

### DIFF
--- a/bindings/ruby/.gitignore
+++ b/bindings/ruby/.gitignore
@@ -1,4 +1,3 @@
-README.md
 LICENSE
 pkg/
 lib/whisper.*

--- a/bindings/ruby/README.md
+++ b/bindings/ruby/README.md
@@ -1,0 +1,63 @@
+whispercpp
+==========
+
+![whisper.cpp](https://user-images.githubusercontent.com/1991296/235238348-05d0f6a4-da44-4900-a1de-d0707e75b763.jpeg)
+
+Ruby bindings for [whisper.cpp][], an interface of automatic speech recognition model.
+
+Installation
+------------
+
+Install the gem and add to the application's Gemfile by executing:
+
+    $ bundle add whispercpp
+
+If bundler is not being used to manage dependencies, install the gem by executing:
+
+    $ gem install whispercpp
+
+Usage
+-----
+
+NOTE: This gem is still in development. API is not stable for now.
+
+```ruby
+require "whisper"
+
+whisper = Whisper::Context.new("path/to/model.bin")
+
+params = Whisper::Params.new
+params.language = "en"
+params.offset = 10_000
+params.duration = 60_000
+params.max_text_tokens = 300
+params.translate = true
+params.print_timestamps = false
+params.new_segment_callback = ->(output, t0, t1, index) {
+  puts "segment #{index}: #{t0}ms -> #{t1}ms: #{output}"
+}
+
+whisper.transcribe("path/to/audio.wav", params) do |whole_text|
+  puts whole_text
+end
+
+```
+
+### Preparing model ###
+
+Use script to download model file(s):
+
+```bash
+git clone https://github.com/ggerganov/whisper.cpp.git
+cd whisper.cpp
+sh ./models/download-ggml-model.sh base.en
+```
+
+There are some types of models. See [models][] page for details.
+
+### Preparing audio file ###
+
+Currently, whisper.cpp accepts only 16-bit WAV files.
+
+[whisper.cpp]: https://github.com/ggerganov/whisper.cpp
+[models]: https://github.com/ggerganov/whisper.cpp/tree/master/models

--- a/bindings/ruby/ext/ruby_whisper.cpp
+++ b/bindings/ruby/ext/ruby_whisper.cpp
@@ -86,9 +86,12 @@ void rb_whisper_free(ruby_whisper *rw) {
 }
 
 void rb_whisper_params_mark(ruby_whisper_params *rwp) {
+  rb_gc_mark(rwp->new_segment_callback_user_data->user_data);
+  rb_gc_mark(rwp->new_segment_callback_user_data->callback);
 }
 
 void rb_whisper_params_free(ruby_whisper_params *rwp) {
+  // How to free user_data and callback only when not referred to by others?
   ruby_whisper_params_free(rwp);
   free(rwp);
 }
@@ -110,6 +113,7 @@ static VALUE ruby_whisper_params_allocate(VALUE klass) {
   new_segment_callback_user_data->user_data = Qnil;
   new_segment_callback_user_data->callback = Qnil;
   rwp->new_segment_callback_user_data = new_segment_callback_user_data;
+
   return Data_Wrap_Struct(klass, rb_whisper_params_mark, rb_whisper_params_free, rwp);
 }
 

--- a/bindings/ruby/ext/ruby_whisper.cpp
+++ b/bindings/ruby/ext/ruby_whisper.cpp
@@ -41,15 +41,30 @@ static VALUE ruby_whisper_s_lang_max_id(VALUE self) {
 }
 
 static VALUE ruby_whisper_s_lang_id(VALUE self, VALUE lang) {
-  return INT2NUM(whisper_lang_id(StringValueCStr(lang)));
+  const char * lang_str = StringValueCStr(lang);
+  const int id = whisper_lang_id(lang_str);
+  if (-1 == id) {
+    rb_raise(rb_eArgError, "language not found: %s", lang_str);
+  }
+  return INT2NUM(id);
 }
 
 static VALUE ruby_whisper_s_lang_str(VALUE self, VALUE id) {
-  return rb_str_new2(whisper_lang_str(NUM2INT(id)));
+  const int lang_id = NUM2INT(id);
+  const char * str = whisper_lang_str(lang_id);
+  if (nullptr == str) {
+    rb_raise(rb_eIndexError, "id %d outside of language id", lang_id);
+  }
+  return rb_str_new2(str);
 }
 
 static VALUE ruby_whisper_s_lang_str_full(VALUE self, VALUE id) {
-  return rb_str_new2(whisper_lang_str_full(NUM2INT(id)));
+  const int lang_id = NUM2INT(id);
+  const char * str_full = whisper_lang_str_full(lang_id);
+  if (nullptr == str_full) {
+    rb_raise(rb_eIndexError, "id %d outside of language id", lang_id);
+  }
+  return rb_str_new2(str_full);
 }
 
 static void ruby_whisper_free(ruby_whisper *rw) {

--- a/bindings/ruby/ext/ruby_whisper.cpp
+++ b/bindings/ruby/ext/ruby_whisper.cpp
@@ -472,6 +472,12 @@ static VALUE ruby_whisper_params_set_new_segment_callback(VALUE self, VALUE valu
   rwp->new_segment_callback_user_data->callback = value;
   return value;
 }
+static VALUE ruby_whisper_params_set_new_segment_callback_user_data(VALUE self, VALUE value) {
+  ruby_whisper_params *rwp;
+  Data_Get_Struct(self, ruby_whisper_params, rwp);
+  rwp->new_segment_callback_user_data->user_data = value;
+  return value;
+}
 
 void Init_whisper() {
   mWhisper = rb_define_module("Whisper");
@@ -532,6 +538,7 @@ void Init_whisper() {
   rb_define_method(cParams, "max_text_tokens=", ruby_whisper_params_set_max_text_tokens, 1);
 
   rb_define_method(cParams, "new_segment_callback=", ruby_whisper_params_set_new_segment_callback, 1);
+  rb_define_method(cParams, "new_segment_callback_user_data=", ruby_whisper_params_set_new_segment_callback_user_data, 1);
 }
 #ifdef __cplusplus
 }

--- a/bindings/ruby/ext/ruby_whisper.cpp
+++ b/bindings/ruby/ext/ruby_whisper.cpp
@@ -262,6 +262,12 @@ static VALUE ruby_whisper_full_n_segments(VALUE self) {
   return INT2NUM(whisper_full_n_segments(rw->context));
 }
 
+static VALUE ruby_whisper_full_lang_id(VALUE self) {
+  ruby_whisper *rw;
+  Data_Get_Struct(self, ruby_whisper, rw);
+  return INT2NUM(whisper_full_lang_id(rw->context));
+}
+
 /*
  * params.language = "auto" | "en", etc...
  */
@@ -426,6 +432,7 @@ void Init_whisper() {
 
   rb_define_method(cContext, "transcribe", ruby_whisper_transcribe, -1);
   rb_define_method(cContext, "full_n_segments", ruby_whisper_full_n_segments, 0);
+  rb_define_method(cContext, "full_lang_id", ruby_whisper_full_lang_id, 0);
 
   rb_define_alloc_func(cParams, ruby_whisper_params_allocate);
 

--- a/bindings/ruby/ext/ruby_whisper.cpp
+++ b/bindings/ruby/ext/ruby_whisper.cpp
@@ -307,6 +307,14 @@ static VALUE ruby_whisper_full_get_segment_t1(VALUE self, VALUE i_segment) {
   return INT2NUM(t1);
 }
 
+static VALUE ruby_whisper_full_get_segment_speaker_turn_next(VALUE self, VALUE i_segment) {
+  ruby_whisper *rw;
+  Data_Get_Struct(self, ruby_whisper, rw);
+  const int c_i_segment = ruby_whisper_full_check_segment_index(rw, i_segment);
+  const bool speaker_turn_next = whisper_full_get_segment_speaker_turn_next(rw->context, c_i_segment);
+  return speaker_turn_next ? Qtrue : Qfalse;
+}
+
 /*
  * params.language = "auto" | "en", etc...
  */
@@ -474,6 +482,7 @@ void Init_whisper() {
   rb_define_method(cContext, "full_lang_id", ruby_whisper_full_lang_id, 0);
   rb_define_method(cContext, "full_get_segment_t0", ruby_whisper_full_get_segment_t0, 1);
   rb_define_method(cContext, "full_get_segment_t1", ruby_whisper_full_get_segment_t1, 1);
+  rb_define_method(cContext, "full_get_segment_speaker_turn_next", ruby_whisper_full_get_segment_speaker_turn_next, 1);
 
   rb_define_alloc_func(cParams, ruby_whisper_params_allocate);
 

--- a/bindings/ruby/ext/ruby_whisper.cpp
+++ b/bindings/ruby/ext/ruby_whisper.cpp
@@ -102,9 +102,14 @@ static VALUE ruby_whisper_allocate(VALUE klass) {
 
 static VALUE ruby_whisper_params_allocate(VALUE klass) {
   ruby_whisper_params *rwp;
+  ruby_whisper_callback_user_data *new_segment_callback_user_data;
   rwp = ALLOC(ruby_whisper_params);
   rwp->params = whisper_full_default_params(WHISPER_SAMPLING_GREEDY);
-  rwp->new_segment_callback = Qnil;
+  new_segment_callback_user_data = ALLOC(ruby_whisper_callback_user_data);
+  new_segment_callback_user_data->context = nullptr;
+  new_segment_callback_user_data->user_data = Qnil;
+  new_segment_callback_user_data->callback = Qnil;
+  rwp->new_segment_callback_user_data = new_segment_callback_user_data;
   return Data_Wrap_Struct(klass, rb_whisper_params_mark, rb_whisper_params_free, rwp);
 }
 
@@ -238,19 +243,16 @@ static VALUE ruby_whisper_transcribe(int argc, VALUE *argv, VALUE self) {
     rwp->params.encoder_begin_callback_user_data = &is_aborted;
   }
 
-  if (!NIL_P(rwp->new_segment_callback)) {
+  if (!NIL_P(rwp->new_segment_callback_user_data->callback)) {
     rwp->params.new_segment_callback = [](struct whisper_context * ctx, struct whisper_state * state, int n_new, void * user_data) {
-      ruby_whisper *rw;;
-      VALUE context = *(VALUE *)user_data;
-      Data_Get_Struct(context, ruby_whisper, rw);
-      VALUE callback = rw->new_segment_callback;
+      const ruby_whisper_callback_user_data *container = (ruby_whisper_callback_user_data *)user_data;
 
-      // Currently, doesn't support state and user_data because
+      // Currently, doesn't support state because
       // those require to resolve GC-related problems.
-      rb_funcall(callback, rb_intern("call"), 4, context, Qnil, INT2NUM(n_new), Qnil);
+      rb_funcall(container->callback, rb_intern("call"), 4, *container->context, Qnil, INT2NUM(n_new), container->user_data);
     };
-    rw->new_segment_callback = rwp->new_segment_callback;
-    rwp->params.new_segment_callback_user_data = &self;
+    rwp->new_segment_callback_user_data->context = &self;
+    rwp->params.new_segment_callback_user_data = rwp->new_segment_callback_user_data;
   }
 
   if (whisper_full_parallel(rw->context, rwp->params, pcmf32.data(), pcmf32.size(), 1) != 0) {
@@ -467,7 +469,7 @@ static VALUE ruby_whisper_params_set_max_text_tokens(VALUE self, VALUE value) {
 static VALUE ruby_whisper_params_set_new_segment_callback(VALUE self, VALUE value) {
   ruby_whisper_params *rwp;
   Data_Get_Struct(self, ruby_whisper_params, rwp);
-  rwp->new_segment_callback = value;
+  rwp->new_segment_callback_user_data->callback = value;
   return value;
 }
 

--- a/bindings/ruby/ext/ruby_whisper.cpp
+++ b/bindings/ruby/ext/ruby_whisper.cpp
@@ -315,6 +315,14 @@ static VALUE ruby_whisper_full_get_segment_speaker_turn_next(VALUE self, VALUE i
   return speaker_turn_next ? Qtrue : Qfalse;
 }
 
+static VALUE ruby_whisper_full_get_segment_text(VALUE self, VALUE i_segment) {
+  ruby_whisper *rw;
+  Data_Get_Struct(self, ruby_whisper, rw);
+  const int c_i_segment = ruby_whisper_full_check_segment_index(rw, i_segment);
+  const char * text = whisper_full_get_segment_text(rw->context, c_i_segment);
+  return rb_str_new2(text);
+}
+
 /*
  * params.language = "auto" | "en", etc...
  */
@@ -483,6 +491,7 @@ void Init_whisper() {
   rb_define_method(cContext, "full_get_segment_t0", ruby_whisper_full_get_segment_t0, 1);
   rb_define_method(cContext, "full_get_segment_t1", ruby_whisper_full_get_segment_t1, 1);
   rb_define_method(cContext, "full_get_segment_speaker_turn_next", ruby_whisper_full_get_segment_speaker_turn_next, 1);
+  rb_define_method(cContext, "full_get_segment_text", ruby_whisper_full_get_segment_text, 1);
 
   rb_define_alloc_func(cParams, ruby_whisper_params_allocate);
 

--- a/bindings/ruby/ext/ruby_whisper.cpp
+++ b/bindings/ruby/ext/ruby_whisper.cpp
@@ -240,18 +240,17 @@ static VALUE ruby_whisper_transcribe(int argc, VALUE *argv, VALUE self) {
 
   if (!NIL_P(rwp->new_segment_callback)) {
     rwp->params.new_segment_callback = [](struct whisper_context * ctx, struct whisper_state * state, int n_new, void * user_data) {
-      VALUE callback = *(VALUE *)user_data;
-      int n_segments = whisper_full_n_segments_from_state(state);
-      for (int i = n_new; i > 0; --i) {
-        const int i_segment = n_segments - i;
-        const char * text = whisper_full_get_segment_text_from_state(state, i_segment);
-        // Multiplying 10 shouldn't cause overflow because to_timestamp() in whisper.cpp does it
-        const int64_t t0 = whisper_full_get_segment_t0_from_state(state, i_segment) * 10;
-        const int64_t t1 = whisper_full_get_segment_t1_from_state(state, i_segment) * 10;
-        rb_funcall(callback, rb_intern("call"), 4, rb_str_new2(text), INT2NUM(t0), INT2NUM(t1), INT2FIX(i_segment));
-      }
+      ruby_whisper *rw;;
+      VALUE context = *(VALUE *)user_data;
+      Data_Get_Struct(context, ruby_whisper, rw);
+      VALUE callback = rw->new_segment_callback;
+
+      // Currently, doesn't support state and user_data because
+      // those require to resolve GC-related problems.
+      rb_funcall(callback, rb_intern("call"), 4, context, Qnil, INT2NUM(n_new), Qnil);
     };
-    rwp->params.new_segment_callback_user_data = &rwp->new_segment_callback;
+    rw->new_segment_callback = rwp->new_segment_callback;
+    rwp->params.new_segment_callback_user_data = &self;
   }
 
   if (whisper_full_parallel(rw->context, rwp->params, pcmf32.data(), pcmf32.size(), 1) != 0) {

--- a/bindings/ruby/ext/ruby_whisper.cpp
+++ b/bindings/ruby/ext/ruby_whisper.cpp
@@ -206,28 +206,24 @@ static VALUE ruby_whisper_transcribe(int argc, VALUE *argv, VALUE self) {
     };
     rwp->params.encoder_begin_callback_user_data = &is_aborted;
   }
-  {
-    // This cannot be used later because it is not incremented when new_segment_callback is not given.
-    static int n_segments = 0;
 
-    rwp->params.new_segment_callback = [](struct whisper_context * ctx, struct whisper_state * state, int n_new, void * user_data) {
-      VALUE callback = *(VALUE *)user_data;
-      if (NIL_P(callback)){
-        return;
-      }
+  rwp->params.new_segment_callback = [](struct whisper_context * ctx, struct whisper_state * state, int n_new, void * user_data) {
+    VALUE callback = *(VALUE *)user_data;
+    if (NIL_P(callback)){
+      return;
+    }
 
-      for (int i = 0; i < n_new; i++) {
-        const int i_segment = n_segments + i;
-        const char * text = whisper_full_get_segment_text_from_state(state, i_segment);
-        // Multiplying 10 shouldn't cause overflow because to_timestamp() in whisper.cpp does it
-        const int64_t t0 = whisper_full_get_segment_t0_from_state(state, i_segment) * 10;
-        const int64_t t1 = whisper_full_get_segment_t1_from_state(state, i_segment) * 10;
-        rb_funcall(callback, rb_intern("call"), 4, rb_str_new2(text), INT2NUM(t0), INT2NUM(t1), INT2FIX(i_segment));
-      }
-      n_segments += n_new;
-    };
-    rwp->params.new_segment_callback_user_data = &rwp->new_segment_callback;
-  }
+    int n_segments = whisper_full_n_segments_from_state(state);
+    for (int i = n_new; i > 0; --i) {
+      const int i_segment = n_segments - i;
+      const char * text = whisper_full_get_segment_text_from_state(state, i_segment);
+      // Multiplying 10 shouldn't cause overflow because to_timestamp() in whisper.cpp does it
+      const int64_t t0 = whisper_full_get_segment_t0_from_state(state, i_segment) * 10;
+      const int64_t t1 = whisper_full_get_segment_t1_from_state(state, i_segment) * 10;
+      rb_funcall(callback, rb_intern("call"), 4, rb_str_new2(text), INT2NUM(t0), INT2NUM(t1), INT2FIX(i_segment));
+    }
+  };
+  rwp->params.new_segment_callback_user_data = &rwp->new_segment_callback;
 
   if (whisper_full_parallel(rw->context, rwp->params, pcmf32.data(), pcmf32.size(), 1) != 0) {
     fprintf(stderr, "failed to process audio\n");

--- a/bindings/ruby/ext/ruby_whisper.cpp
+++ b/bindings/ruby/ext/ruby_whisper.cpp
@@ -210,10 +210,6 @@ static VALUE ruby_whisper_transcribe(int argc, VALUE *argv, VALUE self) {
   if (!NIL_P(rwp->new_segment_callback)) {
     rwp->params.new_segment_callback = [](struct whisper_context * ctx, struct whisper_state * state, int n_new, void * user_data) {
       VALUE callback = *(VALUE *)user_data;
-      if (NIL_P(callback)){
-        return;
-      }
-
       int n_segments = whisper_full_n_segments_from_state(state);
       for (int i = n_new; i > 0; --i) {
         const int i_segment = n_segments - i;

--- a/bindings/ruby/ext/ruby_whisper.cpp
+++ b/bindings/ruby/ext/ruby_whisper.cpp
@@ -36,6 +36,22 @@ VALUE mWhisper;
 VALUE cContext;
 VALUE cParams;
 
+static VALUE ruby_whisper_s_lang_max_id(VALUE self) {
+  return INT2NUM(whisper_lang_max_id());
+}
+
+static VALUE ruby_whisper_s_lang_id(VALUE self, VALUE lang) {
+  return INT2NUM(whisper_lang_id(StringValueCStr(lang)));
+}
+
+static VALUE ruby_whisper_s_lang_str(VALUE self, VALUE id) {
+  return rb_str_new2(whisper_lang_str(NUM2INT(id)));
+}
+
+static VALUE ruby_whisper_s_lang_str_full(VALUE self, VALUE id) {
+  return rb_str_new2(whisper_lang_str_full(NUM2INT(id)));
+}
+
 static void ruby_whisper_free(ruby_whisper *rw) {
   if (rw->context) {
     whisper_free(rw->context);
@@ -399,6 +415,11 @@ void Init_whisper() {
   mWhisper = rb_define_module("Whisper");
   cContext = rb_define_class_under(mWhisper, "Context", rb_cObject);
   cParams  = rb_define_class_under(mWhisper, "Params", rb_cObject);
+
+  rb_define_singleton_method(mWhisper, "lang_max_id", ruby_whisper_s_lang_max_id, 0);
+  rb_define_singleton_method(mWhisper, "lang_id", ruby_whisper_s_lang_id, 1);
+  rb_define_singleton_method(mWhisper, "lang_str", ruby_whisper_s_lang_str, 1);
+  rb_define_singleton_method(mWhisper, "lang_str_full", ruby_whisper_s_lang_str_full, 1);
 
   rb_define_alloc_func(cContext, ruby_whisper_allocate);
   rb_define_method(cContext, "initialize", ruby_whisper_initialize, -1);

--- a/bindings/ruby/ext/ruby_whisper.cpp
+++ b/bindings/ruby/ext/ruby_whisper.cpp
@@ -283,6 +283,30 @@ static VALUE ruby_whisper_full_lang_id(VALUE self) {
   return INT2NUM(whisper_full_lang_id(rw->context));
 }
 
+static int ruby_whisper_full_check_segment_index(const ruby_whisper * rw, const VALUE i_segment) {
+  const int c_i_segment = NUM2INT(i_segment);
+  if (c_i_segment < 0 || c_i_segment >= whisper_full_n_segments(rw->context)) {
+    rb_raise(rb_eIndexError, "segment index %d out of range", c_i_segment);
+  }
+  return c_i_segment;
+}
+
+static VALUE ruby_whisper_full_get_segment_t0(VALUE self, VALUE i_segment) {
+  ruby_whisper *rw;
+  Data_Get_Struct(self, ruby_whisper, rw);
+  const int c_i_segment = ruby_whisper_full_check_segment_index(rw, i_segment);
+  const int64_t t0 = whisper_full_get_segment_t0(rw->context, c_i_segment);
+  return INT2NUM(t0);
+}
+
+static VALUE ruby_whisper_full_get_segment_t1(VALUE self, VALUE i_segment) {
+  ruby_whisper *rw;
+  Data_Get_Struct(self, ruby_whisper, rw);
+  const int c_i_segment = ruby_whisper_full_check_segment_index(rw, i_segment);
+  const int64_t t1 = whisper_full_get_segment_t1(rw->context, c_i_segment);
+  return INT2NUM(t1);
+}
+
 /*
  * params.language = "auto" | "en", etc...
  */
@@ -448,6 +472,8 @@ void Init_whisper() {
   rb_define_method(cContext, "transcribe", ruby_whisper_transcribe, -1);
   rb_define_method(cContext, "full_n_segments", ruby_whisper_full_n_segments, 0);
   rb_define_method(cContext, "full_lang_id", ruby_whisper_full_lang_id, 0);
+  rb_define_method(cContext, "full_get_segment_t0", ruby_whisper_full_get_segment_t0, 1);
+  rb_define_method(cContext, "full_get_segment_t1", ruby_whisper_full_get_segment_t1, 1);
 
   rb_define_alloc_func(cParams, ruby_whisper_params_allocate);
 

--- a/bindings/ruby/ext/ruby_whisper.cpp
+++ b/bindings/ruby/ext/ruby_whisper.cpp
@@ -240,6 +240,12 @@ static VALUE ruby_whisper_transcribe(int argc, VALUE *argv, VALUE self) {
   return self;
 }
 
+static VALUE ruby_whisper_full_n_segments(VALUE self) {
+  ruby_whisper *rw;
+  Data_Get_Struct(self, ruby_whisper, rw);
+  return INT2NUM(whisper_full_n_segments(rw->context));
+}
+
 /*
  * params.language = "auto" | "en", etc...
  */
@@ -398,6 +404,7 @@ void Init_whisper() {
   rb_define_method(cContext, "initialize", ruby_whisper_initialize, -1);
 
   rb_define_method(cContext, "transcribe", ruby_whisper_transcribe, -1);
+  rb_define_method(cContext, "full_n_segments", ruby_whisper_full_n_segments, 0);
 
   rb_define_alloc_func(cParams, ruby_whisper_params_allocate);
 

--- a/bindings/ruby/ext/ruby_whisper.h
+++ b/bindings/ruby/ext/ruby_whisper.h
@@ -4,14 +4,19 @@
 #include "whisper.h"
 
 typedef struct {
+  VALUE *context;
+  VALUE user_data;
+  VALUE callback;
+} ruby_whisper_callback_user_data;
+
+typedef struct {
   struct whisper_context *context;
-  VALUE new_segment_callback;
 } ruby_whisper;
 
 typedef struct {
   struct whisper_full_params params;
   bool diarize;
-  VALUE new_segment_callback;
+  ruby_whisper_callback_user_data *new_segment_callback_user_data;
 } ruby_whisper_params;
 
 #endif

--- a/bindings/ruby/ext/ruby_whisper.h
+++ b/bindings/ruby/ext/ruby_whisper.h
@@ -10,6 +10,7 @@ typedef struct {
 typedef struct {
   struct whisper_full_params params;
   bool diarize;
+  VALUE new_segment_callback;
 } ruby_whisper_params;
 
 #endif

--- a/bindings/ruby/ext/ruby_whisper.h
+++ b/bindings/ruby/ext/ruby_whisper.h
@@ -5,6 +5,7 @@
 
 typedef struct {
   struct whisper_context *context;
+  VALUE new_segment_callback;
 } ruby_whisper;
 
 typedef struct {

--- a/bindings/ruby/extsources.yaml
+++ b/bindings/ruby/extsources.yaml
@@ -27,6 +27,4 @@
 ../../examples:
 - ext/dr_wav.h
 ../..:
-- README.md
 - LICENSE
-

--- a/bindings/ruby/tests/test_callback.rb
+++ b/bindings/ruby/tests/test_callback.rb
@@ -1,0 +1,56 @@
+require "test/unit"
+require "whisper"
+
+class TestCallback < Test::Unit::TestCase
+  TOPDIR = File.expand_path(File.join(File.dirname(__FILE__), '..'))
+
+  def setup
+    @params = Whisper::Params.new
+    @whisper = Whisper::Context.new(File.join(TOPDIR, '..', '..', 'models', 'ggml-base.en.bin'))
+    @audio = File.join(TOPDIR, '..', '..', 'samples', 'jfk.wav')
+  end
+
+  def test_new_segment_callback
+    @params.new_segment_callback = ->(context, state, n_new, user_data) {
+      assert_kind_of Integer, n_new
+      assert n_new > 0
+      assert_same @whisper, context
+
+      n_segments = context.full_n_segments
+      n_new.times do |i|
+        i_segment = n_segments - 1 + i
+        start_time = context.full_get_segment_t0(i_segment) * 10
+        end_time = context.full_get_segment_t1(i_segment) * 10
+        text = context.full_get_segment_text(i_segment)
+
+        assert_kind_of Integer, start_time
+        assert start_time >= 0
+        assert_kind_of Integer, end_time
+        assert end_time > 0
+        assert_match /ask not what your country can do for you, ask what you can do for your country/, text if i_segment == 0
+      end
+    }
+
+    @whisper.transcribe(@audio, @params)
+  end
+
+  def test_new_segment_callback_closure
+    search_word = "what"
+    @params.new_segment_callback = ->(context, state, n_new, user_data) {
+      n_segments = context.full_n_segments
+      n_new.times do |i|
+        i_segment = n_segments - 1 + i
+        text = context.full_get_segment_text(i_segment)
+        if text.include?(search_word)
+          t0 = context.full_get_segment_t0(i_segment)
+          t1 = context.full_get_segment_t1(i_segment)
+          raise "search word '#{search_word}' found at between #{t0} and #{t1}"
+        end
+      end
+    }
+
+    assert_raise RuntimeError do
+      @whisper.transcribe(@audio, @params)
+    end
+  end
+end

--- a/bindings/ruby/tests/test_callback.rb
+++ b/bindings/ruby/tests/test_callback.rb
@@ -63,4 +63,14 @@ class TestCallback < Test::Unit::TestCase
 
     @whisper.transcribe(@audio, @params)
   end
+
+  def test_new_segment_callback_user_data_gc
+    @params.new_segment_callback_user_data = "My user data"
+    @params.new_segment_callback = ->(context, state, n_new, user_data) {
+      assert_equal "My user data", user_data
+    }
+    GC.start
+
+    assert_same @whisper, @whisper.transcribe(@audio, @params)
+  end
 end

--- a/bindings/ruby/tests/test_callback.rb
+++ b/bindings/ruby/tests/test_callback.rb
@@ -53,4 +53,14 @@ class TestCallback < Test::Unit::TestCase
       @whisper.transcribe(@audio, @params)
     end
   end
+
+  def test_new_segment_callback_user_data
+    udata = Object.new
+    @params.new_segment_callback_user_data = udata
+    @params.new_segment_callback = ->(context, state, n_new, user_data) {
+      assert_same udata, user_data
+    }
+
+    @whisper.transcribe(@audio, @params)
+  end
 end

--- a/bindings/ruby/tests/test_package.rb
+++ b/bindings/ruby/tests/test_package.rb
@@ -1,0 +1,28 @@
+require 'test/unit'
+require 'tempfile'
+require 'tmpdir'
+require 'shellwords'
+
+class TestPackage < Test::Unit::TestCase
+  def test_build
+    Tempfile.create do |file|
+      assert system("gem", "build", "whispercpp.gemspec", "--output", file.to_path.shellescape, exception: true)
+      assert_path_exist file.to_path
+    end
+  end
+
+  sub_test_case "Building binary on installation" do
+    def setup
+      system "rake", "build", exception: true
+    end
+
+    def test_install
+      filename = `rake -Tbuild`.match(/(whispercpp-(?:.+)\.gem)/)[1]
+      basename = "whisper.#{RbConfig::CONFIG["DLEXT"]}"
+      Dir.mktmpdir do |dir|
+        system "gem", "install", "--install-dir", dir.shellescape, "pkg/#{filename.shellescape}", exception: true
+        assert_path_exist File.join(dir, "gems/whispercpp-1.3.0/lib", basename)
+      end
+    end
+  end
+end

--- a/bindings/ruby/tests/test_params.rb
+++ b/bindings/ruby/tests/test_params.rb
@@ -1,0 +1,112 @@
+require 'whisper'
+
+class TestParams < Test::Unit::TestCase
+  def setup
+    @params  = Whisper::Params.new
+  end
+
+  def test_language
+    @params.language = "en"
+    assert_equal @params.language, "en"
+    @params.language = "auto"
+    assert_equal @params.language, "auto"
+  end
+
+  def test_offset
+    @params.offset = 10_000
+    assert_equal @params.offset, 10_000
+    @params.offset = 0
+    assert_equal @params.offset, 0
+  end
+
+  def test_duration
+    @params.duration = 60_000
+    assert_equal @params.duration, 60_000
+    @params.duration = 0
+    assert_equal @params.duration, 0
+  end
+
+  def test_max_text_tokens
+    @params.max_text_tokens = 300
+    assert_equal @params.max_text_tokens, 300
+    @params.max_text_tokens = 0
+    assert_equal @params.max_text_tokens, 0
+  end
+
+  def test_translate
+    @params.translate = true
+    assert @params.translate
+    @params.translate = false
+    assert !@params.translate
+  end
+
+  def test_no_context
+    @params.no_context = true
+    assert @params.no_context
+    @params.no_context = false
+    assert !@params.no_context
+  end
+
+  def test_single_segment
+    @params.single_segment = true
+    assert @params.single_segment
+    @params.single_segment = false
+    assert !@params.single_segment
+  end
+
+  def test_print_special
+    @params.print_special = true
+    assert @params.print_special
+    @params.print_special = false
+    assert !@params.print_special
+  end
+
+  def test_print_progress
+    @params.print_progress = true
+    assert @params.print_progress
+    @params.print_progress = false
+    assert !@params.print_progress
+  end
+
+  def test_print_realtime
+    @params.print_realtime = true
+    assert @params.print_realtime
+    @params.print_realtime = false
+    assert !@params.print_realtime
+  end
+
+  def test_print_timestamps
+    @params.print_timestamps = true
+    assert @params.print_timestamps
+    @params.print_timestamps = false
+    assert !@params.print_timestamps
+  end
+
+  def test_suppress_blank
+    @params.suppress_blank = true
+    assert @params.suppress_blank
+    @params.suppress_blank = false
+    assert !@params.suppress_blank
+  end
+
+  def test_suppress_non_speech_tokens
+    @params.suppress_non_speech_tokens = true
+    assert @params.suppress_non_speech_tokens
+    @params.suppress_non_speech_tokens = false
+    assert !@params.suppress_non_speech_tokens
+  end
+
+  def test_token_timestamps
+    @params.token_timestamps = true
+    assert @params.token_timestamps
+    @params.token_timestamps = false
+    assert !@params.token_timestamps
+  end
+
+  def test_split_on_word
+    @params.split_on_word = true
+    assert @params.split_on_word
+    @params.split_on_word = false
+    assert !@params.split_on_word
+  end
+end

--- a/bindings/ruby/tests/test_whisper.rb
+++ b/bindings/ruby/tests/test_whisper.rb
@@ -149,6 +149,22 @@ class TestWhisper < Test::Unit::TestCase
     end
   end
 
+  def test_lang_max_id
+    assert_kind_of Integer, Whisper.lang_max_id
+  end
+
+  def test_lang_id
+    assert_equal 0, Whisper.lang_id("en")
+  end
+
+  def test_lang_str
+    assert_equal "en", Whisper.lang_str(0)
+  end
+
+  def test_lang_str_full
+    assert_equal "english", Whisper.lang_str_full(0)
+  end
+
   def test_build
     Tempfile.create do |file|
       assert system("gem", "build", "whispercpp.gemspec", "--output", file.to_path.shellescape, exception: true)

--- a/bindings/ruby/tests/test_whisper.rb
+++ b/bindings/ruby/tests/test_whisper.rb
@@ -159,14 +159,23 @@ class TestWhisper < Test::Unit::TestCase
 
   def test_lang_id
     assert_equal 0, Whisper.lang_id("en")
+    assert_raise ArgumentError do
+      Whisper.lang_id("non existing language")
+    end
   end
 
   def test_lang_str
     assert_equal "en", Whisper.lang_str(0)
+    assert_raise IndexError do
+      Whisper.lang_str(Whisper.lang_max_id + 1)
+    end
   end
 
   def test_lang_str_full
     assert_equal "english", Whisper.lang_str_full(0)
+    assert_raise IndexError do
+      Whisper.lang_str_full(Whisper.lang_max_id + 1)
+    end
   end
 
   def test_build

--- a/bindings/ruby/tests/test_whisper.rb
+++ b/bindings/ruby/tests/test_whisper.rb
@@ -174,6 +174,10 @@ class TestWhisper < Test::Unit::TestCase
     def test_full_get_segment_speaker_turn_next
       assert_false whisper.full_get_segment_speaker_turn_next(0)
     end
+
+    def test_full_get_segment_text
+      assert_match /ask not what your country can do for you, ask what you can do for your country/, whisper.full_get_segment_text(0)
+    end
   end
 
   def test_lang_max_id

--- a/bindings/ruby/tests/test_whisper.rb
+++ b/bindings/ruby/tests/test_whisper.rb
@@ -116,38 +116,38 @@ class TestWhisper < Test::Unit::TestCase
     assert !@params.split_on_word
   end
 
-  sub_test_case "#transcribe" do
-    def setup
-      @whisper = Whisper::Context.new(File.join(TOPDIR, '..', '..', 'models', 'ggml-base.en.bin'))
-      @params  = Whisper::Params.new
-      @params.print_timestamps = false
-      @jfk = File.join(TOPDIR, '..', '..', 'samples', 'jfk.wav')
-    end
+  def test_whisper
+    @whisper = Whisper::Context.new(File.join(TOPDIR, '..', '..', 'models', 'ggml-base.en.bin'))
+    params  = Whisper::Params.new
+    params.print_timestamps = false
 
-    def test_whisper
-      @whisper.transcribe(@jfk, @params) {|text|
-        assert_match /ask not what your country can do for you, ask what you can do for your country/, text
-      }
-    end
+    jfk = File.join(TOPDIR, '..', '..', 'samples', 'jfk.wav')
+    @whisper.transcribe(jfk, params) {|text|
+      assert_match /ask not what your country can do for you, ask what you can do for your country/, text
+    }
+  end
 
-    def test_new_segment_callback_lambda
-      counter = 0
-      @params.new_segment_callback = ->(text, start_time, end_time, index) {
-        assert_kind_of String, text
-        assert_kind_of Integer, start_time
-        assert_kind_of Integer, end_time
-        assert_same index, counter
-        counter += 1
-      }
-      @whisper.transcribe(@jfk, @params)
-    end
+  def test_new_segment_callback_lambda
+    counter = 0
+    @params.new_segment_callback = ->(text, start_time, end_time, index) {
+      assert_kind_of String, text
+      assert_kind_of Integer, start_time
+      assert_kind_of Integer, end_time
+      assert_same index, counter
+      counter += 1
+    }
+    whisper = Whisper::Context.new(File.join(TOPDIR, '..', '..', 'models', 'ggml-base.en.bin'))
+    jfk = File.join(TOPDIR, '..', '..', 'samples', 'jfk.wav')
+    whisper.transcribe(jfk, @params)
+  end
 
-    def test_new_segment_callback_proc
-      @params.new_segment_callback = proc {|text| # proc checks arguments loosly
-        assert_kind_of String, text
-      }
-      @whisper.transcribe(@jfk, @params)
-    end
+  def test_new_segment_callback_proc
+    @params.new_segment_callback = proc {|text| # proc checks arguments loosly
+      assert_kind_of String, text
+    }
+    whisper = Whisper::Context.new(File.join(TOPDIR, '..', '..', 'models', 'ggml-base.en.bin'))
+    jfk = File.join(TOPDIR, '..', '..', 'samples', 'jfk.wav')
+    whisper.transcribe(jfk, @params)
   end
 
   def test_build

--- a/bindings/ruby/tests/test_whisper.rb
+++ b/bindings/ruby/tests/test_whisper.rb
@@ -116,38 +116,38 @@ class TestWhisper < Test::Unit::TestCase
     assert !@params.split_on_word
   end
 
-  def test_whisper
-    @whisper = Whisper::Context.new(File.join(TOPDIR, '..', '..', 'models', 'ggml-base.en.bin'))
-    params  = Whisper::Params.new
-    params.print_timestamps = false
+  sub_test_case "#transcribe" do
+    def setup
+      @whisper = Whisper::Context.new(File.join(TOPDIR, '..', '..', 'models', 'ggml-base.en.bin'))
+      @params  = Whisper::Params.new
+      @params.print_timestamps = false
+      @jfk = File.join(TOPDIR, '..', '..', 'samples', 'jfk.wav')
+    end
 
-    jfk = File.join(TOPDIR, '..', '..', 'samples', 'jfk.wav')
-    @whisper.transcribe(jfk, params) {|text|
-      assert_match /ask not what your country can do for you, ask what you can do for your country/, text
-    }
-  end
+    def test_whisper
+      @whisper.transcribe(@jfk, @params) {|text|
+        assert_match /ask not what your country can do for you, ask what you can do for your country/, text
+      }
+    end
 
-  def test_new_segment_callback_lambda
-    counter = 0
-    @params.new_segment_callback = ->(text, start_time, end_time, index) {
-      assert_kind_of String, text
-      assert_kind_of Integer, start_time
-      assert_kind_of Integer, end_time
-      assert_same index, counter
-      counter += 1
-    }
-    whisper = Whisper::Context.new(File.join(TOPDIR, '..', '..', 'models', 'ggml-base.en.bin'))
-    jfk = File.join(TOPDIR, '..', '..', 'samples', 'jfk.wav')
-    whisper.transcribe(jfk, @params)
-  end
+    def test_new_segment_callback_lambda
+      counter = 0
+      @params.new_segment_callback = ->(text, start_time, end_time, index) {
+        assert_kind_of String, text
+        assert_kind_of Integer, start_time
+        assert_kind_of Integer, end_time
+        assert_same index, counter
+        counter += 1
+      }
+      @whisper.transcribe(@jfk, @params)
+    end
 
-  def test_new_segment_callback_proc
-    @params.new_segment_callback = proc {|text| # proc checks arguments loosly
-      assert_kind_of String, text
-    }
-    whisper = Whisper::Context.new(File.join(TOPDIR, '..', '..', 'models', 'ggml-base.en.bin'))
-    jfk = File.join(TOPDIR, '..', '..', 'samples', 'jfk.wav')
-    whisper.transcribe(jfk, @params)
+    def test_new_segment_callback_proc
+      @params.new_segment_callback = proc {|text| # proc checks arguments loosly
+        assert_kind_of String, text
+      }
+      @whisper.transcribe(@jfk, @params)
+    end
   end
 
   def test_build

--- a/bindings/ruby/tests/test_whisper.rb
+++ b/bindings/ruby/tests/test_whisper.rb
@@ -147,6 +147,10 @@ class TestWhisper < Test::Unit::TestCase
     def test_full_n_segments
       assert_equal 1, whisper.full_n_segments
     end
+
+    def test_full_lang_id
+      assert_equal 0, whisper.full_lang_id
+    end
   end
 
   def test_lang_max_id

--- a/bindings/ruby/tests/test_whisper.rb
+++ b/bindings/ruby/tests/test_whisper.rb
@@ -127,6 +127,29 @@ class TestWhisper < Test::Unit::TestCase
     }
   end
 
+  def test_new_segment_callback_lambda
+    counter = 0
+    @params.new_segment_callback = ->(text, start_time, end_time, index) {
+      assert_kind_of String, text
+      assert_kind_of Integer, start_time
+      assert_kind_of Integer, end_time
+      assert_same index, counter
+      counter += 1
+    }
+    whisper = Whisper::Context.new(File.join(TOPDIR, '..', '..', 'models', 'ggml-base.en.bin'))
+    jfk = File.join(TOPDIR, '..', '..', 'samples', 'jfk.wav')
+    whisper.transcribe(jfk, @params)
+  end
+
+  def test_new_segment_callback_proc
+    @params.new_segment_callback = proc {|text| # proc checks arguments loosly
+      assert_kind_of String, text
+    }
+    whisper = Whisper::Context.new(File.join(TOPDIR, '..', '..', 'models', 'ggml-base.en.bin'))
+    jfk = File.join(TOPDIR, '..', '..', 'samples', 'jfk.wav')
+    whisper.transcribe(jfk, @params)
+  end
+
   def test_build
     Tempfile.create do |file|
       assert system("gem", "build", "whispercpp.gemspec", "--output", file.to_path.shellescape, exception: true)

--- a/bindings/ruby/tests/test_whisper.rb
+++ b/bindings/ruby/tests/test_whisper.rb
@@ -151,6 +151,25 @@ class TestWhisper < Test::Unit::TestCase
     def test_full_lang_id
       assert_equal 0, whisper.full_lang_id
     end
+
+    def test_full_get_segment_t0
+      assert_equal 0, whisper.full_get_segment_t0(0)
+      assert_raise IndexError do
+        whisper.full_get_segment_t0(whisper.full_n_segments)
+      end
+      assert_raise IndexError do
+        whisper.full_get_segment_t0(-1)
+      end
+    end
+
+    def test_full_get_segment_t1
+      t1 = whisper.full_get_segment_t1(0)
+      assert_kind_of Integer, t1
+      assert t1 > 0
+      assert_raise IndexError do
+        whisper.full_get_segment_t1(whisper.full_n_segments)
+      end
+    end
   end
 
   def test_lang_max_id

--- a/bindings/ruby/tests/test_whisper.rb
+++ b/bindings/ruby/tests/test_whisper.rb
@@ -127,6 +127,28 @@ class TestWhisper < Test::Unit::TestCase
     }
   end
 
+  sub_test_case "After transcription" do
+    class << self
+      attr_reader :whisper
+
+      def startup
+        @whisper = Whisper::Context.new(File.join(TOPDIR, '..', '..', 'models', 'ggml-base.en.bin'))
+        params = Whisper::Params.new
+        params.print_timestamps = false
+        jfk = File.join(TOPDIR, '..', '..', 'samples', 'jfk.wav')
+        @whisper.transcribe(jfk, params)
+      end
+    end
+
+    def whisper
+      self.class.whisper
+    end
+
+    def test_full_n_segments
+      assert_equal 1, whisper.full_n_segments
+    end
+  end
+
   def test_build
     Tempfile.create do |file|
       assert system("gem", "build", "whispercpp.gemspec", "--output", file.to_path.shellescape, exception: true)

--- a/bindings/ruby/tests/test_whisper.rb
+++ b/bindings/ruby/tests/test_whisper.rb
@@ -1,119 +1,11 @@
-TOPDIR = File.expand_path(File.join(File.dirname(__FILE__), '..'))
-
 require 'whisper'
 require 'test/unit'
-require 'tempfile'
-require 'tmpdir'
-require 'shellwords'
 
 class TestWhisper < Test::Unit::TestCase
+  TOPDIR = File.expand_path(File.join(File.dirname(__FILE__), '..'))
+
   def setup
     @params  = Whisper::Params.new
-  end
-
-  def test_language
-    @params.language = "en"
-    assert_equal @params.language, "en"
-    @params.language = "auto"
-    assert_equal @params.language, "auto"
-  end
-
-  def test_offset
-    @params.offset = 10_000
-    assert_equal @params.offset, 10_000
-    @params.offset = 0
-    assert_equal @params.offset, 0
-  end
-
-  def test_duration
-    @params.duration = 60_000
-    assert_equal @params.duration, 60_000
-    @params.duration = 0
-    assert_equal @params.duration, 0
-  end
-
-  def test_max_text_tokens
-    @params.max_text_tokens = 300
-    assert_equal @params.max_text_tokens, 300
-    @params.max_text_tokens = 0
-    assert_equal @params.max_text_tokens, 0
-  end
-
-  def test_translate
-    @params.translate = true
-    assert @params.translate
-    @params.translate = false
-    assert !@params.translate
-  end
-
-  def test_no_context
-    @params.no_context = true
-    assert @params.no_context
-    @params.no_context = false
-    assert !@params.no_context
-  end
-
-  def test_single_segment
-    @params.single_segment = true
-    assert @params.single_segment
-    @params.single_segment = false
-    assert !@params.single_segment
-  end
-
-  def test_print_special
-    @params.print_special = true
-    assert @params.print_special
-    @params.print_special = false
-    assert !@params.print_special
-  end
-
-  def test_print_progress
-    @params.print_progress = true
-    assert @params.print_progress
-    @params.print_progress = false
-    assert !@params.print_progress
-  end
-
-  def test_print_realtime
-    @params.print_realtime = true
-    assert @params.print_realtime
-    @params.print_realtime = false
-    assert !@params.print_realtime
-  end
-
-  def test_print_timestamps
-    @params.print_timestamps = true
-    assert @params.print_timestamps
-    @params.print_timestamps = false
-    assert !@params.print_timestamps
-  end
-
-  def test_suppress_blank
-    @params.suppress_blank = true
-    assert @params.suppress_blank
-    @params.suppress_blank = false
-    assert !@params.suppress_blank
-  end
-
-  def test_suppress_non_speech_tokens
-    @params.suppress_non_speech_tokens = true
-    assert @params.suppress_non_speech_tokens
-    @params.suppress_non_speech_tokens = false
-    assert !@params.suppress_non_speech_tokens
-  end
-
-  def test_token_timestamps
-    @params.token_timestamps = true
-    assert @params.token_timestamps
-    @params.token_timestamps = false
-    assert !@params.token_timestamps
-  end
-
-  def test_split_on_word
-    @params.split_on_word = true
-    assert @params.split_on_word
-    @params.split_on_word = false
-    assert !@params.split_on_word
   end
 
   def test_whisper
@@ -125,56 +17,6 @@ class TestWhisper < Test::Unit::TestCase
     @whisper.transcribe(jfk, params) {|text|
       assert_match /ask not what your country can do for you, ask what you can do for your country/, text
     }
-  end
-
-  def test_new_segment_callback
-    whisper = Whisper::Context.new(File.join(TOPDIR, '..', '..', 'models', 'ggml-base.en.bin'))
-
-    @params.new_segment_callback = ->(context, state, n_new, user_data) {
-      assert_kind_of Integer, n_new
-      assert n_new > 0
-      assert_same whisper, context
-
-      n_segments = context.full_n_segments
-      n_new.times do |i|
-        i_segment = n_segments - 1 + i
-        start_time = context.full_get_segment_t0(i_segment) * 10
-        end_time = context.full_get_segment_t1(i_segment) * 10
-        text = context.full_get_segment_text(i_segment)
-
-        assert_kind_of Integer, start_time
-        assert start_time >= 0
-        assert_kind_of Integer, end_time
-        assert end_time > 0
-        assert_match /ask not what your country can do for you, ask what you can do for your country/, text if i_segment == 0
-      end
-    }
-
-    jfk = File.join(TOPDIR, '..', '..', 'samples', 'jfk.wav')
-    whisper.transcribe(jfk, @params)
-  end
-
-  def test_new_segment_callback_closure
-    whisper = Whisper::Context.new(File.join(TOPDIR, '..', '..', 'models', 'ggml-base.en.bin'))
-
-    search_word = "what"
-    @params.new_segment_callback = ->(context, state, n_new, user_data) {
-      n_segments = context.full_n_segments
-      n_new.times do |i|
-        i_segment = n_segments - 1 + i
-        text = context.full_get_segment_text(i_segment)
-        if text.include?(search_word)
-          t0 = context.full_get_segment_t0(i_segment)
-          t1 = context.full_get_segment_t1(i_segment)
-          raise "search word '#{search_word}' found at between #{t0} and #{t1}"
-        end
-      end
-    }
-
-    jfk = File.join(TOPDIR, '..', '..', 'samples', 'jfk.wav')
-    assert_raise RuntimeError do
-      whisper.transcribe(jfk, @params)
-    end
   end
 
   sub_test_case "After transcription" do
@@ -252,28 +94,6 @@ class TestWhisper < Test::Unit::TestCase
     assert_equal "english", Whisper.lang_str_full(0)
     assert_raise IndexError do
       Whisper.lang_str_full(Whisper.lang_max_id + 1)
-    end
-  end
-
-  def test_build
-    Tempfile.create do |file|
-      assert system("gem", "build", "whispercpp.gemspec", "--output", file.to_path.shellescape, exception: true)
-      assert_path_exist file.to_path
-    end
-  end
-
-  sub_test_case "Building binary on installation" do
-    def setup
-      system "rake", "build", exception: true
-    end
-
-    def test_install
-      filename = `rake -Tbuild`.match(/(whispercpp-(?:.+)\.gem)/)[1]
-      basename = "whisper.#{RbConfig::CONFIG["DLEXT"]}"
-      Dir.mktmpdir do |dir|
-        system "gem", "install", "--install-dir", dir.shellescape, "pkg/#{filename.shellescape}", exception: true
-        assert_path_exist File.join(dir, "gems/whispercpp-1.3.0/lib", basename)
-      end
     end
   end
 end

--- a/bindings/ruby/tests/test_whisper.rb
+++ b/bindings/ruby/tests/test_whisper.rb
@@ -127,29 +127,6 @@ class TestWhisper < Test::Unit::TestCase
     }
   end
 
-  def test_new_segment_callback_lambda
-    counter = 0
-    @params.new_segment_callback = ->(text, start_time, end_time, index) {
-      assert_kind_of String, text
-      assert_kind_of Integer, start_time
-      assert_kind_of Integer, end_time
-      assert_same index, counter
-      counter += 1
-    }
-    whisper = Whisper::Context.new(File.join(TOPDIR, '..', '..', 'models', 'ggml-base.en.bin'))
-    jfk = File.join(TOPDIR, '..', '..', 'samples', 'jfk.wav')
-    whisper.transcribe(jfk, @params)
-  end
-
-  def test_new_segment_callback_proc
-    @params.new_segment_callback = proc {|text| # proc checks arguments loosly
-      assert_kind_of String, text
-    }
-    whisper = Whisper::Context.new(File.join(TOPDIR, '..', '..', 'models', 'ggml-base.en.bin'))
-    jfk = File.join(TOPDIR, '..', '..', 'samples', 'jfk.wav')
-    whisper.transcribe(jfk, @params)
-  end
-
   def test_build
     Tempfile.create do |file|
       assert system("gem", "build", "whispercpp.gemspec", "--output", file.to_path.shellescape, exception: true)

--- a/bindings/ruby/tests/test_whisper.rb
+++ b/bindings/ruby/tests/test_whisper.rb
@@ -170,6 +170,10 @@ class TestWhisper < Test::Unit::TestCase
         whisper.full_get_segment_t1(whisper.full_n_segments)
       end
     end
+
+    def test_full_get_segment_speaker_turn_next
+      assert_false whisper.full_get_segment_speaker_turn_next(0)
+    end
   end
 
   def test_lang_max_id


### PR DESCRIPTION
I added new segment callback to Ruby binding.

By this patch, we can set new segment callback which is called on every segment.

```ruby
whisper = Whisper::Context.new("path/to/model.bin")
params = Whisper::Params.new
params.new_segment_callback = ->(text, start_time, end_time, index) {
  puts "[#{start_time}ms --> #{end_time}ms] #{index}th segment: #{text}"
}
whisper.transcribe "path/to/audio", params

```

It can abort by some condition without waiting for transcription complete:

```ruby
search_word = "A_WORD_I_WANT_TO_FIND"
params.new_segment_callback = ->(text, start_time, end_time, index) {
  if text.match? search_word
    puts "#{search_word} found at between #{start_time}ms and #{end_time}ms"
    raise # an exception stops transcription
  end
}

```

But I'm worried about something below:

## Callback arguments ##
I put segment index at last in arguments for callback function. Is this good? If we add other arguments, for instance, token, speaker turn and so on, in the future, the position of segment index changes. It will cause compatibility issue for existing code using whispercpp gem. Is that acceptable as this is beta version? Should we use a `Hash` or define a class for callback arguments?

## Params initialization ##
Now I initialize `Whisper::Params#new_segment_callback` by `nil`:
```ruby
  rwp->new_segment_callback = Qnil;
```
https://github.com/KitaitiMakoto/whisper.cpp/blob/39a988daca2c69a8504d3081c6442ff97fcacd87/bindings/ruby/ext/ruby_whisper.cpp#L76

Should it be kept initialized by `NULL` to reduce unnecessary code? I'm not sure because I'm not familiar with C/C++.

## Occupation ##
Is it good for single Ruby proc object to occupy `whisper_context_params`' `new_segment_callback_user_data` member:
```ruby
    rwp->params.new_segment_callback_user_data = &rwp->new_segment_callback;
```
https://github.com/KitaitiMakoto/whisper.cpp/blob/39a988daca2c69a8504d3081c6442ff97fcacd87/bindings/ruby/ext/ruby_whisper.cpp#L223

Again, because I'm not familiar with C/C++, I wonder there are any other usages for `new_segment_callback_user_data`?.

## Ruby API ##
Current Ruby API `Whisper::Params#new_segment_callback=` follows C++ API. But other API might be suitable for Ruby such as:

```ruby
params.on_segment do |text, start_time, end_time, index|
  # ...
end
```

or

```ruby
whisper.on_segment do |text, start_time, end_time, index|
  # ...
end
# not params
```
 
How do you think?

## Abortable ##
This is just information rather than discussion. As a side effect, this patch allows us to abort transcription by Ctrl-C (SIGINT) if we set some callback though we cannot to it once whisper started transcription on current `master`. This is because Ruby gains control when C++ code call Ruby callback object, and it handle with SIGINT.

I think we should define how to abort itself, though.

Could you review it?