### PR TITLE
talk-llama : add check for deepseek-r1-qwen in llama-vocab.cpp

### DIFF
--- a/examples/talk-llama/llama-vocab.cpp
+++ b/examples/talk-llama/llama-vocab.cpp
@@ -1522,7 +1522,8 @@ void llama_vocab::impl::load(llama_model_loader & ml, const LLM_KV & kv) {
                 pre_type = LLAMA_VOCAB_PRE_TYPE_COMMAND_R;
                 clean_spaces = false;
             } else if (
-                tokenizer_pre == "qwen2") {
+                    tokenizer_pre == "qwen2" ||
+                    tokenizer_pre == "deepseek-r1-qwen") {
                 pre_type = LLAMA_VOCAB_PRE_TYPE_QWEN2;
                 clean_spaces = false;
             } else if (


### PR DESCRIPTION
talk-llama: Add a check for deepseek-r1-qwen in llama-vocab.cpp to be able to run models like unsloth/DeepSeek-R1-Distill-Qwen-32B from HuggingFace. A full sync of llama.cpp could be better if that is automated somehow.

Solves the following unknown pre-tokenizer error when running with DeepSeek-R1-Distill-Qwen-32B:
`llama_model_load: error loading model: error loading model vocabulary: unknown pre-tokenizer type: 'deepseek-r1-qwen'
llama_model_load_from_file: failed to load model
No llama.cpp model specified. Please provide using -ml <modelfile>`