### PR TITLE
whisper.swiftui : add model download list & bench methods

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,16 +18,17 @@ let package = Package(
             name: "whisper",
             path: ".",
             exclude: [
+               "build",
                "bindings",
                "cmake",
-               "coreml",
                "examples",
-               "extra",
+               "scripts",
                "models",
                "samples",
                "tests",
                "CMakeLists.txt",
-               "Makefile"
+               "Makefile",
+               "ggml/src/ggml-metal-embed.metal"
             ],
             sources: [
                 "ggml/src/ggml.c",
@@ -38,7 +39,7 @@ let package = Package(
                 "ggml/src/ggml-quants.c",
                 "ggml/src/ggml-metal.m"
             ],
-            resources: [.process("ggml-metal.metal")],
+            resources: [.process("ggml/src/ggml-metal.metal")],
             publicHeadersPath: "spm-headers",
             cSettings: [
                 .unsafeFlags(["-Wno-shorten-64-to-32", "-O3", "-DNDEBUG"]),

--- a/examples/whisper.swiftui/whisper.cpp.swift/LibWhisper.swift
+++ b/examples/whisper.swiftui/whisper.cpp.swift/LibWhisper.swift
@@ -119,7 +119,7 @@ actor WhisperContext {
         whisper_print_timings(context)
 
         let system_info = self.system_info()
-        let timings: whisper_timings = whisper_get_timings(context)
+        let timings: whisper_timings = whisper_get_timings(context).pointee
         let encode_ms = String(format: "%.2f", timings.encode_ms)
         let decode_ms = String(format: "%.2f", timings.decode_ms)
         let batchd_ms = String(format: "%.2f", timings.batchd_ms)

--- a/examples/whisper.swiftui/whisper.cpp.swift/LibWhisper.swift
+++ b/examples/whisper.swiftui/whisper.cpp.swift/LibWhisper.swift
@@ -55,7 +55,7 @@ actor WhisperContext {
         return transcription
     }
 
-    func system_info() -> String {
+    private func systemInfo() -> String {
         var info = ""
         if (ggml_cpu_has_neon() != 0) { info += "NEON " }
         if (ggml_cpu_has_metal() != 0) { info += "METAL " }
@@ -63,7 +63,7 @@ actor WhisperContext {
         return String(info.dropLast())
     }
 
-    func bench_full(modelName: String) async -> String {
+    func benchFull(modelName: String) async -> String {
         let n_threads = Int32(min(4, cpuCount())) // Default in whisper.cpp
         
         let n_mels = whisper_model_n_mels(context)
@@ -118,7 +118,7 @@ actor WhisperContext {
 
         whisper_print_timings(context)
 
-        let system_info = self.system_info()
+        let system_info = self.systemInfo()
         let timings: whisper_timings = whisper_get_timings(context).pointee
         let encode_ms = String(format: "%.2f", timings.encode_ms)
         let decode_ms = String(format: "%.2f", timings.decode_ms)

--- a/examples/whisper.swiftui/whisper.cpp.swift/LibWhisper.swift
+++ b/examples/whisper.swiftui/whisper.cpp.swift/LibWhisper.swift
@@ -55,11 +55,85 @@ actor WhisperContext {
         return transcription
     }
 
+    func system_info() -> String {
+        var info = ""
+        if (ggml_cpu_has_neon() != 0) { info += "NEON " }
+        if (ggml_cpu_has_metal() != 0) { info += "METAL " }
+        if (ggml_cpu_has_blas() != 0) { info += "BLAS " }
+        return String(info.dropLast())
+    }
+
+    func bench_full(modelName: String) async -> String {
+        let n_threads = Int32(min(4, cpuCount())) // Default in whisper.cpp
+        
+        let n_mels = whisper_model_n_mels(context)
+        if (whisper_set_mel(context, nil, 0, n_mels) != 0) {
+            return "error: failed to set mel"
+        }
+        
+        // heat encoder
+        if (whisper_encode(context, 0, n_threads) != 0) {
+            return "error: failed to encode"
+        }
+        
+        var tokens = [whisper_token](repeating: 0, count: 512)
+        
+        // prompt heat
+        if (whisper_decode(context, &tokens, 256, 0, n_threads) != 0) {
+            return "error: failed to decode"
+        }
+        
+        // text-generation heat
+        if (whisper_decode(context, &tokens, 1, 256, n_threads) != 0) {
+            return "error: failed to decode"
+        }
+        
+        whisper_reset_timings(context)
+        
+        // actual run
+        if (whisper_encode(context, 0, n_threads) != 0) {
+            return "error: failed to encode"
+        }
+        
+        // text-generation
+        for i in 0..<256 {
+            if (whisper_decode(context, &tokens, 1, Int32(i), n_threads) != 0) {
+                return "error: failed to decode"
+            }
+        }
+        
+        // batched decoding
+        for _ in 0..<64 {
+            if (whisper_decode(context, &tokens, 5, 0, n_threads) != 0) {
+                return "error: failed to decode"
+            }
+        }
+        
+        // prompt processing
+        for _ in 0..<16 {
+            if (whisper_decode(context, &tokens, 256, 0, n_threads) != 0) {
+                return "error: failed to decode"
+            }
+        }
+
+        whisper_print_timings(context)
+
+        let system_info = self.system_info()
+        let timings: whisper_timings = whisper_get_timings(context)
+        let encode_ms = String(format: "%.2f", timings.encode_ms)
+        let decode_ms = String(format: "%.2f", timings.decode_ms)
+        let batchd_ms = String(format: "%.2f", timings.batchd_ms)
+        let prompt_ms = String(format: "%.2f", timings.prompt_ms)
+        return "| <todo> | iOS | \(system_info) | \(modelName) | \(n_threads) | 1 | \(encode_ms) | \(decode_ms) | \(batchd_ms) | \(prompt_ms) | <todo> |"
+    }
+
     static func createContext(path: String) throws -> WhisperContext {
         var params = whisper_context_default_params()
 #if targetEnvironment(simulator)
         params.use_gpu = false
         print("Running on the simulator, using CPU")
+#else
+        params.flash_attn = true // Enabled by default for Metal
 #endif
         let context = whisper_init_from_file_with_params(path, params)
         if let context {

--- a/examples/whisper.swiftui/whisper.cpp.swift/LibWhisper.swift
+++ b/examples/whisper.swiftui/whisper.cpp.swift/LibWhisper.swift
@@ -119,8 +119,8 @@ actor WhisperContext {
 
         whisper_print_timings(context)
 
-        let deviceModel = UIDevice.current.model
-        let systemName = UIDevice.current.systemName
+        let deviceModel = await UIDevice.current.model
+        let systemName = await UIDevice.current.systemName
         let systemInfo = self.systemInfo()
         let timings: whisper_timings = whisper_get_timings(context).pointee
         let encodeMs = String(format: "%.2f", timings.encode_ms)

--- a/examples/whisper.swiftui/whisper.cpp.swift/LibWhisper.swift
+++ b/examples/whisper.swiftui/whisper.cpp.swift/LibWhisper.swift
@@ -56,6 +56,14 @@ actor WhisperContext {
         return transcription
     }
 
+    static func benchMemcpy(nThreads: Int32) async -> String {
+        return String.init(cString: whisper_bench_memcpy_str(nThreads))
+    }
+
+    static func benchGgmlMulMat(nThreads: Int32) async -> String {
+        return String.init(cString: whisper_bench_ggml_mul_mat_str(nThreads))
+    }
+
     private func systemInfo() -> String {
         var info = ""
         if (ggml_cpu_has_neon() != 0) { info += "NEON " }
@@ -64,9 +72,7 @@ actor WhisperContext {
         return String(info.dropLast())
     }
 
-    func benchFull(modelName: String) async -> String {
-        let nThreads = Int32(min(4, cpuCount())) // Default in whisper.cpp
-        
+    func benchFull(modelName: String, nThreads: Int32) async -> String {
         let nMels = whisper_model_n_mels(context)
         if (whisper_set_mel(context, nil, 0, nMels) != 0) {
             return "error: failed to set mel"

--- a/examples/whisper.swiftui/whisper.swiftui.demo/Models/Model.swift
+++ b/examples/whisper.swiftui/whisper.swiftui.demo/Models/Model.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+struct Model: Identifiable {
+    var id = UUID()
+    var name: String
+    var info: String
+    var url: String
+
+    var filename: String
+    var fileURL: URL {
+        FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0].appendingPathComponent(filename)
+    }
+
+    func fileExists() -> Bool {
+        FileManager.default.fileExists(atPath: fileURL.path)
+    }
+}

--- a/examples/whisper.swiftui/whisper.swiftui.demo/Models/WhisperState.swift
+++ b/examples/whisper.swiftui/whisper.swiftui.demo/Models/WhisperState.swift
@@ -2,7 +2,6 @@ import Foundation
 import SwiftUI
 import AVFoundation
 
-
 @MainActor
 class WhisperState: NSObject, ObservableObject, AVAudioRecorderDelegate {
     @Published var isModelLoaded = false
@@ -56,7 +55,7 @@ class WhisperState: NSObject, ObservableObject, AVAudioRecorderDelegate {
             return
         }
         messageLog += "Benchmarking current model\n"
-        let result = await whisperContext?.bench_full(modelName: "<current>")
+        let result = await whisperContext?.benchFull(modelName: "<current>")
         if (result != nil) { messageLog += result! + "\n" }
     }
 
@@ -70,7 +69,7 @@ class WhisperState: NSObject, ObservableObject, AVAudioRecorderDelegate {
                 messageLog += "Cannot bench without loaded model\n"
                 break
             }
-            let result = await whisperContext?.bench_full(modelName: model.name)
+            let result = await whisperContext?.benchFull(modelName: model.name)
             if (result != nil) { messageLog += result! + "\n" }
         }
         messageLog += "Benchmarking completed\n"

--- a/examples/whisper.swiftui/whisper.swiftui.demo/Models/WhisperState.swift
+++ b/examples/whisper.swiftui/whisper.swiftui.demo/Models/WhisperState.swift
@@ -54,13 +54,21 @@ class WhisperState: NSObject, ObservableObject, AVAudioRecorderDelegate {
             messageLog += "Cannot bench without loaded model\n"
             return
         }
-        messageLog += "Benchmarking current model\n"
-        let result = await whisperContext?.benchFull(modelName: "<current>")
+        messageLog += "Running benchmark for loaded model\n"
+        let result = await whisperContext?.benchFull(modelName: "<current>", nThreads: Int32(min(4, cpuCount())))
         if (result != nil) { messageLog += result! + "\n" }
     }
 
     func bench(models: [Model]) async {
-        messageLog += "Benchmarking models\n"
+        let nThreads = Int32(min(4, cpuCount()))
+
+//        messageLog += "Running memcpy benchmark\n"
+//        messageLog += await WhisperContext.benchMemcpy(nThreads: nThreads) + "\n"
+//
+//        messageLog += "Running ggml_mul_mat benchmark with \(nThreads) threads\n"
+//        messageLog += await WhisperContext.benchGgmlMulMat(nThreads: nThreads) + "\n"
+
+        messageLog += "Running benchmark for all downloaded models\n"
         messageLog += "| CPU | OS | Config | Model | Th | FA | Enc. | Dec. | Bch5 | PP | Commit |\n"
         messageLog += "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |\n"
         for model in models {
@@ -69,7 +77,7 @@ class WhisperState: NSObject, ObservableObject, AVAudioRecorderDelegate {
                 messageLog += "Cannot bench without loaded model\n"
                 break
             }
-            let result = await whisperContext?.benchFull(modelName: model.name)
+            let result = await whisperContext?.benchFull(modelName: model.name, nThreads: nThreads)
             if (result != nil) { messageLog += result! + "\n" }
         }
         messageLog += "Benchmarking completed\n"
@@ -187,4 +195,9 @@ class WhisperState: NSObject, ObservableObject, AVAudioRecorderDelegate {
     private func onDidFinishRecording() {
         isRecording = false
     }
+}
+
+
+fileprivate func cpuCount() -> Int {
+    ProcessInfo.processInfo.processorCount
 }

--- a/examples/whisper.swiftui/whisper.swiftui.demo/UI/ContentView.swift
+++ b/examples/whisper.swiftui/whisper.swiftui.demo/UI/ContentView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import AVFoundation
+import Foundation
 
 struct ContentView: View {
     @StateObject var whisperState = WhisperState()
@@ -29,15 +30,125 @@ struct ContentView: View {
                     Text(verbatim: whisperState.messageLog)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
+                .font(.footnote)
+                .padding()
+                .background(Color.gray.opacity(0.1))
+                .cornerRadius(10)
+
+                HStack {
+                    Button("Clear Logs", action: {
+                        whisperState.messageLog = ""
+                    })
+                    .font(.footnote)
+                    .buttonStyle(.bordered)
+
+                    Button("Copy Logs", action: {
+                        UIPasteboard.general.string = whisperState.messageLog
+                    })
+                    .font(.footnote)
+                    .buttonStyle(.bordered)
+
+                    Button("Bench", action: {
+                        Task {
+                            await whisperState.benchCurrentModel()
+                        }
+                    })
+                    .font(.footnote)
+                    .buttonStyle(.bordered)
+                    .disabled(!whisperState.canTranscribe)
+
+                    Button("Bench All", action: {
+                        Task {
+                            await whisperState.bench(models: ModelsView.getDownloadedModels())
+                        }
+                    })
+                    .font(.footnote)
+                    .buttonStyle(.bordered)
+                    .disabled(!whisperState.canTranscribe)
+                }
+
+                NavigationLink(destination: ModelsView(whisperState: whisperState)) {
+                    Text("View Models")
+                }
+                .font(.footnote)
+                .padding()
             }
             .navigationTitle("Whisper SwiftUI Demo")
             .padding()
         }
     }
-}
 
-struct ContentView_Previews: PreviewProvider {
-    static var previews: some View {
-        ContentView()
+    struct ModelsView: View {
+        @ObservedObject var whisperState: WhisperState
+        @Environment(\.dismiss) var dismiss
+        
+        private static let models: [Model] = [
+            Model(name: "tiny", info: "(F16, 75 MiB)", url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-tiny.bin", filename: "tiny.bin"),
+            Model(name: "tiny-q5_1", info: "(31 MiB)", url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-tiny-q5_1.bin", filename: "tiny-q5_1.bin"),
+            Model(name: "tiny-q8_0", info: "(42 MiB)", url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-tiny-q8_0.bin", filename: "tiny-q8_0.bin"),
+            Model(name: "tiny.en", info: "(F16, 75 MiB)", url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-tiny.en.bin", filename: "tiny.en.bin"),
+            Model(name: "tiny.en-q5_1", info: "(31 MiB)", url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-tiny.en-q5_1.bin", filename: "tiny.en-q5_1.bin"),
+            Model(name: "tiny.en-q8_0", info: "(42 MiB)", url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-tiny.en-q8_0.bin", filename: "tiny.en-q8_0.bin"),
+            Model(name: "base", info: "(F16, 142 MiB)", url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.bin", filename: "base.bin"),
+            Model(name: "base-q5_1", info: "(57 MiB)", url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base-q5_1.bin", filename: "base-q5_1.bin"),
+            Model(name: "base-q8_0", info: "(78 MiB)", url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base-q8_0.bin", filename: "base-q8_0.bin"),
+            Model(name: "base.en", info: "(F16, 142 MiB)", url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.en.bin", filename: "base.en.bin"),
+            Model(name: "base.en-q5_1", info: "(57 MiB)", url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.en-q5_1.bin", filename: "base.en-q5_1.bin"),
+            Model(name: "base.en-q8_0", info: "(78 MiB)", url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.en-q8_0.bin", filename: "base.en-q8_0.bin"),
+            Model(name: "small", info: "(F16, 466 MiB)", url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.bin", filename: "small.bin"),
+            Model(name: "small-q5_1", info: "(181 MiB)", url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small-q5_1.bin", filename: "small-q5_1.bin"),
+            Model(name: "small-q8_0", info: "(252 MiB)", url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small-q8_0.bin", filename: "small-q8_0.bin"),
+            Model(name: "small.en", info: "(F16, 466 MiB)", url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.en.bin", filename: "small.en.bin"),
+            Model(name: "small.en-q5_1", info: "(181 MiB)", url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.en-q5_1.bin", filename: "small.en-q5_1.bin"),
+            Model(name: "small.en-q8_0", info: "(252 MiB)", url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.en-q8_0.bin", filename: "small.en-q8_0.bin"),
+            Model(name: "medium", info: "(F16, 1.5 GiB)", url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-medium.bin", filename: "medium.bin"),
+            Model(name: "medium-q5_0", info: "(514 MiB)", url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-medium-q5_0.bin", filename: "medium-q5_0.bin"),
+            Model(name: "medium-q8_0", info: "(785 MiB)", url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-medium-q8_0.bin", filename: "medium-q8_0.bin"),
+            Model(name: "medium.en", info: "(F16, 1.5 GiB)", url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-medium.en.bin", filename: "medium.en.bin"),
+            Model(name: "medium.en-q5_0", info: "(514 MiB)", url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-medium.en-q5_0.bin", filename: "medium.en-q5_0.bin"),
+            Model(name: "medium.en-q8_0", info: "(785 MiB)", url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-medium.en-q8_0.bin", filename: "medium.en-q8_0.bin"),
+            Model(name: "large-v1", info: "(F16, 2.9 GiB)", url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large.bin", filename: "large.bin"),
+            Model(name: "large-v2", info: "(F16, 2.9 GiB)", url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v2.bin", filename: "large-v2.bin"),
+            Model(name: "large-v2-q5_0", info: "(1.1 GiB)", url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v2-q5_0.bin", filename: "large-v2-q5_0.bin"),
+            Model(name: "large-v2-q8_0", info: "(1.5 GiB)", url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v2-q8_0.bin", filename: "large-v2-q8_0.bin"),
+            Model(name: "large-v3", info: "(F16, 2.9 GiB)", url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3.bin", filename: "large-v3.bin"),
+            Model(name: "large-v3-q5_0", info: "(1.1 GiB)", url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-q5_0.bin", filename: "large-v3-q5_0.bin"),
+            Model(name: "large-v3-turbo", info: "(F16, 1.5 GiB)", url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo.bin", filename: "large-v3-turbo.bin"),
+            Model(name: "large-v3-turbo-q5_0", info: "(547 MiB)", url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo-q5_0.bin", filename: "large-v3-turbo-q5_0.bin"),
+            Model(name: "large-v3-turbo-q8_0", info: "(834 MiB)", url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo-q8_0.bin", filename: "large-v3-turbo-q8_0.bin"),
+        ]
+
+        static func getDownloadedModels() -> [Model] {
+            // Filter models that have been downloaded
+            return models.filter {
+                FileManager.default.fileExists(atPath: $0.fileURL.path())
+            }
+        }
+
+        func loadModel(model: Model) {
+            Task {
+                dismiss()
+                whisperState.loadModel(path: model.fileURL)
+            }
+        }
+
+        var body: some View {
+            List {
+                Section(header: Text("Models")) {
+                    ForEach(ModelsView.models) { model in
+                        DownloadButton(model: model)
+                            .onLoad(perform: loadModel)
+                    }
+                }
+            }
+            .listStyle(GroupedListStyle())
+            .navigationBarTitle("Models", displayMode: .inline).toolbar {}
+        }
     }
 }
+
+//struct ContentView_Previews: PreviewProvider {
+//    static var previews: some View {
+//        ContentView()
+//    }
+//}

--- a/examples/whisper.swiftui/whisper.swiftui.demo/UI/DownloadButton.swift
+++ b/examples/whisper.swiftui/whisper.swiftui.demo/UI/DownloadButton.swift
@@ -1,0 +1,102 @@
+import SwiftUI
+
+struct DownloadButton: View {
+    private var model: Model
+
+    @State private var status: String
+
+    @State private var downloadTask: URLSessionDownloadTask?
+    @State private var progress = 0.0
+    @State private var observation: NSKeyValueObservation?
+
+    private var onLoad: ((_ model: Model) -> Void)?
+
+    init(model: Model) {
+        self.model = model
+        status = model.fileExists() ? "downloaded" : "download"
+    }
+
+    func onLoad(perform action: @escaping (_ model: Model) -> Void) -> DownloadButton {
+        var button = self
+        button.onLoad = action
+        return button
+    }
+
+    private func download() {
+        status = "downloading"
+        print("Downloading model \(model.name) from \(model.url)")
+        guard let url = URL(string: model.url) else { return }
+
+        downloadTask = URLSession.shared.downloadTask(with: url) { temporaryURL, response, error in
+            if let error = error {
+                print("Error: \(error.localizedDescription)")
+                return
+            }
+
+            guard let response = response as? HTTPURLResponse, (200...299).contains(response.statusCode) else {
+                print("Server error!")
+                return
+            }
+
+            do {
+                if let temporaryURL = temporaryURL {
+                    try FileManager.default.copyItem(at: temporaryURL, to: model.fileURL)
+                    print("Writing to \(model.filename) completed")
+                    status = "downloaded"
+                }
+            } catch let err {
+                print("Error: \(err.localizedDescription)")
+            }
+        }
+
+        observation = downloadTask?.progress.observe(\.fractionCompleted) { progress, _ in
+            self.progress = progress.fractionCompleted
+        }
+
+        downloadTask?.resume()
+    }
+
+    var body: some View {
+        VStack {
+            Button(action: {
+                if (status == "download") {
+                    download()
+                } else if (status == "downloading") {
+                    downloadTask?.cancel()
+                    status = "download"
+                } else if (status == "downloaded") {
+                    if !model.fileExists() {
+                        download()
+                    }
+                    onLoad?(model)
+                }
+            }) {
+                let title = "\(model.name) \(model.info)"
+                if (status == "download") {
+                    Text("Download \(title)")
+                } else if (status == "downloading") {
+                    Text("\(title) (Downloading \(Int(progress * 100))%)")
+                } else if (status == "downloaded") {
+                    Text("Load \(title)")
+                } else {
+                    Text("Unknown status")
+                }
+            }.swipeActions {
+                if (status == "downloaded") {
+                    Button("Delete") {
+                        do {
+                            try FileManager.default.removeItem(at: model.fileURL)
+                        } catch {
+                            print("Error deleting file: \(error)")
+                        }
+                        status = "download"
+                    }
+                    .tint(.red)
+                }
+            }
+        }
+        .onDisappear() {
+            downloadTask?.cancel()
+        }
+    }
+}

--- a/examples/whisper.swiftui/whisper.swiftui.xcodeproj/project.pbxproj
+++ b/examples/whisper.swiftui/whisper.swiftui.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		0AAC5D9F29539CD0003032C3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0AAC5D9E29539CD0003032C3 /* Assets.xcassets */; };
 		0AAC5DCE2953A05C003032C3 /* WhisperState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AAC5DCD2953A05C003032C3 /* WhisperState.swift */; };
 		0AAC5DD12953A394003032C3 /* LibWhisper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AAC5DD02953A394003032C3 /* LibWhisper.swift */; };
+		7F79E0EE2CE0A78000ACD7BF /* DownloadButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F79E0ED2CE0A78000ACD7BF /* DownloadButton.swift */; };
+		7F79E0F02CE0C6F700ACD7BF /* Model.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F79E0EF2CE0C6F700ACD7BF /* Model.swift */; };
 		E3F92DC52AFA8E3800A6A9D4 /* whisper in Frameworks */ = {isa = PBXBuildFile; productRef = E3F92DC42AFA8E3800A6A9D4 /* whisper */; };
 /* End PBXBuildFile section */
 
@@ -33,6 +35,8 @@
 		0AAC5DA029539CD0003032C3 /* WhisperCppDemo.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = WhisperCppDemo.entitlements; sourceTree = "<group>"; };
 		0AAC5DCD2953A05C003032C3 /* WhisperState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhisperState.swift; sourceTree = "<group>"; };
 		0AAC5DD02953A394003032C3 /* LibWhisper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibWhisper.swift; sourceTree = "<group>"; };
+		7F79E0ED2CE0A78000ACD7BF /* DownloadButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadButton.swift; sourceTree = "<group>"; };
+		7F79E0EF2CE0C6F700ACD7BF /* Model.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Model.swift; sourceTree = "<group>"; };
 		E3F92DC22AFA8DD800A6A9D4 /* whisper.cpp */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = whisper.cpp; path = ../..; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -52,6 +56,7 @@
 			isa = PBXGroup;
 			children = (
 				0AAC5DCD2953A05C003032C3 /* WhisperState.swift */,
+				7F79E0EF2CE0C6F700ACD7BF /* Model.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -119,6 +124,7 @@
 			isa = PBXGroup;
 			children = (
 				0AAC5D9C29539CCF003032C3 /* ContentView.swift */,
+				7F79E0ED2CE0A78000ACD7BF /* DownloadButton.swift */,
 			);
 			path = UI;
 			sourceTree = "<group>";
@@ -220,7 +226,9 @@
 				0AAC5DCE2953A05C003032C3 /* WhisperState.swift in Sources */,
 				0AAC5DD12953A394003032C3 /* LibWhisper.swift in Sources */,
 				0AA7514C2953B569001EE061 /* RiffWaveUtils.swift in Sources */,
+				7F79E0EE2CE0A78000ACD7BF /* DownloadButton.swift in Sources */,
 				0AA7514E2953D958001EE061 /* Recorder.swift in Sources */,
+				7F79E0F02CE0C6F700ACD7BF /* Model.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/include/whisper.h
+++ b/include/whisper.h
@@ -423,6 +423,14 @@ extern "C" {
     WHISPER_API whisper_token whisper_token_transcribe(struct whisper_context * ctx);
 
     // Performance information from the default state.
+    struct whisper_timings {
+        float sample_ms;
+        float encode_ms;
+        float decode_ms;
+        float batchd_ms;
+        float prompt_ms;
+    };
+    WHISPER_API struct whisper_timings whisper_get_timings(struct whisper_context * ctx);
     WHISPER_API void whisper_print_timings(struct whisper_context * ctx);
     WHISPER_API void whisper_reset_timings(struct whisper_context * ctx);
 

--- a/include/whisper.h
+++ b/include/whisper.h
@@ -430,7 +430,7 @@ extern "C" {
         float batchd_ms;
         float prompt_ms;
     };
-    WHISPER_API struct whisper_timings whisper_get_timings(struct whisper_context * ctx);
+    WHISPER_API struct whisper_timings * whisper_get_timings(struct whisper_context * ctx);
     WHISPER_API void whisper_print_timings(struct whisper_context * ctx);
     WHISPER_API void whisper_reset_timings(struct whisper_context * ctx);
 

--- a/scripts/bench-all.sh
+++ b/scripts/bench-all.sh
@@ -24,14 +24,7 @@ else
     fattn="-fa"
 fi
 
-models=(                                                                                                    \
-      "tiny"     "tiny-q4_0"     "tiny-q4_1"     "tiny-q5_0"     "tiny-q5_1"     "tiny-q8_0"                \
-      "base"     "base-q4_0"     "base-q4_1"     "base-q5_0"     "base-q5_1"     "base-q8_0"                \
-     "small"    "small-q4_0"    "small-q4_1"    "small-q5_0"    "small-q5_1"    "small-q8_0"                \
-    "medium"   "medium-q4_0"   "medium-q4_1"   "medium-q5_0"   "medium-q5_1"   "medium-q8_0"   "medium-dis" \
-  "large-v2" "large-v2-q4_0" "large-v2-q4_1" "large-v2-q5_0" "large-v2-q5_1" "large-v2-q8_0" "large-v2-dis" \
-  "large-v3-turbo"                           "large-v3-turbo-q5_0"           "large-v3-turbo-q8_0"          \
-)
+models=("tiny")
 
 if [ "$encoder_only" -eq 0 ]; then
     printf "\n"

--- a/scripts/bench-all.sh
+++ b/scripts/bench-all.sh
@@ -24,7 +24,14 @@ else
     fattn="-fa"
 fi
 
-models=("tiny")
+models=(                                                                                                    \
+      "tiny"     "tiny-q4_0"     "tiny-q4_1"     "tiny-q5_0"     "tiny-q5_1"     "tiny-q8_0"                \
+      "base"     "base-q4_0"     "base-q4_1"     "base-q5_0"     "base-q5_1"     "base-q8_0"                \
+     "small"    "small-q4_0"    "small-q4_1"    "small-q5_0"    "small-q5_1"    "small-q8_0"                \
+    "medium"   "medium-q4_0"   "medium-q4_1"   "medium-q5_0"   "medium-q5_1"   "medium-q8_0"   "medium-dis" \
+  "large-v2" "large-v2-q4_0" "large-v2-q4_1" "large-v2-q5_0" "large-v2-q5_1" "large-v2-q8_0" "large-v2-dis" \
+  "large-v3-turbo"                           "large-v3-turbo-q5_0"           "large-v3-turbo-q8_0"          \
+)
 
 if [ "$encoder_only" -eq 0 ]; then
     printf "\n"

--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -4190,18 +4190,13 @@ struct whisper_timings * whisper_get_timings(struct whisper_context * ctx) {
     if (ctx->state == nullptr) {
         return nullptr;
     }
-    const int32_t n_sample = std::max(1, ctx->state->n_sample);
-    const int32_t n_encode = std::max(1, ctx->state->n_encode);
-    const int32_t n_decode = std::max(1, ctx->state->n_decode);
-    const int32_t n_batchd = std::max(1, ctx->state->n_batchd);
-    const int32_t n_prompt = std::max(1, ctx->state->n_prompt);
-    return new whisper_timings {
-        .sample_ms = 1e-3f * ctx->state->t_sample_us / n_sample,
-        .encode_ms = 1e-3f * ctx->state->t_encode_us / n_encode,
-        .decode_ms = 1e-3f * ctx->state->t_decode_us / n_decode,
-        .batchd_ms = 1e-3f * ctx->state->t_batchd_us / n_batchd,
-        .prompt_ms = 1e-3f * ctx->state->t_prompt_us / n_prompt,
-    };
+    whisper_timings * timings = new whisper_timings;
+    timings->sample_ms = 1e-3f * ctx->state->t_sample_us / std::max(1, ctx->state->n_sample);
+    timings->encode_ms = 1e-3f * ctx->state->t_encode_us / std::max(1, ctx->state->n_encode);
+    timings->decode_ms = 1e-3f * ctx->state->t_decode_us / std::max(1, ctx->state->n_decode);
+    timings->batchd_ms = 1e-3f * ctx->state->t_batchd_us / std::max(1, ctx->state->n_batchd);
+    timings->prompt_ms = 1e-3f * ctx->state->t_prompt_us / std::max(1, ctx->state->n_prompt);
+    return timings;
 }
 
 void whisper_print_timings(struct whisper_context * ctx) {

--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -4186,6 +4186,30 @@ whisper_token whisper_token_transcribe(struct whisper_context * ctx) {
     return ctx->vocab.token_transcribe;
 }
 
+struct whisper_timings whisper_get_timings(struct whisper_context * ctx) {
+    if (ctx->state == nullptr) {
+        return whisper_timings {
+            .sample_ms = 0,
+            .encode_ms = 0,
+            .decode_ms = 0,
+            .batchd_ms = 0,
+            .prompt_ms = 0,
+        };
+    }
+    const int32_t n_sample = std::max(1, ctx->state->n_sample);
+    const int32_t n_encode = std::max(1, ctx->state->n_encode);
+    const int32_t n_decode = std::max(1, ctx->state->n_decode);
+    const int32_t n_batchd = std::max(1, ctx->state->n_batchd);
+    const int32_t n_prompt = std::max(1, ctx->state->n_prompt);
+    return whisper_timings {
+        .sample_ms = 1e-3f * ctx->state->t_sample_us / n_sample,
+        .encode_ms = 1e-3f * ctx->state->t_encode_us / n_encode,
+        .decode_ms = 1e-3f * ctx->state->t_decode_us / n_decode,
+        .batchd_ms = 1e-3f * ctx->state->t_batchd_us / n_batchd,
+        .prompt_ms = 1e-3f * ctx->state->t_prompt_us / n_prompt,
+    };
+}
+
 void whisper_print_timings(struct whisper_context * ctx) {
     const int64_t t_end_us = ggml_time_us();
 

--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -4186,22 +4186,16 @@ whisper_token whisper_token_transcribe(struct whisper_context * ctx) {
     return ctx->vocab.token_transcribe;
 }
 
-struct whisper_timings whisper_get_timings(struct whisper_context * ctx) {
+struct whisper_timings * whisper_get_timings(struct whisper_context * ctx) {
     if (ctx->state == nullptr) {
-        return whisper_timings {
-            .sample_ms = 0,
-            .encode_ms = 0,
-            .decode_ms = 0,
-            .batchd_ms = 0,
-            .prompt_ms = 0,
-        };
+        return nullptr;
     }
     const int32_t n_sample = std::max(1, ctx->state->n_sample);
     const int32_t n_encode = std::max(1, ctx->state->n_encode);
     const int32_t n_decode = std::max(1, ctx->state->n_decode);
     const int32_t n_batchd = std::max(1, ctx->state->n_batchd);
     const int32_t n_prompt = std::max(1, ctx->state->n_prompt);
-    return whisper_timings {
+    return new whisper_timings {
         .sample_ms = 1e-3f * ctx->state->t_sample_us / n_sample,
         .encode_ms = 1e-3f * ctx->state->t_encode_us / n_encode,
         .decode_ms = 1e-3f * ctx->state->t_decode_us / n_decode,


### PR DESCRIPTION
This PR fixes the build of whisper.swiftui, and then add model download list (from [ggerganov/whisper.cpp](https://huggingface.co/ggerganov/whisper.cpp/resolve/main) HF repo) and bench methods.

The bench method output format is following format from `scripts/bench-all.sh`:

https://github.com/ggerganov/whisper.cpp/blob/31aea563a83803c710691fed3e8d700e06ae6788/scripts/bench-all.sh#L61-L62

New Buttons:
- View Models: Navigate to model list (We can download model & load downloaded model)
- Bench (bench_full for current loaded model)
- Bench All (bench_full for downloaded models)
- Copy Logs

The memcpy and ggml_mul_mat methods are added but commented.

The demo looks like in iPhone 15 Pro:

<img width="300px" src="https://github.com/user-attachments/assets/f4cc0a0b-8f86-409d-b012-63355f4b26ba" /><img width="300px" src="https://github.com/user-attachments/assets/cf590a16-0ca3-4c61-9d1b-4ea2ff9274d6" />

Benchmark result in iPhone 15 Pro (A17 Pro):

memcpy and ggml_mul_mat:

```
Running memcpy benchmark
memcpy:   14.97 GB/s (heat-up)
memcpy:   21.46 GB/s ( 1 thread)
memcpy:   20.66 GB/s ( 1 thread)
memcpy:   22.52 GB/s ( 2 thread)
memcpy:   22.57 GB/s ( 3 thread)
memcpy:   22.46 GB/s ( 4 thread)
sum:    -3072001183.000000

Running ggml_mul_mat benchmark with 4 threads
  64 x   64: Q4_0     4.1 GFLOPS (128 runs) | Q4_1     3.7 GFLOPS (128 runs)
  64 x   64: Q5_0     4.5 GFLOPS (128 runs) | Q5_1     4.6 GFLOPS (128 runs) | Q8_0     4.0 GFLOPS (128 runs)
  64 x   64: F16      4.4 GFLOPS (128 runs) | F32      4.7 GFLOPS (128 runs)
 128 x  128: Q4_0    28.2 GFLOPS (128 runs) | Q4_1    25.8 GFLOPS (128 runs)
 128 x  128: Q5_0    20.4 GFLOPS (128 runs) | Q5_1    26.4 GFLOPS (128 runs) | Q8_0    28.9 GFLOPS (128 runs)
 128 x  128: F16     16.7 GFLOPS (128 runs) | F32     31.5 GFLOPS (128 runs)
 256 x  256: Q4_0    89.1 GFLOPS (128 runs) | Q4_1    84.1 GFLOPS (128 runs)
 256 x  256: Q5_0    70.1 GFLOPS (128 runs) | Q5_1    62.5 GFLOPS (128 runs) | Q8_0   103.2 GFLOPS (128 runs)
 256 x  256: F16     66.6 GFLOPS (128 runs) | F32     73.7 GFLOPS (128 runs)
 512 x  512: Q4_0   108.0 GFLOPS (128 runs) | Q4_1   101.0 GFLOPS (128 runs)
 512 x  512: Q5_0    83.1 GFLOPS (128 runs) | Q5_1    74.1 GFLOPS (128 runs) | Q8_0   130.6 GFLOPS (128 runs)
 512 x  512: F16     73.1 GFLOPS (128 runs) | F32     83.2 GFLOPS (128 runs)
1024 x 1024: Q4_0   116.6 GFLOPS ( 55 runs) | Q4_1   107.2 GFLOPS ( 50 runs)
1024 x 1024: Q5_0    87.2 GFLOPS ( 41 runs) | Q5_1    78.7 GFLOPS ( 37 runs) | Q8_0   139.8 GFLOPS ( 66 runs)
1024 x 1024: F16     74.2 GFLOPS ( 35 runs) | F32     76.5 GFLOPS ( 36 runs)
2048 x 2048: Q4_0   120.5 GFLOPS (  8 runs) | Q4_1   110.1 GFLOPS (  7 runs)
2048 x 2048: Q5_0    89.0 GFLOPS (  6 runs) | Q5_1    80.4 GFLOPS (  5 runs) | Q8_0   143.2 GFLOPS (  9 runs)
2048 x 2048: F16     74.0 GFLOPS (  5 runs) | F32     67.5 GFLOPS (  4 runs)
4096 x 4096: Q4_0   119.0 GFLOPS (  3 runs) | Q4_1   107.6 GFLOPS (  3 runs)
4096 x 4096: Q5_0    88.2 GFLOPS (  3 runs) | Q5_1    78.7 GFLOPS (  3 runs) | Q8_0   138.9 GFLOPS (  3 runs)
4096 x 4096: F16     69.1 GFLOPS (  3 runs) | F32     56.1 GFLOPS (  3 runs)
```

full:

| CPU | OS | Config | Model | Th | FA | Enc. | Dec. | Bch5 | PP | Commit |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| A17 Pro | iOS | NEON METAL | tiny | 4 | 1 | 50.00 | 4.47 | 1.17 | 0.07 | 31aea56 |
| A17 Pro | iOS | NEON METAL | tiny-q5_1 | 4 | 1 | 52.75 | 3.88 | 1.34 | 0.07 | 31aea56 |
| A17 Pro | iOS | NEON METAL | tiny-q8_0 | 4 | 1 | 50.81 | 3.79 | 1.13 | 0.07 | 31aea56 |
| A17 Pro | iOS | NEON METAL | tiny.en | 4 | 1 | 50.48 | 4.69 | 1.64 | 0.07 | 31aea56 |
| A17 Pro | iOS | NEON METAL | tiny.en-q5_1 | 4 | 1 | 52.39 | 3.88 | 1.55 | 0.07 | 31aea56 |
| A17 Pro | iOS | NEON METAL | tiny.en-q8_0 | 4 | 1 | 51.07 | 3.78 | 1.08 | 0.07 | 31aea56 |
| A17 Pro | iOS | NEON METAL | base | 4 | 1 | 103.23 | 6.06 | 1.32 | 0.11 | 31aea56 |
| A17 Pro | iOS | NEON METAL | base-q5_1 | 4 | 1 | 108.43 | 4.71 | 1.72 | 0.11 | 31aea56 |
| A17 Pro | iOS | NEON METAL | base-q8_0 | 4 | 1 | 104.34 | 5.46 | 1.36 | 0.11 | 31aea56 |
| A17 Pro | iOS | NEON METAL | base.en | 4 | 1 | 102.70 | 6.00 | 1.39 | 0.11 | 31aea56 |
| A17 Pro | iOS | NEON METAL | base.en-q5_1 | 4 | 1 | 109.11 | 5.22 | 1.44 | 0.11 | 31aea56 |
| A17 Pro | iOS | NEON METAL | base.en-q8_0 | 4 | 1 | 104.17 | 5.13 | 1.55 | 0.11 | 31aea56 |
| A17 Pro | iOS | NEON METAL | small | 4 | 1 | 377.67 | 11.65 | 2.78 | 0.41 | 31aea56 |
| A17 Pro | iOS | NEON METAL | small-q5_1 | 4 | 1 | 366.79 | 8.56 | 2.83 | 0.33 | 31aea56 |
| A17 Pro | iOS | NEON METAL | small-q8_0 | 4 | 1 | 354.77 | 8.90 | 2.61 | 0.32 | 31aea56 |
| A17 Pro | iOS | NEON METAL | small.en | 4 | 1 | 351.71 | 11.74 | 2.78 | 0.32 | 31aea56 |
| A17 Pro | iOS | NEON METAL | small.en-q5_1 | 4 | 1 | 391.11 | 8.34 | 2.74 | 0.36 | 31aea56 |
| A17 Pro | iOS | NEON METAL | small.en-q8_0 | 4 | 1 | 411.22 | 8.96 | 2.65 | 0.43 | 31aea56 |
| A17 Pro | iOS | NEON METAL | medium | 4 | 1 | 1236.87 | 29.46 | 8.70 | 1.18 | 31aea56 |
| A17 Pro | iOS | NEON METAL | medium-q5_0 | 4 | 1 | 1400.28 | 19.67 | 8.47 | 1.31 | 31aea56 |
| A17 Pro | iOS | NEON METAL | medium-q8_0 | 4 | 1 | 1347.07 | 22.92 | 9.75 | 1.25 | 31aea56 |
| A17 Pro | iOS | NEON METAL | medium.en | 4 | 1 | 1307.12 | 30.41 | 9.87 | 1.23 | 31aea56 |
| A17 Pro | iOS | NEON METAL | medium.en-q5_0 | 4 | 1 | 1426.46 | 20.24 | 10.36 | 1.32 | 31aea56 |
| A17 Pro | iOS | NEON METAL | medium.en-q8_0 | 4 | 1 | 1359.09 | 22.92 | 10.04 | 1.24 | 31aea56 |
| A17 Pro | iOS | NEON METAL | large-v3-turbo | 4 | 1 | 2752.62 | 10.63 | 2.60 | 0.54 | 31aea56 |
| A17 Pro | iOS | NEON METAL | large-v3-turbo-q5_0 | 4 | 1 | 2617.94 | 6.44 | 2.64 | 0.60 | 31aea56 |
| A17 Pro | iOS | NEON METAL | large-v3-turbo-q8_0 | 4 | 1 | 2494.79 | 7.20 | 2.63 | 0.69 | 31aea56 |

> Skipped large-v1 ~ v3 downloads