### PR TITLE
fix: missing include common-whisper in addon.node

### DIFF
--- a/examples/addon.node/addon.cpp
+++ b/examples/addon.node/addon.cpp
@@ -1,5 +1,6 @@
 #include "napi.h"
 #include "common.h"
+#include "common-whisper.h"
 
 #include "whisper.h"
 


### PR DESCRIPTION
Because of this commit: 、

https://github.com/ggerganov/whisper.cpp/commit/c64f3e8adabb52232332d805e4b681cd58e29739, 

we need to also modify the reference to common-whisper in addon.node. 

Otherwise, it will throw the error: ·
·
`error: use of undeclared identifier 'to_timestamp'.`