### PR TITLE
examples : fix request path for local worker files

### DIFF
--- a/examples/server.py
+++ b/examples/server.py
@@ -10,11 +10,23 @@ DIRECTORY = os.path.abspath(DIRECTORY)
 class CustomHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, directory=DIRECTORY, **kwargs)
-    
+
+    def do_GET(self):
+        # If requesting a worker file from any subdirectory
+        if '.worker.js' in self.path:
+            worker_file = os.path.basename(self.path)
+            worker_path = os.path.join(DIRECTORY, worker_file)
+
+            if os.path.exists(worker_path):
+                self.path = '/' + worker_file
+
+        return super().do_GET()
+
     def end_headers(self):
         # Add required headers for SharedArrayBuffer
         self.send_header("Cross-Origin-Opener-Policy", "same-origin")
         self.send_header("Cross-Origin-Embedder-Policy", "require-corp")
+        self.send_header("Access-Control-Allow-Origin", "*");
         super().end_headers()
 
 PORT = 8000


### PR DESCRIPTION
This commit adds a fix to the server.py file to handle requests for web worker files when running the local python server to test the wasm examples.

The motivation for this is that currently the server is serving files from the build-em/bin directory which is where the `.worker.js` files exist. But when examples access these resources they do so with the application context path, for example `/whisper.wasm/libmain.worker.js` but this will not be found as it currently works.