### PR TITLE
examples : fix nthread parsing in whisper.wasm

### DIFF
--- a/examples/whisper.wasm/index-tmpl.html
+++ b/examples/whisper.wasm/index-tmpl.html
@@ -614,7 +614,7 @@
             var nthreads = 8;
 
             function changeThreads(value) {
-                nthreads = value;
+                nthreads = parseInt(value, 10);
                 document.getElementById('threads-value').innerHTML = nthreads;
             }
 


### PR DESCRIPTION
This commit fixes the nthread parsing in the whisper.wasm example when using the `Threads` slider to change the number of threads to be used.

Currently this results in the following error:
```console
main.js:5597 Uncaught TypeError: Cannot convert "5" to int
    at checkAssertions (main.js:5597:21)
    at Object.toWireType (main.js:5611:15)
    at Object.full_default (eval at new_ (main.js:5292:27), <anonymous>:10:26)
    at whisper.wasm/:649:42
```