### PR TITLE
ci : add release job and include xcframework

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,8 @@ jobs:
           echo "name=$TAG_NAME" >> $GITHUB_OUTPUT
 
   ubuntu-22:
-    if: ${{ github.event_name == 'push' || github.event.inputs.run_type == 'full-ci' }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' ||
+            github.event.inputs.run_type == 'full-ci' }}
     runs-on: ubuntu-22.04
 
     strategy:
@@ -105,7 +106,8 @@ jobs:
             cmake --build build --config Release -j $(nproc)'
 
   ubuntu-22-arm64:
-    if: ${{ github.event_name == 'push' || github.event.inputs.run_type == 'full-ci' }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' ||
+            github.event.inputs.run_type == 'full-ci' }}
     runs-on: ubuntu-22.04
 
     strategy:
@@ -132,7 +134,8 @@ jobs:
             cmake --build build --config Release -j $(nproc)'
 
   ubuntu-22-arm-v7:
-    if: ${{ github.event_name == 'push' || github.event.inputs.run_type == 'full-ci' }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' ||
+            github.event.inputs.run_type == 'full-ci' }}
     runs-on: ubuntu-22.04
 
     strategy:
@@ -159,7 +162,8 @@ jobs:
             cmake --build build --config Release -j $(nproc)'
 
   macOS-latest:
-    if: ${{ github.event_name == 'push' || github.event.inputs.run_type == 'full-ci' }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' ||
+            github.event.inputs.run_type == 'full-ci' }}
     runs-on: macOS-latest
 
     strategy:
@@ -214,7 +218,8 @@ jobs:
 #            cmake --build build --config Release
 
   ubuntu-22-gcc:
-    if: ${{ github.event_name == 'push' || github.event.inputs.run_type == 'full-ci' }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' ||
+            github.event.inputs.run_type == 'full-ci' }}
     runs-on: ubuntu-22.04
 
     strategy:
@@ -243,7 +248,8 @@ jobs:
             ctest -L gh --output-on-failure'
 
   ubuntu-22-gcc-arm64:
-    if: ${{ github.event_name == 'push' || github.event.inputs.run_type == 'full-ci' }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' ||
+            github.event.inputs.run_type == 'full-ci' }}
     runs-on: ubuntu-22.04
 
     strategy:
@@ -272,7 +278,8 @@ jobs:
             ctest -L gh --output-on-failure'
 
   ubuntu-22-gcc-arm-v7:
-    if: ${{ github.event_name == 'push' || github.event.inputs.run_type == 'full-ci' }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' ||
+            github.event.inputs.run_type == 'full-ci' }}
     runs-on: ubuntu-22.04
 
     strategy:
@@ -301,7 +308,8 @@ jobs:
             ctest -L gh --output-on-failure'
 
   ubuntu-22-clang:
-    if: ${{ github.event_name == 'push' || github.event.inputs.run_type == 'full-ci' }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' ||
+            github.event.inputs.run_type == 'full-ci' }}
     runs-on: ubuntu-22.04
 
     strategy:
@@ -333,7 +341,8 @@ jobs:
             ctest -L gh --output-on-failure'
 
   ubuntu-22-gcc-sanitized:
-    if: ${{ github.event_name == 'push' || github.event.inputs.run_type == 'full-ci' }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' ||
+            github.event.inputs.run_type == 'full-ci' }}
     runs-on: ubuntu-22.04
 
     strategy:
@@ -362,7 +371,8 @@ jobs:
             ctest -L gh --output-on-failure'
 
   ubuntu-22-cmake-sycl:
-    if: ${{ github.event_name == 'push' || github.event.inputs.run_type == 'full-ci' }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' ||
+            github.event.inputs.run_type == 'full-ci' }}
     runs-on: ubuntu-22.04
 
     strategy:
@@ -413,7 +423,8 @@ jobs:
           cmake --build . --config Release -j $(nproc)
 
   ubuntu-22-cmake-sycl-fp16:
-    if: ${{ github.event_name == 'push' || github.event.inputs.run_type == 'full-ci' }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' ||
+            github.event.inputs.run_type == 'full-ci' }}
     runs-on: ubuntu-22.04
 
     strategy:
@@ -464,7 +475,8 @@ jobs:
           cmake --build . --config Release -j $(nproc)
 
   windows-msys2:
-    if: ${{ github.event_name == 'push' || github.event.inputs.run_type == 'full-ci' }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' ||
+            github.event.inputs.run_type == 'full-ci' }}
     runs-on: windows-latest
 
     strategy:
