### PR TITLE
Fixed cooperative matrix shaders on Vulkan builds when CROSS_COMPILE ON

### DIFF
--- a/ggml/src/ggml-vulkan/CMakeLists.txt
+++ b/ggml/src/ggml-vulkan/CMakeLists.txt
@@ -1,15 +1,15 @@
 cmake_minimum_required(VERSION 3.19)
 cmake_policy(SET CMP0114 NEW)
 
-find_package(Vulkan COMPONENTS glslc REQUIRED)
-
-# Allow explicitly specifying glslc executable for cross-compilation scenarios
-if(DEFINED GGML_VULKAN_GLSLC_EXECUTABLE)
-    set(VULKAN_GLSLC_EXECUTABLE_OVERRIDE ${GGML_VULKAN_GLSLC_EXECUTABLE})
-    message(STATUS "Using explicitly provided glslc: ${VULKAN_GLSLC_EXECUTABLE_OVERRIDE}")
-else()
-    set(VULKAN_GLSLC_EXECUTABLE_OVERRIDE ${Vulkan_GLSLC_EXECUTABLE})
+# First find glslc on the host system (not target) to ensure we have control over which one is used
+find_program(Vulkan_GLSLC_EXECUTABLE glslc NO_CMAKE_FIND_ROOT_PATH)
+if(NOT Vulkan_GLSLC_EXECUTABLE)
+    message(WARNING "glslc not found on host system. Will attempt to find via Vulkan package")
 endif()
+
+# Find Vulkan package with required components
+find_package(Vulkan REQUIRED)
+message(STATUS "Using glslc: ${Vulkan_GLSLC_EXECUTABLE}")
 
 function(detect_host_compiler)
     if (CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
@@ -30,37 +30,97 @@ if (Vulkan_FOUND)
                              ggml-vulkan.cpp
                              ../../include/ggml-vulkan.h
                             )
-
-    # Compile a test shader to determine whether GL_KHR_cooperative_matrix is supported.
-    # If it's not, there will be an error to stderr.
-    # If it's supported, set a define to indicate that we should compile those shaders
-    execute_process(COMMAND ${VULKAN_GLSLC_EXECUTABLE_OVERRIDE} -o - -fshader-stage=compute --target-env=vulkan1.3 "${CMAKE_CURRENT_SOURCE_DIR}/vulkan-shaders/test_coopmat_support.comp"
-                    OUTPUT_VARIABLE glslc_output
-                    ERROR_VARIABLE glslc_error)
-
-    if (${glslc_error} MATCHES ".*extension not supported: GL_KHR_cooperative_matrix.*")
-        message(STATUS "GL_KHR_cooperative_matrix not supported by glslc")
-        set(GGML_VULKAN_COOPMAT_GLSLC_SUPPORT OFF CACHE INTERNAL "Not enable coopmat shaders")
+    if (CMAKE_CROSSCOMPILING)
+        # Check if user has explicitly set these options
+        if(NOT DEFINED GGML_VULKAN_COOPMAT_GLSLC_SUPPORT OR NOT DEFINED GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT)
+            # Try to detect target capabilities based on architecture/platform
+            message(STATUS "Cross-compiling: attempting to auto-detect target shader capabilities")
+            
+            # Set defaults based on known platforms
+            if(ANDROID)
+                # Most modern Android devices support cooperative matrices
+                message(STATUS "Android target detected: enabling COOPMAT support by default")
+                set(DETECTED_COOPMAT_SUPPORT ON)
+                
+                # Check Android API level or NDK version for COOPMAT2 support
+                # Android NDK r25+ and modern devices generally support this
+                if(ANDROID_PLATFORM_LEVEL GREATER_EQUAL 29 OR (DEFINED ANDROID_NDK_REVISION AND ANDROID_NDK_REVISION GREATER_EQUAL 25))
+                    message(STATUS "Modern Android target detected: enabling COOPMAT2 support by default")
+                    set(DETECTED_COOPMAT2_SUPPORT ON)
+                else()
+                    set(DETECTED_COOPMAT2_SUPPORT OFF)
+                endif()
+            elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|ARM64")
+                # ARM64 generally supports cooperative matrices on newer GPUs
+                message(STATUS "ARM64 target detected: enabling COOPMAT support by default")
+                set(DETECTED_COOPMAT_SUPPORT ON)
+                set(DETECTED_COOPMAT2_SUPPORT OFF)  # Be conservative with COOPMAT2
+            else()
+                # For other platforms, default to OFF to be safe
+                set(DETECTED_COOPMAT_SUPPORT OFF)
+                set(DETECTED_COOPMAT2_SUPPORT OFF)
+            endif()
+            
+            # Set the options based on detection if not already set
+            if(NOT DEFINED GGML_VULKAN_COOPMAT_GLSLC_SUPPORT)
+                option(GGML_VULKAN_COOPMAT_GLSLC_SUPPORT "Enable coopmat shaders" ${DETECTED_COOPMAT_SUPPORT})
+            endif()
+            
+            if(NOT DEFINED GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT)
+                option(GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT "Enable coopmat2 shaders" ${DETECTED_COOPMAT2_SUPPORT})
+            endif()
+        else()
+            # Options already set, use those values
+            option(GGML_VULKAN_COOPMAT_GLSLC_SUPPORT "Enable coopmat shaders" ${GGML_VULKAN_COOPMAT_GLSLC_SUPPORT})
+            option(GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT "Enable coopmat2 shaders" ${GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT})
+        endif()
+        
+        message(STATUS "Cross-compile COOPMAT support: ${GGML_VULKAN_COOPMAT_GLSLC_SUPPORT}")
+        message(STATUS "Cross-compile COOPMAT2 support: ${GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT}")
     else()
