### PR TITLE
Adjusted stream example to stop on ^C when no audio is received.

### DIFF
--- a/examples/stream/stream.cpp
+++ b/examples/stream/stream.cpp
@@ -244,6 +244,11 @@ int main(int argc, char ** argv) {
 
         if (!use_vad) {
             while (true) {
+                // handle Ctrl + C
+                is_running = sdl_poll_events();
+                if (!is_running) {
+                    break;
+                }
                 audio.get(params.step_ms, pcmf32_new);
 
                 if ((int) pcmf32_new.size() > 2*n_samples_step) {


### PR DESCRIPTION
Add check for ctrl-c in potentially endless loop while calling audio.get() to receive sound.