### PR TITLE
bindings.javascript : update test instructions [no ci]

### DIFF
--- a/bindings/javascript/README.md
+++ b/bindings/javascript/README.md
@@ -33,6 +33,9 @@ mkdir build-em && cd build-em
 emcmake cmake .. && make -j
 
 # run test
+node ../tests/test-whisper.js
+
+# For Node.js versions prior to v16.4.0, experimental features need to be enabled:
 node --experimental-wasm-threads --experimental-wasm-simd ../tests/test-whisper.js
 
 # publish npm package


### PR DESCRIPTION
This commit updates the instructions for running the test in the JavaScript bindings README file.

The motivation for this is for Node.js versions after v16.4.0 the `--experimental-wasm-threads` and `--experimental-wasm-simd` flags are no longer required and they generate the following errors:
```console
$ node --experimental-wasm-threads --experimental-wasm-simd ../tests/test-whisper.js
node: bad option: --experimental-wasm-threads
node: bad option: --experimental-wasm-simd
```