### PR TITLE
ci : add ccache action to windows-cublas job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -590,6 +590,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v4
 
+      - name: Install ccache
+        uses: hendrikmuhs/ccache-action@v1.2.16
+        with:
+          key: ${{ github.job }}-${{ matrix.cuda-toolkit }}-${{ matrix.build }}
+          variant: sccache
+          evict-old-files: 1d
+
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v2
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -639,6 +639,11 @@ jobs:
             -DGGML_CUDA=${{ matrix.cublas }} ^
             -DCMAKE_CUDA_ARCHITECTURES=all  ^
             -DWHISPER_SDL2=${{ matrix.sdl2 }} ^
+            -DCMAKE_CUDA_COMPILER_LAUNCHER=sccache ^
+            -DCMAKE_C_COMPILER_LAUNCHER=sccache ^
+            -DCMAKE_CXX_COMPILER_LAUNCHER=sccache ^
+            -DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded ^
+            -DCMAKE_POLICY_CMP0141=NEW ^
             -DSDL2_DIR="%SDL2_DIR%"
 
       - name: Build Project

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -597,6 +597,12 @@ jobs:
           variant: sccache
           evict-old-files: 1d
 
+      - name: Install CUDA Toolkit
+        id: cuda-toolkit
+        uses: Jimver/cuda-toolkit@v0.2.15
+        with:
+          cuda: '${{ matrix.cuda-toolkit }}'
+
       - name: Configure CUDA compilation cache
         run: |
           New-Item -Path "${{ github.workspace }}\cuda_cache" -ItemType Directory -Force
@@ -613,12 +619,6 @@ jobs:
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v2
-
-      - name: Install CUDA Toolkit
-        id: cuda-toolkit
-        uses: Jimver/cuda-toolkit@v0.2.15
-        with:
-          cuda: '${{ matrix.cuda-toolkit }}'
 
       - name: Install 7-Zip
         run: choco install 7zip -y

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -597,6 +597,20 @@ jobs:
           variant: sccache
           evict-old-files: 1d
 
+      - name: Configure CUDA compilation cache
+        run: |
+          New-Item -Path "${{ github.workspace }}/cuda_cache" -ItemType Directory -Force
+          echo "CUDA_CACHE_PATH=${{ github.workspace }}/cuda_cache" | Out-File -FilePath $env:GITHUB_ENV -Append
+          echo "CUDA_CACHE_MAXSIZE=4294967296" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+      - name: Cache CUDA compilation results
+        uses: actions/cache@v3
+        with:
+          path: ${{ github.workspace }}/cuda_cache
+          key: cuda-cache-${{ runner.os }}-${{ matrix.cuda-toolkit }}-${{ hashFiles('**/*.cu', '**/*.cuh') }}
+          restore-keys: |
+            cuda-cache-${{ runner.os }}-${{ matrix.cuda-toolkit }}-
+
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v2
 
@@ -631,7 +645,7 @@ jobs:
         shell: cmd
         run: |
           cd ./build
-          cmake --build . --config ${{ matrix.build }}
+          cmake --build . --config ${{ matrix.build }} -j %NUMBER_OF_PROCESSORS%
 
       - name: Copy CUDA DLLs
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -604,7 +604,6 @@ jobs:
           echo "CUDA_CACHE_MAXSIZE=4294967296" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Install Cuda Toolkit 11.8.0
-        id: cuda-toolkit
         if: ${{ matrix.cuda-toolkit == '11.8.0' }}
         run: |
           mkdir -p "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8.0"
@@ -633,7 +632,6 @@ jobs:
           echo "CUDA_PATH_V11_8=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8.0" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
 
       - name: Install Cuda Toolkit 12.2
-        id: cuda-toolkit
         if: ${{ matrix.cuda-toolkit == '12.2.0' }}
         run: |
           mkdir -p "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.2.0"
@@ -715,7 +713,7 @@ jobs:
 
       - name: Copy CUDA DLLs
         run: |