-        message(STATUS "GL_KHR_cooperative_matrix supported by glslc")
-        add_compile_definitions(GGML_VULKAN_COOPMAT_GLSLC_SUPPORT)
-        set(GGML_VULKAN_COOPMAT_GLSLC_SUPPORT ON CACHE INTERNAL "Enable coopmat shaders")
+        # Compile a test shader to determine whether GL_KHR_cooperative_matrix is supported.
+        # If it's not, there will be an error to stderr.
+        # If it's supported, set a define to indicate that we should compile those shaders
+        execute_process(COMMAND ${Vulkan_GLSLC_EXECUTABLE} -o - -fshader-stage=compute --target-env=vulkan1.3 "${CMAKE_CURRENT_SOURCE_DIR}/vulkan-shaders/test_coopmat_support.comp"
+                        OUTPUT_VARIABLE glslc_output
+                        ERROR_VARIABLE glslc_error)
+
+        if (${glslc_error} MATCHES ".*extension not supported: GL_KHR_cooperative_matrix.*")
+            message(STATUS "GL_KHR_cooperative_matrix not supported by glslc")
+            set(GGML_VULKAN_COOPMAT_GLSLC_SUPPORT OFF CACHE INTERNAL "Not enable coopmat shaders")
+        else()
+            message(STATUS "GL_KHR_cooperative_matrix supported by glslc")
+            set(GGML_VULKAN_COOPMAT_GLSLC_SUPPORT ON CACHE INTERNAL "Enable coopmat shaders")
+        endif()
+
+        # Compile a test shader to determine whether GL_NV_cooperative_matrix2 is supported.
+        # If it's not, there will be an error to stderr.
+        # If it's supported, set a define to indicate that we should compile those shaders
+        execute_process(COMMAND ${Vulkan_GLSLC_EXECUTABLE} -o - -fshader-stage=compute --target-env=vulkan1.3 "${CMAKE_CURRENT_SOURCE_DIR}/vulkan-shaders/test_coopmat2_support.comp"
+                        OUTPUT_VARIABLE glslc_output
+                        ERROR_VARIABLE glslc_error)
+
+        if (${glslc_error} MATCHES ".*extension not supported: GL_NV_cooperative_matrix2.*")
+            message(STATUS "GL_NV_cooperative_matrix2 not supported by glslc")
+            set(GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT OFF CACHE INTERNAL "Not enable coopmat2 shaders")
+        else()
+            message(STATUS "GL_NV_cooperative_matrix2 supported by glslc")
+            set(GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT ON CACHE INTERNAL "Enable coopmat2 shaders")
+        endif()
     endif()
 
-    # Compile a test shader to determine whether GL_NV_cooperative_matrix2 is supported.
-    # If it's not, there will be an error to stderr.
-    # If it's supported, set a define to indicate that we should compile those shaders
-    execute_process(COMMAND ${VULKAN_GLSLC_EXECUTABLE_OVERRIDE} -o - -fshader-stage=compute --target-env=vulkan1.3 "${CMAKE_CURRENT_SOURCE_DIR}/vulkan-shaders/test_coopmat2_support.comp"
-                    OUTPUT_VARIABLE glslc_output
-                    ERROR_VARIABLE glslc_error)
-
-    if (${glslc_error} MATCHES ".*extension not supported: GL_NV_cooperative_matrix2.*")
-        message(STATUS "GL_NV_cooperative_matrix2 not supported by glslc")
-        set(GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT OFF CACHE INTERNAL "Not enable coopmat2 shaders")
+    if (GGML_VULKAN_COOPMAT_GLSLC_SUPPORT)
+        message(STATUS "GGML_VULKAN_COOPMAT_GLSLC_SUPPORT enabled")
+        add_compile_definitions(GGML_VULKAN_COOPMAT_GLSLC_SUPPORT)
     else()
