### PR TITLE
Add `q8_0` models to `download-ggml-model.sh`

### DIFF
--- a/models/download-ggml-model.sh
+++ b/models/download-ggml-model.sh
@@ -29,26 +29,32 @@ models="tiny
 tiny.en
 tiny-q5_1
 tiny.en-q5_1
+tiny-q8_0
 base
 base.en
 base-q5_1
 base.en-q5_1
+base-q8_0
 small
 small.en
 small.en-tdrz
 small-q5_1
 small.en-q5_1
+small-q8_0
 medium
 medium.en
 medium-q5_0
 medium.en-q5_0
+medium-q8_0
 large-v1
 large-v2
 large-v2-q5_0
+large-v2-8_0
 large-v3
 large-v3-q5_0
 large-v3-turbo
-large-v3-turbo-q5_0"
+large-v3-turbo-q5_0
+large-v3-turbo-q8_0"
 
 # list available models
 list_models() {


### PR DESCRIPTION
Models names as per [v1.7.2 announcement](https://github.com/ggerganov/whisper.cpp/discussions/2572).

PR adds `-q8_0` models for `tiny`, `base`, `small`, `medium`, `large-v2`, & `large-v3-turbo`.

With the changes in this PR, the  remaining differences between the model list in the [v1.7.2 announcement](https://github.com/ggerganov/whisper.cpp/discussions/2572) and `models/download-ggml-model.sh` are:

## Only in `models/download-ggml-model.sh`

* `tiny.en`
* `tiny.en-q5_1`
* `base.en-q5_1`
* `small.en`
* `small.en-tdrz`
* `small.en-q5_1`
* `medium.en`
* `medium.en-q5_0`
* `large-v1`
* `large-v3`
* `large-v3-q5_0`

## Only in [v1.7.2 announcement](https://github.com/ggerganov/whisper.cpp/discussions/2572)

* `tiny`
* `tiny-q5_0`
* `base-q5_0`
* `small-q5_0`
* `medium-q5_1`
* `medium-dis`
* `large-v2-q5_1`
* `large-v2-dis`
