### PR TITLE
fix: prevent division by zero in soft_max vulkan shader

### DIFF
--- a/ggml/src/ggml-vulkan/vulkan-shaders/soft_max.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/soft_max.comp
@@ -32,7 +32,7 @@ shared FLOAT_TYPE vals[BLOCK_SIZE];
 void soft_max(uint num_iters) {
     const uint tid = gl_LocalInvocationID.x;
     const uint rowx = gl_WorkGroupID.z * 262144 + gl_WorkGroupID.y * 512 + gl_WorkGroupID.x;
-    const uint rowy = rowx % p.KY;
+    const uint rowy = (p.KY > 0) ? (rowx % p.KY) : 0;
 
     if (rowx >= p.nrows_x) {
         return;


### PR DESCRIPTION
Fix division by zero error in soft_max vulkan shader

This PR fixes #2596 by adding a check for p.KY being zero in the soft_max compute shader.

Changes:
* Modified the calculation of rowy in soft_max.comp to handle the case where p.KY is 0
* Changed `const uint rowy = rowx % p.KY;` to `const uint rowy = (p.KY > 0) ? (rowx % p.KY) : 0;`

The original code would cause a division by zero error when p.KY is 0. This fix ensures that rowy is set to 0 in such cases, preventing the crash while maintaining the expected behavior in normal scenarios.

Testing:
* Confirmed the fix resolves the crash in my environment
* Existing functionality remains unchanged when p.KY > 0

Note:
This PR is a focused version of #2604, containing only the Vulkan shader fix. The original PR has been closed in favor of this more targeted change to address the specific issue at hand.