-        message(STATUS "GL_NV_cooperative_matrix2 supported by glslc")
-        set(GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT ON CACHE INTERNAL "Enable coopmat2 shaders")
+        message(STATUS "GGML_VULKAN_COOPMAT_GLSLC_SUPPORT disabled")
+    endif()
+
+    if (GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT)
+        message(STATUS "GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT enabled")
         add_compile_definitions(GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT)
+    else()
+        message(STATUS "GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT disabled")
     endif()
 
     target_link_libraries(ggml-vulkan PRIVATE Vulkan::Vulkan)
@@ -133,7 +193,7 @@ if (Vulkan_FOUND)
                     -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}
                     -DGGML_VULKAN_COOPMAT_GLSLC_SUPPORT=${GGML_VULKAN_COOPMAT_GLSLC_SUPPORT}
                     -DGGML_VULKAN_COOPMAT2_GLSLC_SUPPORT=${GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT}
-                    -DGGML_VULKAN_GLSLC_EXECUTABLE=${VULKAN_GLSLC_EXECUTABLE_OVERRIDE}
+                    -DGGML_VULKAN_GLSLC_EXECUTABLE=${Vulkan_GLSLC_EXECUTABLE}
             BUILD_COMMAND ${CMAKE_COMMAND} --build .
             INSTALL_COMMAND ${CMAKE_COMMAND} --install .
             INSTALL_DIR ${CMAKE_BINARY_DIR}
@@ -159,7 +219,7 @@ if (Vulkan_FOUND)
                 ${_ggml_vk_source}
 
         COMMAND ${_ggml_vk_genshaders_cmd}
-            --glslc      ${VULKAN_GLSLC_EXECUTABLE_OVERRIDE}
+            --glslc      ${Vulkan_GLSLC_EXECUTABLE}
             --input-dir  ${_ggml_vk_input_dir}
             --output-dir ${_ggml_vk_output_dir}
             --target-hpp ${_ggml_vk_header}

--- a/ggml/src/ggml-vulkan/CMakeLists.txt
+++ b/ggml/src/ggml-vulkan/CMakeLists.txt
@@ -3,6 +3,14 @@ cmake_policy(SET CMP0114 NEW)
 
 find_package(Vulkan COMPONENTS glslc REQUIRED)
 
