### PR TITLE
examples : add WHISPER_SDL2 check to deprecation executables

### DIFF
--- a/examples/deprecation-warning/CMakeLists.txt
+++ b/examples/deprecation-warning/CMakeLists.txt
@@ -1,4 +1,6 @@
 add_executable(main ./deprecation-warning.cpp)
 add_executable(bench ./deprecation-warning.cpp)
-add_executable(stream ./deprecation-warning.cpp)
-add_executable(command ./deprecation-warning.cpp)
+if (WHISPER_SDL2)
+    add_executable(stream ./deprecation-warning.cpp)
+    add_executable(command ./deprecation-warning.cpp)
+endif()


### PR DESCRIPTION
This commit adds a check for `WHISPER_SDL2` to the deprecation warning examples. This is to prevent the examples from being built when WHISPER_SDL2 is not enabled.

The motivation for this is that currently these deprecation executables are generate and when run they refer the user to examples with other names, for example `whisper-command` but unless they have built with `WHISPER_SDL2` those executable will not be present:
```console
$ ls build/bin/
bench  command  main  quantize  stream  whisper-bench  whisper-cli
whisper-server

$ ./build/bin/command

WARNING: The binary 'command' is deprecated.
 Please use 'whisper-command' instead.
 See https://github.com/ggerganov/whisper.cpp/tree/master/examples/deprecation-warning/README.md for more information.
```