### PR TITLE
Fix hallucinations during silence

### DIFF
--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -6201,10 +6201,12 @@ int whisper_full_with_state(
                 }
             }
 
-            const int single_timestamp_ending = tokens_cur.size() > 1 &&
-                tokens_cur[tokens_cur.size()-2].id < whisper_token_beg(ctx) &&
-                tokens_cur.back().id > whisper_token_beg(ctx);
+            // ref: https://github.com/ggerganov/whisper.cpp/pull/2629
+            const bool single_timestamp_ending = tokens_cur.size() > 1 &&
+                tokens_cur[tokens_cur.size() - 2].id < whisper_token_beg(ctx) &&
+                tokens_cur[tokens_cur.size() - 1].id > whisper_token_beg(ctx);
             if (single_timestamp_ending) {
+                WHISPER_LOG_DEBUG("single timestamp ending - skip entire chunk\n");
                 seek_delta = std::min(seek_end - seek, WHISPER_CHUNK_SIZE * 100);
             }
 

--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -6060,7 +6060,7 @@ int whisper_full_with_state(
         {
             const auto & best_decoder = state->decoders[best_decoder_id];
 
-            const auto seek_delta = best_decoder.seek_delta;
+            auto seek_delta = best_decoder.seek_delta;
             const auto result_len = best_decoder.sequence.result_len;
 
             const auto & tokens_cur = best_decoder.sequence.tokens;
@@ -6199,6 +6199,13 @@ int whisper_full_with_state(
                         }
                     }
                 }
+            }
+
+            const int single_timestamp_ending = tokens_cur.size() > 1 &&
+                tokens_cur[tokens_cur.size()-2].id < whisper_token_beg(ctx) &&
+                tokens_cur.back().id > whisper_token_beg(ctx);
+            if (single_timestamp_ending) {
+                seek_delta = std::min(seek_end - seek, WHISPER_CHUNK_SIZE * 100);
             }
 
             // update audio window


### PR DESCRIPTION
When the predicted tokens end with a single timestamp the the entire 30 segment should be considered as done, to avoid hallucinations for the remaining part of segment.
This behaviour is on par with openai's whisper. Refer to logic related to `single_timestamp_ending` in https://github.com/openai/whisper/blob/main/whisper/transcribe.py