### PR TITLE
examples : reduce initial memory to 512MB

### DIFF
--- a/examples/whisper.wasm/CMakeLists.txt
+++ b/examples/whisper.wasm/CMakeLists.txt
@@ -32,8 +32,8 @@ set_target_properties(${TARGET} PROPERTIES LINK_FLAGS " \
     --bind \
     -s USE_PTHREADS=1 \
     -s PTHREAD_POOL_SIZE_STRICT=0 \
-    -s INITIAL_MEMORY=256MB \
-    -s TOTAL_MEMORY=2000MB \
+    -s INITIAL_MEMORY=512MB \
+    -s MAXIMUM_MEMORY=2000MB \
     -s ALLOW_MEMORY_GROWTH=1 \
     -s FORCE_FILESYSTEM=1 \
     -s EXPORTED_RUNTIME_METHODS=\"['print', 'printErr', 'ccall', 'cwrap']\" \

--- a/examples/whisper.wasm/CMakeLists.txt
+++ b/examples/whisper.wasm/CMakeLists.txt
@@ -32,8 +32,9 @@ set_target_properties(${TARGET} PROPERTIES LINK_FLAGS " \
     --bind \
     -s USE_PTHREADS=1 \
     -s PTHREAD_POOL_SIZE_STRICT=0 \
-    -s INITIAL_MEMORY=2000MB \
+    -s INITIAL_MEMORY=256MB \
     -s TOTAL_MEMORY=2000MB \
+    -s ALLOW_MEMORY_GROWTH=1 \
     -s FORCE_FILESYSTEM=1 \
     -s EXPORTED_RUNTIME_METHODS=\"['print', 'printErr', 'ccall', 'cwrap']\" \
     ${EXTRA_FLAGS} \


### PR DESCRIPTION
This commit reduces the initial memory size to 512MB. This is done to to avoid WebAssembly memory allocation issues on some platforms. It also adds a flag to allow the memory to grow dynamically (up to the maximum).

The motivation for this change is that currently the initial memory is set to 2GB which might be to large for some platforms. This will lead to an error being thrown from the JavaScript code generated by Emscripten when trying to allocate memory. More details can be found in the referenced issue below.

Refs: https://github.com/ggerganov/whisper.cpp/issues/2920