### PR TITLE
Fix typo in Java Binding README

### DIFF
--- a/bindings/java/README.md
+++ b/bindings/java/README.md
@@ -67,5 +67,5 @@ copy /y ..\..\build\bin\Release\whisper.dll build\generated\resources\main\win32
 
 ## License
 
-The license for the Go bindings is the same as the license for the rest of the whisper.cpp project, which is the MIT License. See the `LICENSE` file for more details.
+The license for the Java bindings is the same as the license for the rest of the whisper.cpp project, which is the MIT License. See the `LICENSE` file for more details.
 


### PR DESCRIPTION
In the Java Binding README, the license segment said:

> The license for the Go bindings is the same as the license...

I changed "Go" to "Java", as this file has the instructions for the Java binding, not Go. 

I am assuming that the Java bindings are still using the MIT license.