### PR TITLE
whisper : add option to use system-installed GGML

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,8 @@ option(WHISPER_ALL_WARNINGS           "whisper: enable all compiler warnings"   
 option(WHISPER_ALL_WARNINGS_3RD_PARTY "whisper: enable all compiler warnings in 3rd party libs" OFF)
 
 # build
-option(WHISPER_FATAL_WARNINGS "whisper: enable -Werror flag" OFF)
+option(WHISPER_FATAL_WARNINGS  "whisper: enable -Werror flag"               OFF)
+option(WHISPER_USE_SYSTEM_GGML "whisper: use system-installed GGML library" OFF)
 
 # sanitizers
 option(WHISPER_SANITIZE_THREAD    "whisper: enable thread sanitizer"    OFF)
@@ -121,7 +122,15 @@ whisper_option_depr(WARNING     WHISPER_SYCL_F16            GGML_SYCL_F16)
 #
 
 if (NOT TARGET ggml)
-    add_subdirectory(ggml)
+    if (WHISPER_USE_SYSTEM_GGML)
+        find_package(ggml REQUIRED)
+        if (NOT ggml_FOUND)
+            message(FATAL_ERROR "System-installed GGML library not found.")
+        endif()
+        add_library(ggml ALIAS ggml::ggml)
+    else()
+        add_subdirectory(ggml)
+    endif()
     # ... otherwise assume ggml is added by a parent CMakeLists.txt
 endif()
 add_subdirectory(src)


### PR DESCRIPTION
Introduces a new CMake option, WHISPER_USE_SYSTEM_GGML (default: OFF), allowing users to use a system-installed GGML library instead of building the bundled one. When enabled, CMake attempts to find GGML using find_package(ggml REQUIRED). If GGML is not found, the build fails with an error.

If the option is disabled, the project falls back to using the bundled GGML.

Tested in an MSYS2 environment using GGML from the llama.cpp package as a shared library.

This change improves flexibility for packagers and advanced users who prefer system-wide GGML installations.