### PR TITLE
bindings-go : update Makefile to use cmake

### DIFF
--- a/bindings/go/Makefile
+++ b/bindings/go/Makefile
@@ -11,11 +11,11 @@ UNAME_M := $(shell uname -m)
 endif
 
 GGML_METAL_PATH_RESOURCES := $(abspath ../..)
-BUILD_DIR := build
+BUILD_DIR := build_go
 MODELS_DIR := models
 EXAMPLES_DIR := $(wildcard examples/*)
 INCLUDE_PATH := $(abspath ../../include):$(abspath ../../ggml/include)
-LIBRARY_PATH := $(abspath ../..)
+LIBRARY_PATH := $(abspath ../../${BUILD_DIR}/src:$(abspath ../../${BUILD_DIR}/ggml/src))
 
 ifeq ($(GGML_CUDA),1)
 	LIBRARY_PATH := $(LIBRARY_PATH):$(CUDA_PATH)/targets/$(UNAME_M)-linux/lib/
@@ -29,8 +29,10 @@ endif
 all: clean whisper examples
 
 whisper: mkdir
-	@echo Build whisper
-	@${MAKE} -C ../.. libwhisper.a
+	cmake -S ../.. -B ../../${BUILD_DIR} \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DBUILD_SHARED_LIBS=OFF
+	cmake --build ../../${BUILD_DIR} --target whisper
 
 test: model-small whisper modtidy
 ifeq ($(UNAME_S),Darwin)

--- a/bindings/go/whisper.go
+++ b/bindings/go/whisper.go
@@ -9,7 +9,7 @@ import (
 // CGO
 
 /*
-#cgo LDFLAGS: -lwhisper -lm -lstdc++ -fopenmp
+#cgo LDFLAGS: -lwhisper -lggml -lggml-base -lggml-cpu  -lm -lstdc++ -fopenmp
 #cgo darwin LDFLAGS: -framework Accelerate -framework Metal -framework Foundation -framework CoreGraphics
 #include <whisper.h>
 #include <stdlib.h>


### PR DESCRIPTION
This commit updates the Makefile to use cmake instead of make to build whisper.cpp.

The motivation for this change is that currently the make recipe test will fail with the following error:
```console
$ make test
Mkdir build
Mkdir models
Build whisper
make[1]: Entering directory '/home/danbev/work/ai/whisper-work'
make[1]: *** No rule to make target 'libwhisper.a'.  Stop.
make[1]: Leaving directory '/home/danbev/work/ai/whisper-work'
make: *** [Makefile:33: whisper] Error 2
```