### PR TITLE
Fixes for Windows

### DIFF
--- a/cmake/build-info.cmake
+++ b/cmake/build-info.cmake
@@ -42,6 +42,7 @@ endif()
 if(MSVC)
     set(BUILD_COMPILER "${CMAKE_C_COMPILER_ID} ${CMAKE_C_COMPILER_VERSION}")
     set(BUILD_TARGET ${CMAKE_VS_PLATFORM_NAME})
+    add_compile_options("/utf-8")
 else()
     execute_process(
         COMMAND sh -c "$@ --version | head -1" _ ${CMAKE_C_COMPILER}

--- a/cmake/build-info.cmake
+++ b/cmake/build-info.cmake
@@ -42,7 +42,8 @@ endif()
 if(MSVC)
     set(BUILD_COMPILER "${CMAKE_C_COMPILER_ID} ${CMAKE_C_COMPILER_VERSION}")
     set(BUILD_TARGET ${CMAKE_VS_PLATFORM_NAME})
-    add_compile_options("/utf-8")
+    add_compile_options("$<$<COMPILE_LANGUAGE:C>:/utf-8>")
+    add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:/utf-8>")
 else()
     execute_process(
         COMMAND sh -c "$@ --version | head -1" _ ${CMAKE_C_COMPILER}

--- a/examples/cli/cli.cpp
+++ b/examples/cli/cli.cpp
@@ -12,6 +12,11 @@
 #include <vector>
 #include <cstring>
 
+#if defined(_WIN32)
+#define NOMINMAX
+#include <windows.h>
+#endif
+
 #if defined(_MSC_VER)
 #pragma warning(disable: 4244 4267) // possible loss of data
 #endif
@@ -915,7 +920,14 @@ static bool output_lrc(struct whisper_context * ctx, const char * fname, const w
 
 static void cb_log_disable(enum ggml_log_level , const char * , void * ) { }
 
-int main(int argc, char ** argv) {
+int main(int argc, char **argv) {
+#if defined(_WIN32)
+    // Set the console output code page to UTF-8, while command line arguments
+    // are still encoded in the system's code page. In this way, we can print
+    // non-ASCII characters to the console, and access files with non-ASCII paths.
+    SetConsoleOutputCP(CP_UTF8);
+#endif
+
     whisper_params params;
 
     // If the only argument starts with "@", read arguments line-by-line

--- a/examples/cli/cli.cpp
+++ b/examples/cli/cli.cpp
@@ -920,7 +920,7 @@ static bool output_lrc(struct whisper_context * ctx, const char * fname, const w
 
 static void cb_log_disable(enum ggml_log_level , const char * , void * ) { }
 
-int main(int argc, char **argv) {
+int main(int argc, char ** argv) {
 #if defined(_WIN32)
     // Set the console output code page to UTF-8, while command line arguments
     // are still encoded in the system's code page. In this way, we can print


### PR DESCRIPTION
* MSVC default to utf-8 without BOM.
* Console output code page changed to utf-8.