+# Allow explicitly specifying glslc executable for cross-compilation scenarios
+if(DEFINED GGML_VULKAN_GLSLC_EXECUTABLE)
+    set(VULKAN_GLSLC_EXECUTABLE_OVERRIDE ${GGML_VULKAN_GLSLC_EXECUTABLE})
+    message(STATUS "Using explicitly provided glslc: ${VULKAN_GLSLC_EXECUTABLE_OVERRIDE}")
+else()
+    set(VULKAN_GLSLC_EXECUTABLE_OVERRIDE ${Vulkan_GLSLC_EXECUTABLE})
+endif()
+
 function(detect_host_compiler)
     if (CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
         find_program(HOST_C_COMPILER NAMES cl gcc clang NO_CMAKE_FIND_ROOT_PATH)
@@ -26,7 +34,7 @@ if (Vulkan_FOUND)
     # Compile a test shader to determine whether GL_KHR_cooperative_matrix is supported.
     # If it's not, there will be an error to stderr.
     # If it's supported, set a define to indicate that we should compile those shaders
-    execute_process(COMMAND ${Vulkan_GLSLC_EXECUTABLE} -o - -fshader-stage=compute --target-env=vulkan1.3 "${CMAKE_CURRENT_SOURCE_DIR}/vulkan-shaders/test_coopmat_support.comp"
+    execute_process(COMMAND ${VULKAN_GLSLC_EXECUTABLE_OVERRIDE} -o - -fshader-stage=compute --target-env=vulkan1.3 "${CMAKE_CURRENT_SOURCE_DIR}/vulkan-shaders/test_coopmat_support.comp"
                     OUTPUT_VARIABLE glslc_output
                     ERROR_VARIABLE glslc_error)
 
@@ -42,7 +50,7 @@ if (Vulkan_FOUND)
     # Compile a test shader to determine whether GL_NV_cooperative_matrix2 is supported.
     # If it's not, there will be an error to stderr.
     # If it's supported, set a define to indicate that we should compile those shaders
-    execute_process(COMMAND ${Vulkan_GLSLC_EXECUTABLE} -o - -fshader-stage=compute --target-env=vulkan1.3 "${CMAKE_CURRENT_SOURCE_DIR}/vulkan-shaders/test_coopmat2_support.comp"
+    execute_process(COMMAND ${VULKAN_GLSLC_EXECUTABLE_OVERRIDE} -o - -fshader-stage=compute --target-env=vulkan1.3 "${CMAKE_CURRENT_SOURCE_DIR}/vulkan-shaders/test_coopmat2_support.comp"
                     OUTPUT_VARIABLE glslc_output
                     ERROR_VARIABLE glslc_error)
 
@@ -125,6 +133,7 @@ if (Vulkan_FOUND)
                     -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}
                     -DGGML_VULKAN_COOPMAT_GLSLC_SUPPORT=${GGML_VULKAN_COOPMAT_GLSLC_SUPPORT}
                     -DGGML_VULKAN_COOPMAT2_GLSLC_SUPPORT=${GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT}
+                    -DGGML_VULKAN_GLSLC_EXECUTABLE=${VULKAN_GLSLC_EXECUTABLE_OVERRIDE}
             BUILD_COMMAND ${CMAKE_COMMAND} --build .
             INSTALL_COMMAND ${CMAKE_COMMAND} --install .
             INSTALL_DIR ${CMAKE_BINARY_DIR}
@@ -150,7 +159,7 @@ if (Vulkan_FOUND)
                 ${_ggml_vk_source}
 
         COMMAND ${_ggml_vk_genshaders_cmd}
-            --glslc      ${Vulkan_GLSLC_EXECUTABLE}
+            --glslc      ${VULKAN_GLSLC_EXECUTABLE_OVERRIDE}
             --input-dir  ${_ggml_vk_input_dir}
             --output-dir ${_ggml_vk_output_dir}
             --target-hpp ${_ggml_vk_header}

--- a/ggml/src/ggml-vulkan/CMakeLists.txt
+++ b/ggml/src/ggml-vulkan/CMakeLists.txt
@@ -22,54 +22,36 @@ if (Vulkan_FOUND)
                              ggml-vulkan.cpp
                              ../../include/ggml-vulkan.h
                             )
-    if (CMAKE_CROSSCOMPILING)
-        # Make this configurable for cross builds
-        option(GGML_VULKAN_COOPMAT_GLSLC_SUPPORT "Enable coopmat shaders" OFF)
-        option(GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT "Enable coopmat2 shaders" OFF)
+
+    # Compile a test shader to determine whether GL_KHR_cooperative_matrix is supported.
+    # If it's not, there will be an error to stderr.
+    # If it's supported, set a define to indicate that we should compile those shaders
+    execute_process(COMMAND ${Vulkan_GLSLC_EXECUTABLE} -o - -fshader-stage=compute --target-env=vulkan1.3 "${CMAKE_CURRENT_SOURCE_DIR}/vulkan-shaders/test_coopmat_support.comp"
+                    OUTPUT_VARIABLE glslc_output
+                    ERROR_VARIABLE glslc_error)
+
+    if (${glslc_error} MATCHES ".*extension not supported: GL_KHR_cooperative_matrix.*")
+        message(STATUS "GL_KHR_cooperative_matrix not supported by glslc")
+        set(GGML_VULKAN_COOPMAT_GLSLC_SUPPORT OFF CACHE INTERNAL "Not enable coopmat shaders")
     else()
-        # Compile a test shader to determine whether GL_KHR_cooperative_matrix is supported.
-        # If it's not, there will be an error to stderr.
-        # If it's supported, set a define to indicate that we should compile those shaders
-        execute_process(COMMAND ${Vulkan_GLSLC_EXECUTABLE} -o - -fshader-stage=compute --target-env=vulkan1.3 "${CMAKE_CURRENT_SOURCE_DIR}/vulkan-shaders/test_coopmat_support.comp"
-                        OUTPUT_VARIABLE glslc_output
-                        ERROR_VARIABLE glslc_error)
-
-        if (${glslc_error} MATCHES ".*extension not supported: GL_KHR_cooperative_matrix.*")
-            message(STATUS "GL_KHR_cooperative_matrix not supported by glslc")
-            set(GGML_VULKAN_COOPMAT_GLSLC_SUPPORT OFF CACHE INTERNAL "Not enable coopmat shaders")
-        else()
-            message(STATUS "GL_KHR_cooperative_matrix supported by glslc")
-            set(GGML_VULKAN_COOPMAT_GLSLC_SUPPORT ON CACHE INTERNAL "Enable coopmat shaders")
-        endif()
-
-        # Compile a test shader to determine whether GL_NV_cooperative_matrix2 is supported.
-        # If it's not, there will be an error to stderr.
-        # If it's supported, set a define to indicate that we should compile those shaders
-        execute_process(COMMAND ${Vulkan_GLSLC_EXECUTABLE} -o - -fshader-stage=compute --target-env=vulkan1.3 "${CMAKE_CURRENT_SOURCE_DIR}/vulkan-shaders/test_coopmat2_support.comp"
-                        OUTPUT_VARIABLE glslc_output
-                        ERROR_VARIABLE glslc_error)
-
-        if (${glslc_error} MATCHES ".*extension not supported: GL_NV_cooperative_matrix2.*")
-            message(STATUS "GL_NV_cooperative_matrix2 not supported by glslc")
-            set(GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT OFF CACHE INTERNAL "Not enable coopmat2 shaders")
-        else()
-            message(STATUS "GL_NV_cooperative_matrix2 supported by glslc")
-            set(GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT ON CACHE INTERNAL "Enable coopmat2 shaders")
-        endif()
-    endif()
-
-    if (GGML_VULKAN_COOPMAT_GLSLC_SUPPORT)
-        message(STATUS "GGML_VULKAN_COOPMAT_GLSLC_SUPPORT enabled")
+        message(STATUS "GL_KHR_cooperative_matrix supported by glslc")
         add_compile_definitions(GGML_VULKAN_COOPMAT_GLSLC_SUPPORT)
-    else()
-        message(STATUS "GGML_VULKAN_COOPMAT_GLSLC_SUPPORT disabled")
+        set(GGML_VULKAN_COOPMAT_GLSLC_SUPPORT ON CACHE INTERNAL "Enable coopmat shaders")
     endif()
 
-    if (GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT)
-        message(STATUS "GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT enabled")
-        add_compile_definitions(GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT)
+    # Compile a test shader to determine whether GL_NV_cooperative_matrix2 is supported.
+    # If it's not, there will be an error to stderr.
+    # If it's supported, set a define to indicate that we should compile those shaders
+    execute_process(COMMAND ${Vulkan_GLSLC_EXECUTABLE} -o - -fshader-stage=compute --target-env=vulkan1.3 "${CMAKE_CURRENT_SOURCE_DIR}/vulkan-shaders/test_coopmat2_support.comp"
+                    OUTPUT_VARIABLE glslc_output
+                    ERROR_VARIABLE glslc_error)
+
+    if (${glslc_error} MATCHES ".*extension not supported: GL_NV_cooperative_matrix2.*")
+        message(STATUS "GL_NV_cooperative_matrix2 not supported by glslc")
     else()
-        message(STATUS "GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT disabled")
+        message(STATUS "GL_NV_cooperative_matrix2 supported by glslc")
+        set(GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT ON CACHE INTERNAL "Enable coopmat2 shaders")
+        add_compile_definitions(GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT)
     endif()
 
     target_link_libraries(ggml-vulkan PRIVATE Vulkan::Vulkan)

--- a/ggml/src/ggml-vulkan/CMakeLists.txt
+++ b/ggml/src/ggml-vulkan/CMakeLists.txt
@@ -22,33 +22,54 @@ if (Vulkan_FOUND)
                              ggml-vulkan.cpp
                              ../../include/ggml-vulkan.h
                             )
