### PR TITLE
whisper : update default model download directory behavior to use current working directory when script is in /bin/ directory

### DIFF
--- a/models/download-coreml-model.sh
+++ b/models/download-coreml-model.sh
@@ -19,7 +19,15 @@ get_script_path() {
     fi
 }
 
-models_path="$(get_script_path)"
+script_path="$(get_script_path)"
+
+# Check if the script is inside a /bin/ directory
+case "$script_path" in
+    */bin) default_download_path="$PWD" ;;  # Use current directory as default download path if in /bin/
+    *) default_download_path="$script_path" ;;  # Otherwise, use script directory
+esac
+
+models_path="${2:-$default_download_path}"
 
 # Whisper models
 models="tiny.en tiny base.en base small.en small medium.en medium large-v1 large-v2 large-v3 large-v3-turbo"
@@ -34,8 +42,8 @@ list_models() {
         printf "\n\n"
 }
 
-if [ "$#" -ne 1 ]; then
-    printf "Usage: %s <model>\n" "$0"
+if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
+    printf "Usage: %s <model> [models_path]\n" "$0"
     list_models
 
     exit 1

--- a/models/download-ggml-model.sh
+++ b/models/download-ggml-model.sh
@@ -22,7 +22,15 @@ get_script_path() {
     fi
 }
 
-models_path="${2:-$(get_script_path)}"
+script_path="$(get_script_path)"
+
+# Check if the script is inside a /bin/ directory
+case "$script_path" in
+    */bin) default_download_path="$PWD" ;;  # Use current directory as default download path if in /bin/
+    *) default_download_path="$script_path" ;;  # Otherwise, use script directory
+esac
+
+models_path="${2:-$default_download_path}"
 
 # Whisper models
 models="tiny


### PR DESCRIPTION
This change ensures that when the script is packaged and distributed, models are downloaded to the current directory instead of the script's location, preventing conflicts with system directories. This improves flexibility and usability for distribution and packaging scenarios.