### PR TITLE
ci : increase windows-cublas evict-old-files to 5d

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -687,7 +687,7 @@ jobs:
         with:
           key: ${{ github.job }}-${{ matrix.cuda-toolkit }}-${{ matrix.build }}
           variant: sccache
-          evict-old-files: 1d
+          evict-old-files: 5d
 
       - name: Install Cuda Toolkit 11.8.0
         if: ${{ matrix.cuda-toolkit == '11.8.0' }}


### PR DESCRIPTION
This commit updates the evict-old-files parameter for the windows-cublas build job to 5 days.

The motivation for this change is to avoid the full rebuild which takes around 1.5 hours for the windows-cublas build job. Considering that there are periods of low traffic on whisper.cpp (like weekends etc.) it might be better to have a longer eviction policy to avoid the full rebuild.