-
-    # Compile a test shader to determine whether GL_KHR_cooperative_matrix is supported.
-    # If it's not, there will be an error to stderr.
-    # If it's supported, set a define to indicate that we should compile those shaders
-    execute_process(COMMAND ${Vulkan_GLSLC_EXECUTABLE} -o - -fshader-stage=compute --target-env=vulkan1.3 "${CMAKE_CURRENT_SOURCE_DIR}/vulkan-shaders/test_coopmat_support.comp"
-                    OUTPUT_VARIABLE glslc_output
-                    ERROR_VARIABLE glslc_error)
-
-    if (${glslc_error} MATCHES ".*extension not supported: GL_KHR_cooperative_matrix.*")
-        message(STATUS "GL_KHR_cooperative_matrix not supported by glslc")
+    if (CMAKE_CROSSCOMPILING)
+        # Make this configurable for cross builds
+        option(GGML_VULKAN_COOPMAT_GLSLC_SUPPORT "Enable coopmat shaders" OFF)
+        option(GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT "Enable coopmat2 shaders" OFF)
     else()
-        message(STATUS "GL_KHR_cooperative_matrix supported by glslc")
-        add_compile_definitions(GGML_VULKAN_COOPMAT_GLSLC_SUPPORT)
+        # Compile a test shader to determine whether GL_KHR_cooperative_matrix is supported.
+        # If it's not, there will be an error to stderr.
+        # If it's supported, set a define to indicate that we should compile those shaders
+        execute_process(COMMAND ${Vulkan_GLSLC_EXECUTABLE} -o - -fshader-stage=compute --target-env=vulkan1.3 "${CMAKE_CURRENT_SOURCE_DIR}/vulkan-shaders/test_coopmat_support.comp"
+                        OUTPUT_VARIABLE glslc_output
+                        ERROR_VARIABLE glslc_error)
+
+        if (${glslc_error} MATCHES ".*extension not supported: GL_KHR_cooperative_matrix.*")
+            message(STATUS "GL_KHR_cooperative_matrix not supported by glslc")
+            set(GGML_VULKAN_COOPMAT_GLSLC_SUPPORT OFF CACHE INTERNAL "Not enable coopmat shaders")
+        else()
+            message(STATUS "GL_KHR_cooperative_matrix supported by glslc")
+            set(GGML_VULKAN_COOPMAT_GLSLC_SUPPORT ON CACHE INTERNAL "Enable coopmat shaders")
+        endif()
+
+        # Compile a test shader to determine whether GL_NV_cooperative_matrix2 is supported.
+        # If it's not, there will be an error to stderr.
+        # If it's supported, set a define to indicate that we should compile those shaders
+        execute_process(COMMAND ${Vulkan_GLSLC_EXECUTABLE} -o - -fshader-stage=compute --target-env=vulkan1.3 "${CMAKE_CURRENT_SOURCE_DIR}/vulkan-shaders/test_coopmat2_support.comp"
+                        OUTPUT_VARIABLE glslc_output
+                        ERROR_VARIABLE glslc_error)
+
+        if (${glslc_error} MATCHES ".*extension not supported: GL_NV_cooperative_matrix2.*")
+            message(STATUS "GL_NV_cooperative_matrix2 not supported by glslc")
+            set(GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT OFF CACHE INTERNAL "Not enable coopmat2 shaders")
+        else()
+            message(STATUS "GL_NV_cooperative_matrix2 supported by glslc")
+            set(GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT ON CACHE INTERNAL "Enable coopmat2 shaders")
+        endif()
     endif()
 
