### PR TITLE
ci : add missing env.branch_name to build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,7 @@ permissions:
   contents: write  # for creating release
 
 env:
+  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
   ubuntu_image: "ubuntu:22.04"
   VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
 


### PR DESCRIPTION
This commit adds the missing env.branch_name to the build.yml file.

The motivation for this is that the currently the build is failing during the release job because the branch_name is not set in the an invalid tag is being used.