@@ -509,7 +521,8 @@ jobs:
             cmake --build build --config ${{ matrix.build }} -j $(nproc)
 
   windows:
-    if: ${{ github.event_name == 'push' || github.event.inputs.run_type == 'full-ci' }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' ||
+            github.event.inputs.run_type == 'full-ci' }}
     runs-on: windows-latest
 
     strategy:
@@ -570,7 +583,8 @@ jobs:
           path: build/bin/${{ matrix.build }}
 
   windows-blas:
-    if: ${{ github.event_name == 'push' || github.event.inputs.run_type == 'full-ci' }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' ||
+            github.event.inputs.run_type == 'full-ci' }}
     runs-on: windows-latest
 
     strategy:
@@ -644,7 +658,8 @@ jobs:
           path: build/bin/${{ matrix.build }}
 
   windows-cublas:
-    if: ${{ github.event_name == 'push' || github.event.inputs.run_type == 'full-ci' }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' ||
+            github.event.inputs.run_type == 'full-ci' }}
     runs-on: windows-2019
     strategy:
       matrix:
@@ -713,7 +728,8 @@ jobs:
           path: build/bin/${{ matrix.build }}
 
   emscripten:
-    if: ${{ github.event_name == 'push' || github.event.inputs.run_type == 'full-ci' }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' ||
+            github.event.inputs.run_type == 'full-ci' }}
     runs-on: ubuntu-22.04
 
     strategy:
@@ -798,7 +814,8 @@ jobs:
           name: whisper-${{ needs.determine-tag.outputs.tag_name }}-xcframework
 
   android:
-    if: ${{ github.event_name == 'push' || github.event.inputs.run_type == 'full-ci' }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' ||
+            github.event.inputs.run_type == 'full-ci' }}
     runs-on: ubuntu-22.04
 
     steps:
@@ -898,7 +915,8 @@ jobs:
 #          PGP_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
   quantize:
-    if: ${{ github.event_name == 'push' || github.event.inputs.run_type == 'full-ci' }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' ||
+            github.event.inputs.run_type == 'full-ci' }}
     runs-on: ubuntu-22.04
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,17 +6,79 @@ on:
       - master
   pull_request:
     types: [opened, synchronize, reopened]
+  workflow_dispatch:
+    inputs:
+      create_release:
+        description: 'Create new release'
+        required: true
+        type: boolean
+      pre_release_tag:
+        description: 'Pre-release tag name'
+        required: false
+        type: string
+      run_type:
+        description: 'Workflow type to run'
+        required: true
+        type: choice
+        options:
+          - full-ci
+          - release-only
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
   cancel-in-progress: true
+
+permissions:
+  contents: write  # for creating release
 
 env:
   ubuntu_image: "ubuntu:22.04"
   VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
 
 jobs:
+  determine-tag:
+    runs-on: ubuntu-latest
+    outputs:
+      tag_name: ${{ steps.tag.outputs.name }}
+
+    steps:
+      - name: Checkout with full history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine tag name
+        id: tag
+        shell: bash
+        run: |
+          BUILD_NUMBER=$(git rev-list --count HEAD)
+          SHORT_HASH=$(git rev-parse --short=7 HEAD)
+          CUSTOM_TAG="${{ github.event.inputs.pre_release_tag }}"
+
+          echo "Raw values:"
+          echo "BUILD_NUMBER: $BUILD_NUMBER"
+          echo "SHORT_HASH: $SHORT_HASH"
+          echo "BRANCH_NAME: ${{ env.BRANCH_NAME }}"
+          echo "CUSTOM_TAG: $CUSTOM_TAG"
+
+          # Use custom tag if provided
+          if [[ -n "$CUSTOM_TAG" ]]; then
+            echo "Using custom tag"
+            TAG_NAME="${CUSTOM_TAG}"
+          elif [[ "${{ env.BRANCH_NAME }}" == "master" ]]; then
+            echo "Using master branch format"
+            TAG_NAME="b${BUILD_NUMBER}"
+          else
+            echo "Using non-master branch format"
+            SAFE_NAME=$(echo "${{ env.BRANCH_NAME }}" | tr '/' '-')
+            TAG_NAME="${SAFE_NAME}-b${BUILD_NUMBER}-${SHORT_HASH}"
+          fi
+
+          echo "Final tag name: $TAG_NAME"
+          echo "name=$TAG_NAME" >> $GITHUB_OUTPUT
+
   ubuntu-22:
