### PR TITLE
Fix the instructions on the Ruby binding

### DIFF
--- a/bindings/ruby/README.md
+++ b/bindings/ruby/README.md
@@ -31,7 +31,7 @@ params.duration = 60_000
 params.max_text_tokens = 300
 params.translate = true
 params.print_timestamps = false
-params.prompt = "Initial prompt here."
+params.initial_prompt = "Initial prompt here."
 
 whisper.transcribe("path/to/audio.wav", params) do |whole_text|
   puts whole_text


### PR DESCRIPTION
`#prompt` doesn't exist but `#initial_prompt` does