### PR TITLE
Exposed whisper_full_get_segment_no_speech_prob_from_state

### DIFF
--- a/include/whisper.h
+++ b/include/whisper.h
@@ -667,6 +667,7 @@ extern "C" {
 
     // Get the no_speech probability for the specified segment
     WHISPER_API float whisper_full_get_segment_no_speech_prob           (struct whisper_context * ctx, int i_segment);
+    WHISPER_API float whisper_full_get_segment_no_speech_prob_from_state(struct whisper_state * state, int i_segment);
 #ifdef __cplusplus
 }
 #endif

--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -6464,6 +6464,10 @@ float whisper_full_get_segment_no_speech_prob(struct whisper_context * ctx, int 
     return ctx->state->result_all[i_segment].no_speech_prob;
 }
 
+float whisper_full_get_segment_no_speech_prob_from_state(struct whisper_state * state, int i_segment) {
+    return state->result_all[i_segment].no_speech_prob;
+}
+
 // =================================================================================================
 
 //


### PR DESCRIPTION
Exposed whisper_full_get_segment_no_speech_prob_from_state in addition to context based retrieval.

This is to make sure that no_speech_prob can be retrieved from the state-based inference calls as well (not only on the default state provided on the context). 