### PR TITLE
Fix building workflow for linux/arm64 container

### DIFF
--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -3164,7 +3164,7 @@ static bool log_mel_spectrogram(
         std::vector<std::thread> workers(n_threads - 1);
         for (int iw = 0; iw < n_threads - 1; ++iw) {
             workers[iw] = std::thread(
-                    log_mel_spectrogram_worker_thread, iw + 1, hann, samples_padded,
+                    log_mel_spectrogram_worker_thread, iw + 1, hann, std::cref(samples_padded),
                     n_samples + stage_2_pad, frame_size, frame_step, n_threads,
                     std::cref(filters), std::ref(mel));
         }


### PR DESCRIPTION
This fixes issue #2081.

This workflow will build the containers for `linux/amd64`, `linux/arm64`, and `unknown/unknown`.

Please note that `unknown/unknown` appears to be generated due to a bug in GHCR.
