### PR TITLE
Fix typo in `download-ggml-model.sh`

### DIFF
--- a/models/download-ggml-model.sh
+++ b/models/download-ggml-model.sh
@@ -49,7 +49,7 @@ medium-q8_0
 large-v1
 large-v2
 large-v2-q5_0
-large-v2-8_0
+large-v2-q8_0
 large-v3
 large-v3-q5_0
 large-v3-turbo


### PR DESCRIPTION
Whoops, I introduced a typo in #2589 -- `q` was missing from `large-v2-8_0`, should be `large-v2-q8_0` as per [v1.7.2 announcement](https://github.com/ggerganov/whisper.cpp/discussions/2572).