### PR TITLE
whisper : fix compiler warnings in whisper.cpp

### DIFF
--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -206,7 +206,7 @@ static ggml_tensor * whisper_set_f32(struct ggml_tensor * t, float v) {
     GGML_ASSERT(t->type == GGML_TYPE_F32);
     GGML_ASSERT(ggml_is_contiguous(t));
     size_t nels = ggml_nelements(t);
-    for (int64_t i = 0; i < nels; ++i) {
+    for (size_t i = 0; i < nels; ++i) {
         ((float *) t->data)[i] = v;
     }
     return t;
@@ -216,7 +216,7 @@ static ggml_tensor * whisper_set_i32(struct ggml_tensor * t, int32_t v) {
     GGML_ASSERT(t->type == GGML_TYPE_I32);
     GGML_ASSERT(ggml_is_contiguous(t));
     size_t nels = ggml_nelements(t);
-    for (int64_t i = 0; i < nels; ++i) {
+    for (size_t i = 0; i < nels; ++i) {
         ((int32_t *) t->data)[i] = v;
     }
     return t;


### PR DESCRIPTION
This commit fixes compiler warnings in whisper.cpp by changing the type of the loop index variable from int64_t to size_t.

Currently the following warnings are generated by the compiler:
```console
/whisper.cpp/src/whisper.cpp:209:27: warning: comparison of integers of different signs: 'int64_t' (aka 'long long') and 'size_t' (aka 'unsigned long') [-Wsign-compare]
  209 |     for (int64_t i = 0; i < nels; ++i) {
      |                         ~ ^ ~~~~
/whisper.cpp/src/whisper.cpp:219:27: warning: comparison of integers of different signs: 'int64_t' (aka 'long long') and 'size_t' (aka 'unsigned long') [-Wsign-compare]
  219 |     for (int64_t i = 0; i < nels; ++i) {
      |                         ~ ^ ~~~~
```