### PR TITLE
ruby : Add low-level methods to transcribe

### DIFF
--- a/.github/workflows/bindings-ruby.yml
+++ b/.github/workflows/bindings-ruby.yml
@@ -50,6 +50,6 @@ jobs:
     steps:
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.0'
+          ruby-version: '3.1'
       - uses: actions/checkout@v4
       - run: rake test

--- a/bindings/ruby/README.md
+++ b/bindings/ruby/README.md
@@ -160,6 +160,23 @@ Whisper.log_set ->(level, buffer, user_data) {
 Whisper::Context.new(MODEL)
 ```
 
+You can also call `Whisper::Context#full` with a Ruby array as samples. Although `#transcribe` with audio file path is recommended because it extracts PCM samples in C++ and is fast, `#full` give you flexibility.
+
+```ruby
+require "whisper"
+require "wavefile"
+
+reader = WaveFile::Reader.new("path/to/audio.wav", WaveFile::Format.new(:mono, :float, 16000))
+samples = reader.enum_for(:each_buffer).map(&:samples).flatten
+
+whisper = Whisper::Context.new("path/to/model.bin")
+whisper.full(Whisper::Params.new, samples)
+whisper.each_segment do |segment|
+  puts segment.text
+end
+```
+
+
 License
 -------
 

--- a/bindings/ruby/README.md
+++ b/bindings/ruby/README.md
@@ -160,7 +160,7 @@ Whisper.log_set ->(level, buffer, user_data) {
 Whisper::Context.new(MODEL)
 ```
 
-You can also call `Whisper::Context#full` with a Ruby array as samples. Although `#transcribe` with audio file path is recommended because it extracts PCM samples in C++ and is fast, `#full` give you flexibility.
+You can also call `Whisper::Context#full` and `#full_parallel` with a Ruby array as samples. Although `#transcribe` with audio file path is recommended because it extracts PCM samples in C++ and is fast, `#full` and `#full_parallel` give you flexibility.
 
 ```ruby
 require "whisper"
@@ -176,6 +176,7 @@ whisper.each_segment do |segment|
 end
 ```
 
+The second argument `samples` may be a MemoryView. If you can prepare audio data as C array and export it as a MemoryView, whispercpp accepts and works with it with zero copy.
 
 License
 -------

--- a/bindings/ruby/README.md
+++ b/bindings/ruby/README.md
@@ -176,7 +176,7 @@ whisper.each_segment do |segment|
 end
 ```
 
-The second argument `samples` may be a MemoryView. If you can prepare audio data as C array and export it as a MemoryView, whispercpp accepts and works with it with zero copy.
+The second argument `samples` may be an array, an object with `length` method, or a MemoryView. If you can prepare audio data as C array and export it as a MemoryView, whispercpp accepts and works with it with zero copy.
 
 License
 -------

--- a/bindings/ruby/Rakefile
+++ b/bindings/ruby/Rakefile
@@ -68,3 +68,13 @@ file TEST_MODEL do
     sh "./models/download-ggml-model.sh base.en"
   end
 end
+
+TEST_MEMORY_VIEW = "tests/jfk_reader/jfk_reader.#{RbConfig::CONFIG['DLEXT']}"
+file TEST_MEMORY_VIEW => "tests/jfk_reader/jfk_reader.c" do |t|
+  Dir.chdir "tests/jfk_reader" do
+    ruby "extconf.rb"
+    sh "make"
+  end
+end
+CLEAN.include "tests/jfk_reader/jfk_reader.{o,#{RbConfig::CONFIG['DLEXT']}}"
+task test: TEST_MEMORY_VIEW

--- a/bindings/ruby/ext/ruby_whisper.cpp
+++ b/bindings/ruby/ext/ruby_whisper.cpp
@@ -546,6 +546,10 @@ VALUE ruby_whisper_model_type(VALUE self) {
 }
 
 /*
+ * Run the entire model: PCM -> log mel spectrogram -> encoder -> decoder -> text
+ * Not thread safe for same context
+ * Uses the specified decoding strategy to obtain the text.
+ *
  * call-seq:
  *   full(params, samples, n_samples) -> nil
  *   full(params, samples) -> nil

--- a/bindings/ruby/ext/ruby_whisper.cpp
+++ b/bindings/ruby/ext/ruby_whisper.cpp
@@ -101,13 +101,13 @@ static VALUE ruby_whisper_s_finalize_log_callback(VALUE self, VALUE id) {
  *   log_set ->(level, buffer, user_data) { ... }, user_data -> nil
  */
 static VALUE ruby_whisper_s_log_set(VALUE self, VALUE log_callback, VALUE user_data) {
-  VALUE old_callback = rb_iv_get(self, "@log_callback");
+  VALUE old_callback = rb_iv_get(self, "log_callback");
   if (!NIL_P(old_callback)) {
     rb_undefine_finalizer(old_callback);
   }
 
-  rb_iv_set(self, "@log_callback", log_callback);
-  rb_iv_set(self, "@user_data", user_data);
+  rb_iv_set(self, "log_callback", log_callback);
+  rb_iv_set(self, "user_data", user_data);
 
   VALUE finalize_log_callback = rb_funcall(mWhisper, rb_intern("method"), 1, rb_str_new2("finalize_log_callback"));
   rb_define_finalizer(log_callback, finalize_log_callback);
@@ -116,8 +116,8 @@ static VALUE ruby_whisper_s_log_set(VALUE self, VALUE log_callback, VALUE user_d
     if (is_log_callback_finalized) {
       return;
     }
-    VALUE log_callback = rb_iv_get(mWhisper, "@log_callback");
-    VALUE udata = rb_iv_get(mWhisper, "@user_data");
+    VALUE log_callback = rb_iv_get(mWhisper, "log_callback");
+    VALUE udata = rb_iv_get(mWhisper, "user_data");
     rb_funcall(log_callback, id_call, 3, INT2NUM(level), rb_str_new2(buffer), udata);
   }, nullptr);
 

--- a/bindings/ruby/ext/ruby_whisper.cpp
+++ b/bindings/ruby/ext/ruby_whisper.cpp
@@ -548,6 +548,7 @@ VALUE ruby_whisper_model_type(VALUE self) {
 /*
  * call-seq:
  *   full(params, samples, n_samples) -> nil
+ *   full(params, samples) -> nil
  *
  * @todo Accept MemoryView as +samples+
  */

--- a/bindings/ruby/ext/ruby_whisper.cpp
+++ b/bindings/ruby/ext/ruby_whisper.cpp
@@ -558,7 +558,7 @@ VALUE ruby_whisper_model_type(VALUE self) {
  *   full(params, samples, n_samples) -> nil
  *   full(params, samples) -> nil
  *
- * The second argument +samples+ must be an array of samples, respond to :length, or be a MemoryView of an array of float
+ * The second argument +samples+ must be an array of samples, respond to :length, or be a MemoryView of an array of float. It must be 32 bit float PCM audio data.
  */
 VALUE ruby_whisper_full(int argc, VALUE *argv, VALUE self) {
   if (argc < 2 || argc > 3) {

--- a/bindings/ruby/tests/helper.rb
+++ b/bindings/ruby/tests/helper.rb
@@ -1,5 +1,6 @@
 require "test/unit"
 require "whisper"
+require_relative "jfk_reader/jfk_reader"
 
 class TestBase < Test::Unit::TestCase
   MODEL = File.join(__dir__, "..", "..", "..", "models", "ggml-base.en.bin")

--- a/bindings/ruby/tests/jfk_reader/.gitignore
+++ b/bindings/ruby/tests/jfk_reader/.gitignore
@@ -1,0 +1,5 @@
+Makefile
+jfk_reader.o
+jfk_reader.so
+jfk_reader.bundle
+jfk_reader.dll

--- a/bindings/ruby/tests/jfk_reader/extconf.rb
+++ b/bindings/ruby/tests/jfk_reader/extconf.rb
@@ -1,0 +1,3 @@
+require "mkmf"
+
+create_makefile("jfk_reader")

--- a/bindings/ruby/tests/jfk_reader/jfk_reader.c
+++ b/bindings/ruby/tests/jfk_reader/jfk_reader.c
@@ -1,0 +1,116 @@
+#include <ruby.h>
+#include <ruby/memory_view.h>
+#include <ruby/encoding.h>
+
+static VALUE
+jfk_reader_initialize(VALUE self, VALUE audio_path)
+{
+  rb_iv_set(self, "audio_path", audio_path);
+  return Qnil;
+}
+
+static bool
+jfk_reader_get_memory_view(const VALUE obj, rb_memory_view_t *view, int flags)
+{
+  VALUE audio_path = rb_iv_get(obj, "audio_path");
+  const char *audio_path_str = StringValueCStr(audio_path);
+  const int n_samples = 176000;
+  float *data = (float *)malloc(n_samples * sizeof(float));
+  short *samples = (short *)malloc(n_samples * sizeof(short));
+  FILE *file = fopen(audio_path_str, "rb");
+
+  fpos_t fsize = { 0 };
+  fseek(file, 0, SEEK_END);
+  fgetpos(file, &fsize);
+
+  fseek(file, 78, SEEK_SET);
+  fread(samples, sizeof(short), n_samples, file);
+  fclose(file);
+  for (int i = 0; i < n_samples; i++) {
+    data[i] = samples[i]/32768.0;
+  }
+
+  view->obj = obj;
+  view->data = (void *)data;
+  view->byte_size = sizeof(float) * n_samples;
+  view->readonly = true;
+  view->format = "f";
+  view->item_size = sizeof(float);
+  view->item_desc.components = NULL;
+  view->item_desc.length = 0;
+  view->ndim = 1;
+  view->shape = NULL;
+  view->sub_offsets = NULL;
+  view->private_data = NULL;
+
+  return true;
+}
+
+static bool
+jfk_reader_release_memory_view(const VALUE obj, rb_memory_view_t *view)
+{
+  return true;
+}
+
+static bool
+jfk_reader_memory_view_available_p(const VALUE obj)
+{
+  return true;
+}
+
+static const rb_memory_view_entry_t jfk_reader_view_entry = {
+  jfk_reader_get_memory_view,
+  jfk_reader_release_memory_view,
+  jfk_reader_memory_view_available_p
+};
+
+static VALUE
+read_jfk(int argc, VALUE *argv, VALUE obj)
+{
+  const char *audio_path_str = StringValueCStr(argv[0]);
+  const int n_samples = 176000;
+
+  short samples[n_samples];
+  FILE *file = fopen(audio_path_str, "rb");
+
+  fpos_t fsize = { 0 };
+  fseek(file, 0, SEEK_END);
+  fgetpos(file, &fsize);
+
+  fseek(file, 78, SEEK_SET);
+  fread(samples, sizeof(short), n_samples, file);
+  fclose(file);
+
+  VALUE rb_samples = rb_ary_new2(n_samples);
+  for (int i = 0; i < n_samples; i++) {
+    rb_ary_push(rb_samples, INT2FIX(samples[i]));
+  }
+
+  VALUE rb_data = rb_ary_new2(n_samples);
+  for (int i = 0; i < n_samples; i++) {
+    rb_ary_push(rb_data, DBL2NUM(samples[i]/32768.0));
+  }
+
+  float data[n_samples];
+  for (int i = 0; i < n_samples; i++) {
+    data[i] = samples[i]/32768.0;
+  }
+  void *c_data = (void *)data;
+  VALUE rb_void = rb_enc_str_new((const char *)c_data, sizeof(data), rb_ascii8bit_encoding());
+
+  VALUE rb_result = rb_ary_new3(3, rb_samples, rb_data, rb_void);
+  return rb_result;
+}
+
+void Init_jfk_reader(void)
+{
+  VALUE cJFKReader = rb_define_class("JFKReader", rb_cObject);
+  rb_memory_view_register(cJFKReader, &jfk_reader_view_entry);
+  rb_define_method(cJFKReader, "initialize", jfk_reader_initialize, 1);
+
+
+  rb_define_global_function("read_jfk", read_jfk, -1);
+
+
+
+}

--- a/bindings/ruby/tests/jfk_reader/jfk_reader.c
+++ b/bindings/ruby/tests/jfk_reader/jfk_reader.c
@@ -19,10 +19,6 @@ jfk_reader_get_memory_view(const VALUE obj, rb_memory_view_t *view, int flags)
   short *samples = (short *)malloc(n_samples * sizeof(short));
   FILE *file = fopen(audio_path_str, "rb");
 
-  fpos_t fsize = { 0 };
-  fseek(file, 0, SEEK_END);
-  fgetpos(file, &fsize);
-
   fseek(file, 78, SEEK_SET);
   fread(samples, sizeof(short), n_samples, file);
   fclose(file);
@@ -72,10 +68,6 @@ read_jfk(int argc, VALUE *argv, VALUE obj)
 
   short samples[n_samples];
   FILE *file = fopen(audio_path_str, "rb");
-
-  fpos_t fsize = { 0 };
-  fseek(file, 0, SEEK_END);
-  fgetpos(file, &fsize);
 
   fseek(file, 78, SEEK_SET);
   fread(samples, sizeof(short), n_samples, file);

--- a/bindings/ruby/tests/test_error.rb
+++ b/bindings/ruby/tests/test_error.rb
@@ -1,0 +1,20 @@
+require_relative "helper"
+
+class TestError < TestBase
+  def test_error
+    error = Whisper::Error.new(-2)
+    assert_equal "failed to compute log mel spectrogram", error.message
+    assert_equal -2, error.code
+  end
+
+  def test_unknown_error
+    error = Whisper::Error.new(-20)
+    assert_equal "unknown error", error.message
+  end
+
+  def test_non_int_code
+    assert_raise TypeError do
+      error = Whisper::Error.new("non int")
+    end
+  end
+end

--- a/bindings/ruby/tests/test_whisper.rb
+++ b/bindings/ruby/tests/test_whisper.rb
@@ -169,8 +169,26 @@ class TestWhisper < TestBase
       end
     end
 
+    def test_full_with_memory_view
+      samples = JFKReader.new(AUDIO)
+      @whisper.full(@params, samples)
+
+      assert_equal 1, @whisper.full_n_segments
+      assert_match /ask not what your country can do for you, ask what you can do for your country/, @whisper.each_segment.first.text
+    end
+
     def test_full_parallel
       @whisper.full_parallel(@params, @samples, @samples.length, Etc.nprocessors)
+
+      assert_equal Etc.nprocessors, @whisper.full_n_segments
+      text = @whisper.each_segment.collect(&:text).join
+      assert_match /ask what you can do/i, text
+      assert_match /for your country/i, text
+    end
+
+    def test_full_parallel_with_memory_view
+      samples = JFKReader.new(AUDIO)
+      @whisper.full_parallel(@params, samples, nil, Etc.nprocessors)
 
       assert_equal Etc.nprocessors, @whisper.full_n_segments
       text = @whisper.each_segment.collect(&:text).join


### PR DESCRIPTION
Hello,

This pull request adds methods corresponding to `whisper_full` and `whisper_full_parallel`. They support Ruby's MemoryView, which allows sharing C (multidimensional) array data with zero copy like Python's buffer protocol.

Thank you.