-          Get-ChildItem "${{ steps.cuda-toolkit.outputs.CUDA_PATH }}/bin/" -Filter "*.dll" |
+          Get-ChildItem "$env:CUDA_PATH\bin\" -Filter "*.dll" |
           Copy-Item -Destination "build/bin/${{ matrix.build }}"
 
       - name: Copy SDL2.dll

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -625,11 +625,11 @@ jobs:
           xcopy "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8.0\visual_studio_integration-windows-x86_64-11.8.86-archive\*" "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8.0" /E /I /H /Y
           xcopy "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8.0\cuda_nvprof-windows-x86_64-11.8.87-archive\*" "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8.0" /E /I /H /Y
           xcopy "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8.0\cuda_cccl-windows-x86_64-11.8.89-archive\*" "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8.0" /E /I /H /Y
+          xcopy "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8.0\visual_studio_integration-windows-x86_64-11.8.86-archive\visual_studio_integration\MSBuildExtensions\*" "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Microsoft\VC\v160\BuildCustomizations" /E /I /H /Y
           echo "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8.0\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           echo "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8.0\libnvvp" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           echo "CUDA_PATH=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8.0" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
           echo "CUDA_PATH_V11_8=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8.0" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
-          xcopy "%CUDA_PATH%\visual_studio_integration-windows-x86_64*\MSBuildExtensions\*" "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Microsoft\VC\v160\BuildCustomizations" /E /I /H /Y
 
       - name: Install Cuda Toolkit 12.2
         if: ${{ matrix.cuda-toolkit == '12.2.0' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -630,6 +630,9 @@ jobs:
           echo "CUDA_PATH=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8.0" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
           echo "CUDA_PATH_V11_8=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8.0" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
 
+          mkdir -p "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Microsoft\VC\v160\BuildCustomizations"
+          xcopy "%CUDA_PATH%\visual_studio_integration-windows-x86_64*\MSBuildExtensions\*" "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Microsoft\VC\v160\BuildCustomizations" /E /I /H /Y
+
       - name: Install Cuda Toolkit 12.2
         if: ${{ matrix.cuda-toolkit == '12.2.0' }}
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -629,8 +629,6 @@ jobs:
           echo "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8.0\libnvvp" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           echo "CUDA_PATH=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8.0" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
           echo "CUDA_PATH_V11_8=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8.0" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
-
-          mkdir -p "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Microsoft\VC\v160\BuildCustomizations"
           xcopy "%CUDA_PATH%\visual_studio_integration-windows-x86_64*\MSBuildExtensions\*" "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Microsoft\VC\v160\BuildCustomizations" /E /I /H /Y
 
       - name: Install Cuda Toolkit 12.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -684,6 +684,7 @@ jobs:
       - name: Configure CMake
         shell: cmd
         run: |
+          set "CUDACXX=sccache %CUDA_PATH%\bin\nvcc.exe"
           cmake -S . -B ./build -A ${{ matrix.arch }} ^
             -DCMAKE_BUILD_TYPE=${{ matrix.build }} ^
             -DGGML_CUDA=${{ matrix.cublas }} ^
@@ -695,6 +696,10 @@ jobs:
             -DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded ^
             -DCMAKE_POLICY_CMP0141=NEW ^
             -DSDL2_DIR="%SDL2_DIR%"
+
+      - name: Check sccache status after build
+        run: |
+          sccache --show-stats
 
       - name: Build Project
         shell: cmd

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -599,8 +599,8 @@ jobs:
 
       - name: Configure CUDA compilation cache
         run: |
-          New-Item -Path "${{ github.workspace }}/cuda_cache" -ItemType Directory -Force
-          echo "CUDA_CACHE_PATH=${{ github.workspace }}/cuda_cache" | Out-File -FilePath $env:GITHUB_ENV -Append
+          New-Item -Path "${{ github.workspace }}\cuda_cache" -ItemType Directory -Force
+          echo "CUDA_CACHE_PATH=${{ github.workspace }}\cuda_cache" | Out-File -FilePath $env:GITHUB_ENV -Append
           echo "CUDA_CACHE_MAXSIZE=4294967296" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Cache CUDA compilation results

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -684,6 +684,7 @@ jobs:
       - name: Configure CMake
         shell: cmd
         run: |
+          call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           set "CUDACXX=sccache %CUDA_PATH%\bin\nvcc.exe"
           cmake -S . -B ./build -A ${{ matrix.arch }} ^
             -DCMAKE_BUILD_TYPE=${{ matrix.build }} ^
@@ -704,6 +705,7 @@ jobs:
       - name: Build Project
         shell: cmd
         run: |
+          call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           cd ./build
           cmake --build . --config ${{ matrix.build }} -j %NUMBER_OF_PROCESSORS%
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -604,6 +604,7 @@ jobs:
           echo "CUDA_CACHE_MAXSIZE=4294967296" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Install Cuda Toolkit 11.8.0
+        id: cuda-toolkit
         if: ${{ matrix.cuda-toolkit == '11.8.0' }}
         run: |
           mkdir -p "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8.0"
@@ -632,6 +633,7 @@ jobs:
           echo "CUDA_PATH_V11_8=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8.0" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
 
       - name: Install Cuda Toolkit 12.2
+        id: cuda-toolkit
         if: ${{ matrix.cuda-toolkit == '12.2.0' }}
         run: |
           mkdir -p "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.2.0"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -597,17 +597,67 @@ jobs:
           variant: sccache
           evict-old-files: 1d
 
-      - name: Install CUDA Toolkit
-        id: cuda-toolkit
-        uses: Jimver/cuda-toolkit@v0.2.15
-        with:
-          cuda: '${{ matrix.cuda-toolkit }}'
-
       - name: Configure CUDA compilation cache
         run: |
           New-Item -Path "${{ github.workspace }}\cuda_cache" -ItemType Directory -Force
           echo "CUDA_CACHE_PATH=${{ github.workspace }}\cuda_cache" | Out-File -FilePath $env:GITHUB_ENV -Append
           echo "CUDA_CACHE_MAXSIZE=4294967296" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+      - name: Install Cuda Toolkit 11.8.0
+        if: ${{ matrix.cuda-toolkit == '11.8.0' }}
+        run: |
+          mkdir -p "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8.0"
+          choco install unzip -y
+          curl -O "https://developer.download.nvidia.com/compute/cuda/redist/cuda_cudart/windows-x86_64/cuda_cudart-windows-x86_64-11.8.89-archive.zip"
+          curl -O "https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvcc/windows-x86_64/cuda_nvcc-windows-x86_64-11.8.89-archive.zip"
+          curl -O "https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvrtc/windows-x86_64/cuda_nvrtc-windows-x86_64-11.8.89-archive.zip"
+          curl -O "https://developer.download.nvidia.com/compute/cuda/redist/libcublas/windows-x86_64/libcublas-windows-x86_64-11.8.1.74-archive.zip"
+          curl -O "https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvtx/windows-x86_64/cuda_nvtx-windows-x86_64-11.8.86-archive.zip"
+          curl -O "https://developer.download.nvidia.com/compute/cuda/redist/visual_studio_integration/windows-x86_64/visual_studio_integration-windows-x86_64-11.8.86-archive.zip"
+          curl -O "https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvprof/windows-x86_64/cuda_nvprof-windows-x86_64-11.8.87-archive.zip"
+          curl -O "https://developer.download.nvidia.com/compute/cuda/redist/cuda_cccl/windows-x86_64/cuda_cccl-windows-x86_64-11.8.89-archive.zip"
+          unzip '*.zip' -d "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8.0"
+          xcopy "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8.0\cuda_cudart-windows-x86_64-11.8.89-archive\*" "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8.0" /E /I /H /Y
+          xcopy "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8.0\cuda_nvcc-windows-x86_64-11.8.89-archive\*" "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8.0" /E /I /H /Y
+          xcopy "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8.0\cuda_nvrtc-windows-x86_64-11.8.89-archive\*" "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8.0" /E /I /H /Y
+          xcopy "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8.0\libcublas-windows-x86_64-11.8.1.74-archive\*" "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8.0" /E /I /H /Y
+          xcopy "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8.0\cuda_nvtx-windows-x86_64-11.8.86-archive\*" "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8.0" /E /I /H /Y
+          xcopy "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8.0\visual_studio_integration-windows-x86_64-11.8.86-archive\*" "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8.0" /E /I /H /Y
+          xcopy "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8.0\cuda_nvprof-windows-x86_64-11.8.87-archive\*" "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8.0" /E /I /H /Y
+          xcopy "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8.0\cuda_cccl-windows-x86_64-11.8.89-archive\*" "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8.0" /E /I /H /Y
+          echo "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8.0\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8.0\libnvvp" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "CUDA_PATH=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8.0" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          echo "CUDA_PATH_V11_8=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8.0" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
+      - name: Install Cuda Toolkit 12.2
+        if: ${{ matrix.cuda-toolkit == '12.2.0' }}
+        run: |
+          mkdir -p "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.2.0"
+          choco install unzip -y
+          curl -O "https://developer.download.nvidia.com/compute/cuda/redist/cuda_cudart/windows-x86_64/cuda_cudart-windows-x86_64-12.2.140-archive.zip"
+          curl -O "https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvcc/windows-x86_64/cuda_nvcc-windows-x86_64-12.2.140-archive.zip"
+          curl -O "https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvrtc/windows-x86_64/cuda_nvrtc-windows-x86_64-12.2.140-archive.zip"
+          curl -O "https://developer.download.nvidia.com/compute/cuda/redist/libcublas/windows-x86_64/libcublas-windows-x86_64-12.2.5.6-archive.zip"
+          curl -O "https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvtx/windows-x86_64/cuda_nvtx-windows-x86_64-12.2.140-archive.zip"
+          curl -O "https://developer.download.nvidia.com/compute/cuda/redist/cuda_profiler_api/windows-x86_64/cuda_profiler_api-windows-x86_64-12.2.140-archive.zip"
+          curl -O "https://developer.download.nvidia.com/compute/cuda/redist/visual_studio_integration/windows-x86_64/visual_studio_integration-windows-x86_64-12.2.140-archive.zip"
+          curl -O "https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvprof/windows-x86_64/cuda_nvprof-windows-x86_64-12.2.142-archive.zip"
+          curl -O "https://developer.download.nvidia.com/compute/cuda/redist/cuda_cccl/windows-x86_64/cuda_cccl-windows-x86_64-12.2.140-archive.zip"
+          unzip '*.zip' -d "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.2.0"
+          xcopy "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.2.0\cuda_cudart-windows-x86_64-12.2.140-archive\*" "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.2.0" /E /I /H /Y
+          xcopy "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.2.0\cuda_nvcc-windows-x86_64-12.2.140-archive\*" "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.2.0" /E /I /H /Y
+          xcopy "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.2.0\cuda_nvrtc-windows-x86_64-12.2.140-archive\*" "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.2.0" /E /I /H /Y
+          xcopy "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.2.0\libcublas-windows-x86_64-12.2.5.6-archive\*" "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.2.0" /E /I /H /Y
+          xcopy "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.2.0\cuda_nvtx-windows-x86_64-12.2.140-archive\*" "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.2.0" /E /I /H /Y
+          xcopy "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.2.0\cuda_profiler_api-windows-x86_64-12.2.140-archive\*" "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.2.0" /E /I /H /Y
+          xcopy "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.2.0\visual_studio_integration-windows-x86_64-12.2.140-archive\*" "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.2.0" /E /I /H /Y
+          xcopy "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.2.0\cuda_nvprof-windows-x86_64-12.2.142-archive\*" "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.2.0" /E /I /H /Y
+          xcopy "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.2.0\cuda_cccl-windows-x86_64-12.2.140-archive\*" "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.2.0" /E /I /H /Y
+          echo "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.2.0\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.2.0\libnvvp" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "CUDA_PATH=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.2.0" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          echo "CUDA_PATH_V12_2=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.2.0" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
 
       - name: Cache CUDA compilation results
         uses: actions/cache@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -655,6 +655,7 @@ jobs:
           xcopy "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.2.0\visual_studio_integration-windows-x86_64-12.2.140-archive\*" "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.2.0" /E /I /H /Y
           xcopy "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.2.0\cuda_nvprof-windows-x86_64-12.2.142-archive\*" "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.2.0" /E /I /H /Y
           xcopy "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.2.0\cuda_cccl-windows-x86_64-12.2.140-archive\*" "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.2.0" /E /I /H /Y
+          xcopy "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.2.0\visual_studio_integration-windows-x86_64-12.2.140-archive\visual_studio_integration\MSBuildExtensions\*" "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Microsoft\VC\v160\BuildCustomizations" /E /I /H /Y
           echo "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.2.0\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           echo "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.2.0\libnvvp" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           echo "CUDA_PATH=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.2.0" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8


### PR DESCRIPTION
This commit adds the ccache action to the windows-cublas job. This will allow us to cache the build artifacts and hopefully speed up the build process.