+    if: ${{ github.event_name == 'push' || github.event.inputs.run_type == 'full-ci' }}
     runs-on: ubuntu-22.04
 
     strategy:
@@ -43,6 +105,7 @@ jobs:
             cmake --build build --config Release -j $(nproc)'
 
   ubuntu-22-arm64:
+    if: ${{ github.event_name == 'push' || github.event.inputs.run_type == 'full-ci' }}
     runs-on: ubuntu-22.04
 
     strategy:
@@ -69,6 +132,7 @@ jobs:
             cmake --build build --config Release -j $(nproc)'
 
   ubuntu-22-arm-v7:
+    if: ${{ github.event_name == 'push' || github.event.inputs.run_type == 'full-ci' }}
     runs-on: ubuntu-22.04
 
     strategy:
@@ -95,6 +159,7 @@ jobs:
             cmake --build build --config Release -j $(nproc)'
 
   macOS-latest:
+    if: ${{ github.event_name == 'push' || github.event.inputs.run_type == 'full-ci' }}
     runs-on: macOS-latest
 
     strategy:
@@ -129,11 +194,6 @@ jobs:
             -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64"
           cmake --build build --config Release -j $(sysctl -n hw.logicalcpu)
 
-      - name: xcodebuild for swift package
-        id: xcodebuild
-        run: |
-          ./build-xcframework.sh
-
 
 #  freeBSD-latest:
 #    runs-on: macos-12
@@ -154,6 +214,7 @@ jobs:
 #            cmake --build build --config Release
 
   ubuntu-22-gcc:
+    if: ${{ github.event_name == 'push' || github.event.inputs.run_type == 'full-ci' }}
     runs-on: ubuntu-22.04
 
     strategy:
@@ -182,6 +243,7 @@ jobs:
             ctest -L gh --output-on-failure'
 
   ubuntu-22-gcc-arm64:
+    if: ${{ github.event_name == 'push' || github.event.inputs.run_type == 'full-ci' }}
     runs-on: ubuntu-22.04
 
     strategy:
@@ -210,6 +272,7 @@ jobs:
             ctest -L gh --output-on-failure'
 
   ubuntu-22-gcc-arm-v7:
+    if: ${{ github.event_name == 'push' || github.event.inputs.run_type == 'full-ci' }}
     runs-on: ubuntu-22.04
 
     strategy:
@@ -238,6 +301,7 @@ jobs:
             ctest -L gh --output-on-failure'
 
   ubuntu-22-clang:
+    if: ${{ github.event_name == 'push' || github.event.inputs.run_type == 'full-ci' }}
     runs-on: ubuntu-22.04
 
     strategy:
@@ -269,6 +333,7 @@ jobs:
             ctest -L gh --output-on-failure'
 
   ubuntu-22-gcc-sanitized:
+    if: ${{ github.event_name == 'push' || github.event.inputs.run_type == 'full-ci' }}
     runs-on: ubuntu-22.04
 
     strategy:
@@ -297,6 +362,7 @@ jobs:
             ctest -L gh --output-on-failure'
 
   ubuntu-22-cmake-sycl:
+    if: ${{ github.event_name == 'push' || github.event.inputs.run_type == 'full-ci' }}
     runs-on: ubuntu-22.04
 
     strategy:
@@ -347,6 +413,7 @@ jobs:
           cmake --build . --config Release -j $(nproc)
 
   ubuntu-22-cmake-sycl-fp16:
+    if: ${{ github.event_name == 'push' || github.event.inputs.run_type == 'full-ci' }}
     runs-on: ubuntu-22.04
 
     strategy:
@@ -397,6 +464,7 @@ jobs:
           cmake --build . --config Release -j $(nproc)
 
   windows-msys2:
+    if: ${{ github.event_name == 'push' || github.event.inputs.run_type == 'full-ci' }}
     runs-on: windows-latest
 
     strategy:
@@ -441,6 +509,7 @@ jobs:
             cmake --build build --config ${{ matrix.build }} -j $(nproc)
 
   windows:
+    if: ${{ github.event_name == 'push' || github.event.inputs.run_type == 'full-ci' }}
     runs-on: windows-latest
 
     strategy:
@@ -501,6 +570,7 @@ jobs:
           path: build/bin/${{ matrix.build }}
 
   windows-blas:
+    if: ${{ github.event_name == 'push' || github.event.inputs.run_type == 'full-ci' }}
     runs-on: windows-latest
 
     strategy:
