### PR TITLE
ci : remove CMAKE_CUDA_ARCHITECTURES in windows-cublas

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -828,7 +828,6 @@ jobs:
           cmake -S . -B build -G "Ninja Multi-Config" ^
             -DCMAKE_BUILD_TYPE=${{ matrix.build }} ^
             -DGGML_CUDA=${{ matrix.cublas }} ^
-            -DCMAKE_CUDA_ARCHITECTURES=all  ^
             -DWHISPER_SDL2=${{ matrix.sdl2 }} ^
             -DSDL2_DIR="%SDL2_DIR%"
           set /A NINJA_JOBS=%NUMBER_OF_PROCESSORS%-1


### PR DESCRIPTION
This commit removes the -DCMAKE_CUDA_ARCHITECTURES=all flag from the windows-cublas job in the build.yml file.

The motivation for this is that building for all architectures is unnecessary and takes a long time. Without this flag the architectures will instead be set by ggml-cuda.

Refs: https://github.com/ggerganov/whisper.cpp/pull/2915#issuecomment-2743160743