### PR TITLE
examples : add dl to the list of libraries linked

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -61,7 +61,11 @@ add_library(${TARGET} STATIC
 
 include(DefaultTargetOptions)
 
-target_link_libraries(${TARGET} PRIVATE whisper ${COMMON_EXTRA_LIBS} dl)
+if(UNIX AND NOT APPLE)
+  target_link_libraries(${TARGET} PRIVATE whisper ${COMMON_EXTRA_LIBS} dl)
+else()
+  target_link_libraries(${TARGET} PRIVATE whisper ${COMMON_EXTRA_LIBS})
+endif()
 
 set_target_properties(${TARGET} PROPERTIES POSITION_INDEPENDENT_CODE ON)
 set_target_properties(${TARGET} PROPERTIES FOLDER "libs")

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -61,11 +61,7 @@ add_library(${TARGET} STATIC
 
 include(DefaultTargetOptions)
 
-if(UNIX AND NOT APPLE)
-  target_link_libraries(${TARGET} PRIVATE whisper ${COMMON_EXTRA_LIBS} dl)
-else()
-  target_link_libraries(${TARGET} PRIVATE whisper ${COMMON_EXTRA_LIBS})
-endif()
+target_link_libraries(${TARGET} PRIVATE whisper ${COMMON_EXTRA_LIBS} ${CMAKE_DL_LIBS})
 
 set_target_properties(${TARGET} PROPERTIES POSITION_INDEPENDENT_CODE ON)
 set_target_properties(${TARGET} PROPERTIES FOLDER "libs")

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -61,7 +61,7 @@ add_library(${TARGET} STATIC
 
 include(DefaultTargetOptions)
 
-target_link_libraries(${TARGET} PRIVATE whisper ${COMMON_EXTRA_LIBS})
+target_link_libraries(${TARGET} PRIVATE whisper ${COMMON_EXTRA_LIBS} dl)
 
 set_target_properties(${TARGET} PROPERTIES POSITION_INDEPENDENT_CODE ON)
 set_target_properties(${TARGET} PROPERTIES FOLDER "libs")


### PR DESCRIPTION
This commit adds the dynamic linker library to the list of libraries linked by the examples.

The motivation for this change is that when building the examples on ubuntu 20.04, which uses GCC 9.4.0, the dynamic linker requires explicit linking or the following error is generated:
```console
[ 64%] Linking CXX executable ../../bin/whisper-cli
cd /app/whisper.cpp/build/examples/cli && /usr/bin/cmake -E cmake_link_script CMakeFiles/whisper-cli.dir/link.txt --verbose=1
/usr/bin/c++  -O3 -DNDEBUG   CMakeFiles/whisper-cli.dir/cli.cpp.o  -o ../../bin/whisper-cli  -Wl,-rpath,/app/whisper.cpp/build/src:/app/whisper.cpp/build/ggml/src: ../libcommon.a ../../src/libwhisper.so.1.7.4 -pthread ../../ggml/src/libggml.so ../../ggml/src/libggml-cpu.so ../../ggml/src/libggml-base.so
/usr/bin/ld: ../libcommon.a(common-whisper.cpp.o): undefined reference to symbol 'dlclose@@GLIBC_2.2.5'
/usr/bin/ld: /lib/x86_64-linux-gnu/libdl.so.2: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make[2]: *** [examples/cli/CMakeFiles/whisper-cli.dir/build.make:89: bin/whisper-cli] Error 1
make[2]: Leaving directory '/app/whisper.cpp/build'
make[1]: *** [CMakeFiles/Makefile2:433: examples/cli/CMakeFiles/whisper-cli.dir/all] Error 2
make[1]: Leaving directory '/app/whisper.cpp/build'
make: *** [Makefile:130: all] Error 2
```

Refs: https://github.com/ggerganov/whisper.cpp/issues/2854