### PR TITLE
whisper.android : add GGML_USE_CPU compile definition

### DIFF
--- a/examples/whisper.android/lib/src/main/jni/whisper/CMakeLists.txt
+++ b/examples/whisper.android/lib/src/main/jni/whisper/CMakeLists.txt
@@ -44,6 +44,8 @@ function(build_library target_name)
         ${SOURCE_FILES}
     )
 
+    target_compile_definitions(${target_name} PUBLIC GGML_USE_CPU)
+
     if (${target_name} STREQUAL "whisper_v8fp16_va")
         target_compile_options(${target_name} PRIVATE -march=armv8.2-a+fp16)
         set(GGML_COMPILE_OPTIONS                      -march=armv8.2-a+fp16)


### PR DESCRIPTION
This commit add `GGML_USE_CPU` to built target library to enable CPU backend.

The motivation for this that without the compile definition the CPU backend is not enabled and the app will crash when trying to use it.