-    # Compile a test shader to determine whether GL_NV_cooperative_matrix2 is supported.
-    # If it's not, there will be an error to stderr.
-    # If it's supported, set a define to indicate that we should compile those shaders
-    execute_process(COMMAND ${Vulkan_GLSLC_EXECUTABLE} -o - -fshader-stage=compute --target-env=vulkan1.3 "${CMAKE_CURRENT_SOURCE_DIR}/vulkan-shaders/test_coopmat2_support.comp"
-                    OUTPUT_VARIABLE glslc_output
-                    ERROR_VARIABLE glslc_error)
-
-    if (${glslc_error} MATCHES ".*extension not supported: GL_NV_cooperative_matrix2.*")
-        message(STATUS "GL_NV_cooperative_matrix2 not supported by glslc")
+    if (GGML_VULKAN_COOPMAT_GLSLC_SUPPORT)
+        message(STATUS "GGML_VULKAN_COOPMAT_GLSLC_SUPPORT enabled")
+        add_compile_definitions(GGML_VULKAN_COOPMAT_GLSLC_SUPPORT)
     else()
-        message(STATUS "GL_NV_cooperative_matrix2 supported by glslc")
+        message(STATUS "GGML_VULKAN_COOPMAT_GLSLC_SUPPORT disabled")
+    endif()
+
+    if (GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT)
+        message(STATUS "GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT enabled")
         add_compile_definitions(GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT)
+    else()
+        message(STATUS "GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT disabled")
     endif()
 
     target_link_libraries(ggml-vulkan PRIVATE Vulkan::Vulkan)
@@ -119,6 +140,8 @@ if (Vulkan_FOUND)
             SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/vulkan-shaders
             CMAKE_ARGS -DCMAKE_TOOLCHAIN_FILE=${HOST_CMAKE_TOOLCHAIN_FILE}
                     -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}
+                    -DGGML_VULKAN_COOPMAT_GLSLC_SUPPORT=${GGML_VULKAN_COOPMAT_GLSLC_SUPPORT}
+                    -DGGML_VULKAN_COOPMAT2_GLSLC_SUPPORT=${GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT}
             BUILD_COMMAND ${CMAKE_COMMAND} --build .
             INSTALL_COMMAND ${CMAKE_COMMAND} --install .
             INSTALL_DIR ${CMAKE_BINARY_DIR}

--- a/ggml/src/ggml-vulkan/CMakeLists.txt
+++ b/ggml/src/ggml-vulkan/CMakeLists.txt
@@ -48,6 +48,7 @@ if (Vulkan_FOUND)
 
     if (${glslc_error} MATCHES ".*extension not supported: GL_NV_cooperative_matrix2.*")
         message(STATUS "GL_NV_cooperative_matrix2 not supported by glslc")