@@ -574,6 +644,7 @@ jobs:
           path: build/bin/${{ matrix.build }}
 
   windows-cublas:
+    if: ${{ github.event_name == 'push' || github.event.inputs.run_type == 'full-ci' }}
     runs-on: windows-2019
     strategy:
       matrix:
@@ -642,6 +713,7 @@ jobs:
           path: build/bin/${{ matrix.build }}
 
   emscripten:
+    if: ${{ github.event_name == 'push' || github.event.inputs.run_type == 'full-ci' }}
     runs-on: ubuntu-22.04
 
     strategy:
@@ -665,6 +737,7 @@ jobs:
 
   ios-xcode-build:
     runs-on: macos-latest
+    needs: determine-tag
 
     strategy:
       matrix:
@@ -707,7 +780,25 @@ jobs:
       - name: Build swiftui example
         run: xcodebuild -project examples/whisper.swiftui/whisper.swiftui.xcodeproj -scheme WhisperCppDemo -configuration ${{ matrix.build }} -sdk iphoneos CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= -destination 'generic/platform=iOS' FRAMEWORK_FOLDER_PATH=./build-ios build
 
+      - name: Pack artifacts
+        id: pack_artifacts
+        if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/master') ||
+                github.event.inputs.create_release == 'true' ||
+                github.event.inputs.pre_release_tag != '' }}
+        run: |
+          zip --symlinks -r whisper-${{ needs.determine-tag.outputs.tag_name }}-xcframework.zip build-apple/whisper.xcframework
+
+      - name: Upload artifacts
+        if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/master') ||
+                github.event.inputs.create_release == 'true' ||
+                github.event.inputs.pre_release_tag != '' }}
+        uses: actions/upload-artifact@v4
+        with:
+          path: whisper-${{ needs.determine-tag.outputs.tag_name }}-xcframework.zip
+          name: whisper-${{ needs.determine-tag.outputs.tag_name }}-xcframework
+
   android:
+    if: ${{ github.event_name == 'push' || github.event.inputs.run_type == 'full-ci' }}
     runs-on: ubuntu-22.04
 
     steps:
@@ -807,6 +898,7 @@ jobs:
 #          PGP_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
   quantize:
+    if: ${{ github.event_name == 'push' || github.event.inputs.run_type == 'full-ci' }}
     runs-on: ubuntu-22.04
 
     steps:
@@ -819,3 +911,69 @@ jobs:
           cmake -B build
           cmake --build build --config Release
           ./build/bin/quantize models/ggml-tiny.en.bin models/ggml-tiny.en-q4_0.bin q4_0
+
+  release:
+    if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/master') ||
+            github.event.inputs.create_release == 'true' ||
+            github.event.inputs.pre_release_tag != '' }}
+
+    runs-on: ubuntu-latest
+
+    needs:
+      - determine-tag
+      - ios-xcode-build
+
+    steps:
+      - name: Clone
+        id: checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2.16
+        with:
+          key: release
+          evict-old-files: 1d
+
+      # Downloads all the artifacts from the previous jobs
+      - name: Download artifacts
+        id: download-artifact
+        uses: actions/download-artifact@v4
+        with:
+          path: ./artifact
+
+      - name: Move artifacts
+        id: move_artifacts
+        run: mkdir -p ./artifact/release && mv ./artifact/*/*.zip ./artifact/release
+
+      - name: Create release
+        id: create_release
+        uses: ggml-org/action-create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ needs.determine-tag.outputs.tag_name }}
+          prerelease: ${{ github.event.inputs.pre_release_tag != '' }}
+
+      - name: Upload release
+        id: upload_release
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const path = require('path');
+            const fs = require('fs');
+            const release_id = '${{ steps.create_release.outputs.id }}';
+            for (let file of await fs.readdirSync('./artifact/release')) {
+              if (path.extname(file) === '.zip') {
+                console.log('uploadReleaseAsset', file);
+                await github.repos.uploadReleaseAsset({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  release_id: release_id,
+                  name: file,
+                  data: await fs.readFileSync(`./artifact/release/${file}`)
+                });
+              }
+            }


### PR DESCRIPTION
This commit adds a release job that uploads the xcframework as an artifact and creates a release with the xcframework as an asset.

This job can be triggered manually and enables a pre-release tag name to be specified to that these releases can be distinguished from the regular releases more easily.

Resolves: https://github.com/ggerganov/whisper.cpp/issues/2886