### PR TITLE
passing samples_padded by ref to the threads.

### DIFF
--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -3164,7 +3164,7 @@ static bool log_mel_spectrogram(
         std::vector<std::thread> workers(n_threads - 1);
         for (int iw = 0; iw < n_threads - 1; ++iw) {
             workers[iw] = std::thread(
-                    log_mel_spectrogram_worker_thread, iw + 1, hann, samples_padded,
+                    log_mel_spectrogram_worker_thread, iw + 1, hann, std:cref(samples_padded),
                     n_samples + stage_2_pad, frame_size, frame_step, n_threads,
                     std::cref(filters), std::ref(mel));
         }


### PR DESCRIPTION
I observed substantial memory usage during multithreaded MFCC processing of large audio files. This appears to originate from copying the full `samples_padded` audio sequence to each MFCC processing thread.

This minor optimization switches to a cref to avoid copying. MFCC extraction doesn't modify the samples so I believe this is safe.