### PR TITLE
Improve consistency in stream exameple README commands

### DIFF
--- a/examples/stream/README.md
+++ b/examples/stream/README.md
@@ -15,7 +15,7 @@ https://user-images.githubusercontent.com/1991296/194935793-76afede7-cfa8-48d8-a
 Setting the `--step` argument to `0` enables the sliding window mode:
 
 ```bash
- ./build/bin/stream -m ./models/ggml-small.en.bin -t 6 --step 0 --length 30000 -vth 0.6
+ ./build/bin/stream -m ./models/ggml-base.en.bin -t 6 --step 0 --length 30000 -vth 0.6
 ```
 
 In this mode, the tool will transcribe only after some speech activity is detected. A very


### PR DESCRIPTION
I playing around with the stream example, and noticed that the top command uses the `base.en` model, and the sliding window command uses the `small.en` model. This doesn't really mater that much, but I had to spend ~20 seconds double checking the commands to see if I typed something wrong. Some consistency can always help.