### PR TITLE
Add Missing Include Directory for ggml-cpu in whisper.android CMakeLists

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -564,35 +564,34 @@ jobs:
       - name: Build swiftui example
         run: xcodebuild -project examples/whisper.swiftui/whisper.swiftui.xcodeproj -scheme WhisperCppDemo -configuration ${{ matrix.build }} -sdk iphoneos CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= -destination 'generic/platform=iOS' build
 
-# TODO: update android build and re-enable when it works
-#  android:
-#    runs-on: ubuntu-latest
-#
-#    steps:
-#      - name: Clone
-#        uses: actions/checkout@v4
-#        with:
-#          path: whisper
-#
-#      - name: Install Java
-#        uses: actions/setup-java@v4
-#        with:
-#          distribution: zulu
-#          java-version: 21
-#
-#      - name: Setup Android SDK
-#        uses: android-actions/setup-android@v3
-#
-#      - name: Build
-#        run: |
-#          cd whisper/examples/whisper.android
-#          ./gradlew assembleRelease --no-daemon
-#
-#      - name: Build with external ggml
-#        run: |
-#          export PATH_TO_GGML=$PWD/ggml
-#          cd whisper/examples/whisper.android
-#          ./gradlew assembleRelease --no-daemon
+  android:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Clone
+        uses: actions/checkout@v4
+        with:
+          path: whisper
+
+      - name: Install Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: 21
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Build
+        run: |
+          cd whisper/examples/whisper.android
+          ./gradlew assembleRelease --no-daemon
+
+      - name: Build with external ggml
+        run: |
+          export PATH_TO_GGML=$PWD/ggml
+          cd whisper/examples/whisper.android
+          ./gradlew assembleRelease --no-daemon
 
 # TODO: disable because of following fail: https://github.com/ggerganov/whisper.cpp/actions/runs/11019444420/job/30627193602
 #  android_java:

--- a/examples/whisper.android/lib/src/main/jni/whisper/CMakeLists.txt
+++ b/examples/whisper.android/lib/src/main/jni/whisper/CMakeLists.txt
@@ -88,3 +88,5 @@ include_directories(${WHISPER_LIB_DIR}/src)
 include_directories(${WHISPER_LIB_DIR}/include)
 include_directories(${WHISPER_LIB_DIR}/ggml/include)
 include_directories(${WHISPER_LIB_DIR}/ggml/src)
+include_directories(${WHISPER_LIB_DIR}/ggml/src/ggml-cpu)
+


### PR DESCRIPTION
This PR adds the ggml/src/ggml-cpu directory to the include paths in the CMakeLists.txt for the whisper.android example.
Context:

The JNI version of whisper.android requires the ggml-cpu include path for successful compilation. Without this addition, the build fails with missing header errors on Windows.
Changes:

    Added the ggml/src/ggml-cpu directory to the include_directories list in CMakeLists.txt.

Testing:

    Verified the build completes successfully on Windows after this change.
    Observed the following error when building without this change:

    fatal error: 'ggml-cpu-impl.h' file not found

    1 error generated.
      [4/6] Building CXX object CMakeFiles/whisper_v8fp16_va.dir/C_/Users/adm1n/Desktop/text-generation-webui/whisper.cpp/ggml/src/ggml-cpu/ggml-cpu.cpp.o
      FAILED: CMakeFiles/whisper_v8fp16_va.dir/C_/Users/adm1n/Desktop/text-generation-webui/whisper.cpp/ggml/src/ggml-cpu/ggml-cpu.cpp.o
      C:\Users\adm1n\AppData\Local\Android\Sdk\ndk\25.2.9519653\toolchains\llvm\prebuilt\windows-x86_64\bin\clang++.exe --target=aarch64-none-linux-android26 --sysroot=C:/Users/adm1n/A
    ppData/Local/Android/Sdk/ndk/25.2.9519653/toolchains/llvm/prebuilt/windows-x86_64/sysroot -Dwhisper_v8fp16_va_EXPORTS -IC:/Users/adm1n/Desktop/text-generation-webui/whisper.cpp/exa
    mples/whisper.android/lib/src/main/jni/whisper/../../../../../../.. -IC:/Users/adm1n/Desktop/text-generation-webui/whisper.cpp/examples/whisper.android/lib/src/main/jni/whisper/../
    ../../../../../../src -IC:/Users/adm1n/Desktop/text-generation-webui/whisper.cpp/examples/whisper.android/lib/src/main/jni/whisper/../../../../../../../include -IC:/Users/adm1n/Des
    ktop/text-generation-webui/whisper.cpp/examples/whisper.android/lib/src/main/jni/whisper/../../../../../../../ggml/include -IC:/Users/adm1n/Desktop/text-generation-webui/whisper.cp
    p/examples/whisper.android/lib/src/main/jni/whisper/../../../../../../../ggml/src -g -DANDROID -fdata-sections -ffunction-sections -funwind-tables -fstack-protector-strong -no-cano
    nical-prefixes -D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security   -fno-limit-debug-info  -fPIC -march=armv8.2-a+fp16 -std=gnu++17 -MD -MT CMakeFiles/whisper_v8fp16_va.dir/C_/Us
    ers/adm1n/Desktop/text-generation-webui/whisper.cpp/ggml/src/ggml-cpu/ggml-cpu.cpp.o -MF CMakeFiles\whisper_v8fp16_va.dir\C_\Users\adm1n\Desktop\text-generation-webui\whisper.cpp\g
    gml\src\ggml-cpu\ggml-cpu.cpp.o.d -o CMakeFiles/whisper_v8fp16_va.dir/C_/Users/adm1n/Desktop/text-generation-webui/whisper.cpp/ggml/src/ggml-cpu/ggml-cpu.cpp.o -c C:/Users/adm1n/Desktop/text-generation-webui/whisper.cpp/ggml/src/ggml-cpu/ggml-cpu.cpp
      In file included from C:/Users/adm1n/Desktop/text-generation-webui/whisper.cpp/ggml/src/ggml-cpu/ggml-cpu.cpp:6:
      C:/Users/adm1n/Desktop/text-generation-webui/whisper.cpp/ggml/src/ggml-cpu/amx/amx.h:2:10: fatal error: 'ggml-cpu-impl.h' file not found
      #include "ggml-cpu-impl.h"
               ^~~~~~~~~~~~~~~~~
      1 error generated.
      ninja: build stopped: subcommand failed.

      C++ build system [build] failed while executing:
          @echo off
          "C:\\Users\\adm1n\\AppData\\Local\\Android\\Sdk\\cmake\\3.22.1\\bin\\ninja.exe" ^
            -C ^
            "C:\\Users\\adm1n\\Desktop\\text-generation-webui\\whisper.cpp\\examples\\whisper.android\\lib\\.cxx\\Debug\\3id2k6h3\\arm64-v8a" ^
            whisper ^
            whisper_v8fp16_va
        from C:\Users\adm1n\Desktop\text-generation-webui\whisper.cpp\examples\whisper.android\lib



This is a minor but necessary change to ensure smooth compilation of the JNI example for whisper.android.
