### PR TITLE
whisper : add check for CPU backend initialization

### DIFF
--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -1355,7 +1355,11 @@ static std::vector<ggml_backend_t> whisper_backend_init(const whisper_context_pa
 
     GGML_UNUSED(params);
 
-    result.push_back(ggml_backend_init_by_type(GGML_BACKEND_DEVICE_TYPE_CPU, nullptr));
+    ggml_backend_t backend_cpu = ggml_backend_init_by_type(GGML_BACKEND_DEVICE_TYPE_CPU, nullptr);
+    if (backend_cpu == nullptr) {
+        throw std::runtime_error("failed to initialize CPU backend");
+    }
+    result.push_back(backend_cpu);
 
     return result;
 }


### PR DESCRIPTION
This commit adds a check for the CPU backend initialization in the whisper library. If the initialization fails, an exception is thrown.

The motivation for this change is to make the library more robust and handle the case when the CPU backend initialization fails.

Resolves: https://github.com/ggerganov/whisper.cpp/issues/2917