### PR TITLE
[Fix] When m_audio_pos overflows, m_audio_len should also increase in…

### DIFF
--- a/examples/common-sdl.cpp
+++ b/examples/common-sdl.cpp
@@ -159,15 +159,11 @@ void audio_async::callback(uint8_t * stream, int len) {
 
             memcpy(&m_audio[m_audio_pos], stream, n0 * sizeof(float));
             memcpy(&m_audio[0], stream + n0 * sizeof(float), (n_samples - n0) * sizeof(float));
-
-            m_audio_pos = (m_audio_pos + n_samples) % m_audio.size();
-            m_audio_len = m_audio.size();
         } else {
             memcpy(&m_audio[m_audio_pos], stream, n_samples * sizeof(float));
-
-            m_audio_pos = (m_audio_pos + n_samples) % m_audio.size();
-            m_audio_len = std::min(m_audio_len + n_samples, m_audio.size());
         }
+        m_audio_pos = (m_audio_pos + n_samples) % m_audio.size();
+        m_audio_len = std::min(m_audio_len + n_samples, m_audio.size());
     }
 }
 


### PR DESCRIPTION
In audio_sync, m_audio_pos records the position that should be written from the SDL buffer callback, and m_audio_len records the length of the buffer that has been written.
When the m_audio buffer overflows, m_audio_len is directly set to the buffer length. Is it more reasonable to change this behavior to increase with m_audio_pos until the maximum value? Although this change cannot be realized when the audio stream is read-only or cleared, it seems to be more in line with its meaning?