### PR TITLE
whisper : enhance model download scripts functionality and resolve compiler warning

### DIFF
--- a/examples/cli/cli.cpp
+++ b/examples/cli/cli.cpp
@@ -13,7 +13,9 @@
 #include <cstring>
 
 #if defined(_WIN32)
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 #include <windows.h>
 #endif
 

--- a/models/download-coreml-model.sh
+++ b/models/download-coreml-model.sh
@@ -85,9 +85,18 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-printf "Done! Model '%s' saved in 'models/ggml-%s.mlmodel'\n" "$model" "$model"
+# Check if 'whisper-cli' is available in the system PATH
+if command -v whisper-cli >/dev/null 2>&1; then
+    # If found, use 'whisper-cli' (relying on PATH resolution)
+    whisper_cmd="whisper-cli"
+else
+    # If not found, use the local build version
+    whisper_cmd="./build/bin/whisper-cli"
+fi
+
+printf "Done! Model '%s' saved in '%s/ggml-%s.bin'\n" "$model" "$models_path" "$model"
 printf "Run the following command to compile it:\n\n"
-printf "  $ xcrun coremlc compile ./models/ggml-%s.mlmodel ./models\n\n" "$model"
+printf "  $ xcrun coremlc compile %s/ggml-%s.mlmodel %s\n\n" "$models_path" "$model" "$models_path"
 printf "You can now use it like this:\n\n"
-printf "  $ ./build/bin/whisper-cli -m models/ggml-%s.bin -f samples/jfk.wav\n" "$model"
+printf "  $ %s -m %s/ggml-%s.bin -f samples/jfk.wav\n" "$whisper_cmd" "$models_path" "$model"
 printf "\n"

--- a/models/download-ggml-model.cmd
+++ b/models/download-ggml-model.cmd
@@ -1,10 +1,27 @@
 @echo off
 
-pushd %~dp0
-set models_path=%CD%
-for %%d in (%~dp0..) do set root_path=%%~fd
-popd
+rem Save the original working directory
+set "orig_dir=%CD%"
 
+rem Get the script directory
+set "script_dir=%~dp0"
+
+rem Check if the script directory contains "\bin\" (case-insensitive)
+echo %script_dir% | findstr /i "\\bin\\" >nul
+if %ERRORLEVEL%==0 (
+  rem If script is in a \bin\ directory, use the original working directory as default download path
+  set "default_download_path=%orig_dir%"
+) else (
+  rem Otherwise, use script directory
+  pushd %~dp0
+  set "default_download_path=%CD%"
+  popd
+)
+
+rem Set the root path to be the parent directory of the script
+for %%d in (%~dp0..) do set "root_path=%%~fd"
+
+rem Count number of arguments passed to script
 set argc=0
 for %%x in (%*) do set /A argc+=1
 
@@ -21,11 +38,20 @@ large-v2 large-v2-q5_0 large-v2-q8_0 ^
 large-v3 large-v3-q5_0 ^
 large-v3-turbo large-v3-turbo-q5_0 large-v3-turbo-q8_0
 
-if %argc% neq 1 (
-  echo.
-  echo Usage: download-ggml-model.cmd model
-  CALL :list_models
-  goto :eof
+rem If argc is not equal to 1 or 2, print usage information and exit
+if %argc% NEQ 1 (
+  if %argc% NEQ 2 (
+    echo.
+    echo Usage: download-ggml-model.cmd model [models_path]
+    CALL :list_models
+    goto :eof
+  )
+)
+
+if %argc% EQU 2 (
+  set models_path=%2
+) else (
+  set models_path=%default_download_path%
 )
 
 set model=%1
@@ -44,14 +70,12 @@ goto :eof
 :download_model
 echo Downloading ggml model %model%...
 
-cd "%models_path%"
-
-if exist "ggml-%model%.bin" (
+if exist "%models_path%\\ggml-%model%.bin" (
   echo Model %model% already exists. Skipping download.
   goto :eof
 )
 
-PowerShell -NoProfile -ExecutionPolicy Bypass -Command "Start-BitsTransfer -Source https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-%model%.bin -Destination ggml-%model%.bin"
+PowerShell -NoProfile -ExecutionPolicy Bypass -Command "Start-BitsTransfer -Source https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-%model%.bin -Destination \"%models_path%\\ggml-%model%.bin\""
 
 if %ERRORLEVEL% neq 0 (
   echo Failed to download ggml model %model%
@@ -59,9 +83,19 @@ if %ERRORLEVEL% neq 0 (
   goto :eof
 )
 
-echo Done! Model %model% saved in %root_path%\models\ggml-%model%.bin
+rem Check if 'whisper-cli' is available in the system PATH
+where whisper-cli >nul 2>&1
+if %ERRORLEVEL%==0 (
+  rem If found, suggest 'whisper-cli' (relying on PATH resolution)
+  set "whisper_cmd=whisper-cli"
+) else (
+  rem If not found, suggest the local build version
+  set "whisper_cmd=%root_path%\build\bin\Release\whisper-cli.exe"
+)
+
+echo Done! Model %model% saved in %models_path%\ggml-%model%.bin
 echo You can now use it like this:
-echo %~dp0build\bin\Release\whisper-cli.exe -m %root_path%\models\ggml-%model%.bin -f %root_path%\samples\jfk.wav
+echo %whisper_cmd% -m %models_path%\ggml-%model%.bin -f samples\jfk.wav
 
 goto :eof
 

--- a/models/download-ggml-model.sh
+++ b/models/download-ggml-model.sh
@@ -134,7 +134,16 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
+# Check if 'whisper-cli' is available in the system PATH
+if command -v whisper-cli >/dev/null 2>&1; then
+    # If found, use 'whisper-cli' (relying on PATH resolution)
+    whisper_cmd="whisper-cli"
+else
+    # If not found, use the local build version
+    whisper_cmd="./build/bin/whisper-cli"
+fi
+
 printf "Done! Model '%s' saved in '%s/ggml-%s.bin'\n" "$model" "$models_path" "$model"
 printf "You can now use it like this:\n\n"
-printf "  $ ./build/bin/whisper-cli -m %s/ggml-%s.bin -f samples/jfk.wav\n" "$models_path" "$model"
+printf "  $ %s -m %s/ggml-%s.bin -f samples/jfk.wav\n" "$whisper_cmd" "$models_path" "$model"
 printf "\n"


### PR DESCRIPTION
* Improve whisper-cli executable path detection in model download shell scripts. If whisper-cli is found on the path, do not suggest invoking from build directory
* Enhance Windows model download batch script to have comparable functionality and behaviour as shell scripts
* Resolve compiler warning by removing duplicate definition of NOMINMAX in whisper-cli code