### PR TITLE
ruby : sync ggml

### DIFF
--- a/bindings/ruby/ext/extconf.rb
+++ b/bindings/ruby/ext/extconf.rb
@@ -162,7 +162,6 @@ end
 
 $OBJ_GGML <<
   'ggml/src/ggml.o' <<
-  'ggml/src/ggml-aarch64.o' <<
   'ggml/src/ggml-alloc.o' <<
   'ggml/src/ggml-backend.o' <<
   'ggml/src/ggml-backend-reg.o' <<
@@ -172,7 +171,9 @@ $OBJ_GGML <<
   'ggml/src/ggml-cpu/ggml-cpu.o' <<
   'ggml/src/ggml-cpu/ggml-cpu-cpp.o' <<
   'ggml/src/ggml-cpu/ggml-cpu-aarch64.o' <<
-  'ggml/src/ggml-cpu/ggml-cpu-quants.o'
+  'ggml/src/ggml-cpu/ggml-cpu-hbm.o' <<
+  'ggml/src/ggml-cpu/ggml-cpu-quants.o' <<
+  'ggml/src/ggml-cpu/ggml-cpu-traits.o'
 
 $OBJ_WHISPER <<
   'src/whisper.o'


### PR DESCRIPTION
Hi,

This pull request fixes build error of Ruby bindings for #2639. Note that this is not sent to `master` but `sync-ggml-24-12-17-0` branch.

Thanks.