### PR TITLE
examples : update wasm examples to include server.py [no ci]

### DIFF
--- a/examples/bench.wasm/README.md
+++ b/examples/bench.wasm/README.md
@@ -15,7 +15,17 @@ cd whisper.cpp
 mkdir build-em && cd build-em
 emcmake cmake ..
 make -j
+```
+The example can then be started by running a local HTTP server:
+```console
+python3 examples/server.py
+```
+And then opening a browser to the following URL:
+http://localhost:8000/bench.wasm
 
+To run the example in a different server, you need to copy the following files
+to the server's HTTP path:
+```
 # copy the produced page to your HTTP path
 cp bin/bench.wasm/*       /path/to/html/
 cp bin/libbench.worker.js /path/to/html/

--- a/examples/stream.wasm/README.md
+++ b/examples/stream.wasm/README.md
@@ -13,7 +13,17 @@ cd whisper.cpp
 mkdir build-em && cd build-em
 emcmake cmake ..
 make -j
+```
+The example can then be started by running a local HTTP server:
+```console
+python3 examples/server.py
+```
+And then opening a browser to the following URL:
+http://localhost:8000/stream.wasm
 
+To run the example in a different server, you need to copy the following files
+to the server's HTTP path:
+```
 # copy the produced page to your HTTP path
 cp bin/stream.wasm/*       /path/to/html/
 cp bin/libstream.worker.js /path/to/html/

--- a/examples/whisper.wasm/README.md
+++ b/examples/whisper.wasm/README.md
@@ -35,7 +35,17 @@ cd whisper.cpp
 mkdir build-em && cd build-em
 emcmake cmake ..
 make -j
+```
+The example can then be started by running a local HTTP server:
+```console
+python3 examples/server.py
+```
+And then opening a browser to the following URL:
+http://localhost:8000/whisper.wasm
 
+To run the example in a different server, you need to copy the following files
+to the server's HTTP path:
+```
 # copy the produced page to your HTTP path
 cp bin/whisper.wasm/*    /path/to/html/
 cp bin/libmain.worker.js /path/to/html/


### PR DESCRIPTION
This commit updates the README files for the wasm examples to include instructions on how to run the examples using the provided server.py which was included in Commit 6e8242f7fe166b7798bbf49b4c65aba8afe1e131 ("examples : command.wasm updates (#2904)").

The motivation for this is consistency with the command.wasm example.