### PR TITLE
Fix coreml export script

### DIFF
--- a/models/convert-whisper-to-coreml.py
+++ b/models/convert-whisper-to-coreml.py
@@ -245,7 +245,7 @@ def convert_encoder(hparams, model, quantize=False):
 
     model = ct.convert(
         traced_model,
-        convert_to=None if quantize else "mlprogram", # convert will fail if weights are quantized, not sure why
+        convert_to="neuralnetwork",
         inputs=[ct.TensorType(name="logmel_data", shape=input_shape)],
         outputs=[ct.TensorType(name="output")],
         compute_units=ct.ComputeUnit.ALL
@@ -268,7 +268,7 @@ def convert_decoder(hparams, model, quantize=False):
 
     model = ct.convert(
         traced_model,
-        convert_to=None if quantize else "mlprogram", # convert will fail if weights are quantized, not sure why
+        convert_to="neuralnetwork",
         inputs=[
             ct.TensorType(name="token_data", shape=tokens_shape, dtype=int),
             ct.TensorType(name="audio_data", shape=audio_shape)


### PR DESCRIPTION
Running the coreml export script fails when using current versions of the `coremltools` package. Specifying `convert_to="neuralnetwork"` solves this issue.

Fixes https://github.com/ggerganov/whisper.cpp/issues/1495