+        set(GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT OFF CACHE INTERNAL "Not enable coopmat2 shaders")
     else()
         message(STATUS "GL_NV_cooperative_matrix2 supported by glslc")
         set(GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT ON CACHE INTERNAL "Enable coopmat2 shaders")

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -1394,7 +1394,7 @@ static std::array<uint32_t, 2> fa_rows_cols(uint32_t D, uint32_t clamp, ggml_typ
         return {64, 32};
     }
     return {64, 64};
-};
+}
 
 static bool ggml_vk_matmul_shmem_support(const vk_device& device, const std::vector<uint32_t>& warptile, bool mul_mat_id, ggml_type src0_type) {
 

--- a/ggml/src/ggml-vulkan/vulkan-shaders/CMakeLists.txt
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/CMakeLists.txt
@@ -4,8 +4,22 @@ if(NOT GLSLC_EXECUTABLE)
     message(FATAL_ERROR "glslc not found.")
 endif()
 
+option(GGML_VULKAN_COOPMAT_GLSLC_SUPPORT "Enable coopmat shaders" OFF)
+option(GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT "Enable coopmat2 shaders" OFF)
+
+message(STATUS "GGML_VULKAN_COOPMAT_GLSLC_SUPPORT: ${GGML_VULKAN_COOPMAT_GLSLC_SUPPORT}")
+message(STATUS "GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT: ${GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT}")
+
 set(TARGET vulkan-shaders-gen)
 add_executable(${TARGET} vulkan-shaders-gen.cpp)
+if (GGML_VULKAN_COOPMAT_GLSLC_SUPPORT)
+    target_compile_definitions(vulkan-shaders-gen PRIVATE GGML_VULKAN_COOPMAT_GLSLC_SUPPORT)
+endif()
+
+if (GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT)
+    target_compile_definitions(vulkan-shaders-gen PRIVATE GGML_VULKAN_COOPMAT2_GLSLC_SUPPORT)
+endif()
+
 install(TARGETS ${TARGET} RUNTIME)
 target_compile_features(${TARGET} PRIVATE cxx_std_17)
 target_link_libraries(vulkan-shaders-gen PUBLIC Threads::Threads)

--- a/ggml/src/ggml-vulkan/vulkan-shaders/CMakeLists.txt
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/CMakeLists.txt
@@ -1,7 +1,14 @@
 find_package (Threads REQUIRED)
-find_program(GLSLC_EXECUTABLE glslc)
-if(NOT GLSLC_EXECUTABLE)
-    message(FATAL_ERROR "glslc not found.")
+
+# Allow explicitly specifying glslc executable path from parent CMake
+if(DEFINED GGML_VULKAN_GLSLC_EXECUTABLE)
+    set(GLSLC_EXECUTABLE ${GGML_VULKAN_GLSLC_EXECUTABLE})
+    message(STATUS "Using explicitly provided glslc: ${GLSLC_EXECUTABLE}")
+else()
+    find_program(GLSLC_EXECUTABLE glslc)
+    if(NOT GLSLC_EXECUTABLE)
+        message(FATAL_ERROR "glslc not found.")
+    endif()
 endif()
 
 option(GGML_VULKAN_COOPMAT_GLSLC_SUPPORT "Enable coopmat shaders" OFF)

--- a/ggml/src/ggml-vulkan/vulkan-shaders/CMakeLists.txt
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/CMakeLists.txt
@@ -1,14 +1,18 @@
 find_package (Threads REQUIRED)
 
-# Allow explicitly specifying glslc executable path from parent CMake
-if(DEFINED GGML_VULKAN_GLSLC_EXECUTABLE)
-    set(GLSLC_EXECUTABLE ${GGML_VULKAN_GLSLC_EXECUTABLE})
-    message(STATUS "Using explicitly provided glslc: ${GLSLC_EXECUTABLE}")
+# Use glslc from the parent CMake context or find it on the host system
+if(DEFINED Vulkan_GLSLC_EXECUTABLE)
+    set(GLSLC_EXECUTABLE ${Vulkan_GLSLC_EXECUTABLE})
+    message(STATUS "Using glslc from parent CMake: ${GLSLC_EXECUTABLE}")
+    # Also define this at compile time to set the default value in the shader generator
+    add_compile_definitions(VULKAN_GLSLC_EXECUTABLE="${GLSLC_EXECUTABLE}")
 else()
-    find_program(GLSLC_EXECUTABLE glslc)
+    # Find glslc on the host system, not the target
+    find_program(GLSLC_EXECUTABLE glslc NO_CMAKE_FIND_ROOT_PATH)
     if(NOT GLSLC_EXECUTABLE)
-        message(FATAL_ERROR "glslc not found.")
+        message(FATAL_ERROR "glslc not found. Please set Vulkan_GLSLC_EXECUTABLE in parent CMake.")
     endif()
+    message(STATUS "Found host glslc: ${GLSLC_EXECUTABLE}")
 endif()
 
 option(GGML_VULKAN_COOPMAT_GLSLC_SUPPORT "Enable coopmat shaders" OFF)

--- a/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
@@ -1,5 +1,6 @@
 
 
+
 #include <iostream>
 #include <fstream>
 #include <sstream>
@@ -35,7 +36,12 @@
 std::mutex lock;
 std::vector<std::pair<std::string, std::string>> shader_fnames;
 
-std::string GLSLC = "glslc";
+// Default glslc path, can be overridden by --glslc command line argument
+#ifndef VULKAN_GLSLC_EXECUTABLE
+    #define VULKAN_GLSLC_EXECUTABLE "glslc"
+#endif
+
+std::string GLSLC = VULKAN_GLSLC_EXECUTABLE;
 std::string input_dir = "vulkan-shaders";
 std::string output_dir = "/tmp";
 std::string target_hpp = "ggml-vulkan-shaders.hpp";

--- a/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
@@ -36,12 +36,16 @@
 std::mutex lock;
 std::vector<std::pair<std::string, std::string>> shader_fnames;
 
-// Default glslc path, can be overridden by --glslc command line argument
-#ifndef VULKAN_GLSLC_EXECUTABLE
-    #define VULKAN_GLSLC_EXECUTABLE "glslc"
+// Default glslc path, can be overridden at compile time or runtime 
+#ifdef VULKAN_GLSLC_EXECUTABLE
+    // If VULKAN_GLSLC_EXECUTABLE is defined at compile time, use it
+    #define DEFAULT_GLSLC_EXECUTABLE VULKAN_GLSLC_EXECUTABLE
+#else
+    // Otherwise default to "glslc"
+    #define DEFAULT_GLSLC_EXECUTABLE "glslc"
 #endif
 
-std::string GLSLC = VULKAN_GLSLC_EXECUTABLE;
+std::string GLSLC = DEFAULT_GLSLC_EXECUTABLE;
 std::string input_dir = "vulkan-shaders";
 std::string output_dir = "/tmp";
 std::string target_hpp = "ggml-vulkan-shaders.hpp";


### PR DESCRIPTION
# Cross-Compilation System for GGML Vulkan

## Key Components and Flow

### glslc Executable Handling:

 - The system now finds the glslc executable on the host system first (before loading Vulkan) using `find_program(Vulkan_GLSLC_EXECUTABLE glslc NO_CMAKE_FIND_ROOT_PATH)`
 - This ensures that we use a host version of glslc even in cross-compilation scenarios
 - Users can override this by setting the Vulkan_GLSLC_EXECUTABLE cache variable directly (`-DVulkan_GLSLC_EXECUTABLE=/path/to/glslc`)

### Cooperative Matrix Support Detection:

 - In normal builds, the system tests if the host glslc supports cooperative matrices by compiling test shaders
 - In cross-compilation, it makes intelligent guesses based on the target platform:
      - Android targets default to COOPMAT=ON and may enable COOPMAT2 for newer API/NDK versions
      - ARM64 platforms default to COOPMAT=ON but keep COOPMAT2=OFF
      - Other platforms default to both OFF
  - These defaults can be overridden with explicit CMake options:
     - `-DGGML_VULKAN_COOPMAT_GLSLC_SUPPORT=ON `
     -  `-DGGML_VULKAN_COOPMAT2_GLSLC_SUPPORT=ON`
     
### Shader Compilation Process:
  - During cross-compilation, the build system creates a host-native version of the vulkan-shaders-gen tool
  - This tool receives the glslc path from the main CMake and embeds it as a default at compile-time
  - The tool can still accept a runtime override via the --glslc command-line parameter
  - This approach ensures that shader compilation always uses a compatible host glslc
    
### Android NDK Compatibility:
  - The system now properly handles the case where different Android NDKs might have different glslc versions
  - Users can explicitly select which glslc to use, allowing them to pick a newer version if needed
  - This solves potential compatibility issues with older NDK glslc versions
  
  
 ## CI (in Whisper.net)
 
 As whisper.cpp doesn't have some CI for Vulkan, I'm attaching my CI runs for whisper.net (only building, no tests yet :( ):
 
 With Cross-Compile:
 https://github.com/sandrohanea/whisper.net/actions/runs/14092352637/job/39471912246
 
 Without Cross-Compile:
 https://github.com/sandrohanea/whisper.net/actions/runs/14092371745/job/39471978181
 