### PR TITLE
bindings.ruby : fix test failures in test_whisper

### DIFF
--- a/bindings/ruby/tests/test_callback.rb
+++ b/bindings/ruby/tests/test_callback.rb
@@ -25,7 +25,7 @@ class TestCallback < TestBase
         assert start_time >= 0
         assert_kind_of Integer, end_time
         assert end_time > 0
-        assert_match /ask not what your country can do for you, ask what you can do for your country/, text if i_segment == 0
+        assert_match(/ask not what your country can do for you, ask what you can do for your country/, text) if i_segment == 0
       end
     }
 
@@ -145,9 +145,9 @@ class TestCallback < TestBase
 
   def test_abort_on
     do_abort = false
-    aborted_from_callback = false
+    _aborted_from_callback = false
     @params.on_new_segment do |segment|
-      do_abort = true if segment.text.match? /ask/
+      do_abort = true if segment.text.match?(/ask/)
     end
     i = 0
     @params.abort_on do

--- a/bindings/ruby/tests/test_error.rb
+++ b/bindings/ruby/tests/test_error.rb
@@ -4,7 +4,7 @@ class TestError < TestBase
   def test_error
     error = Whisper::Error.new(-2)
     assert_equal "failed to compute log mel spectrogram", error.message
-    assert_equal -2, error.code
+    assert_equal(-2, error.code)
   end
 
   def test_unknown_error
@@ -14,7 +14,7 @@ class TestError < TestBase
 
   def test_non_int_code
     assert_raise TypeError do
-      error = Whisper::Error.new("non int")
+      _error = Whisper::Error.new("non int")
     end
   end
 end

--- a/bindings/ruby/tests/test_params.rb
+++ b/bindings/ruby/tests/test_params.rb
@@ -162,7 +162,7 @@ class TestParams < TestBase
   end
 
   def test_length_penalty
-    assert_equal -1.0, @params.length_penalty
+    assert_equal(-1.0, @params.length_penalty)
     @params.length_penalty = 0.5
     assert_equal 0.5, @params.length_penalty
   end
@@ -180,9 +180,9 @@ class TestParams < TestBase
   end
 
   def test_logprob_thold
-    assert_in_delta -1.0, @params.logprob_thold
+    assert_in_delta(-1.0, @params.logprob_thold)
     @params.logprob_thold = -0.5
-    assert_in_delta -0.5, @params.logprob_thold
+    assert_in_delta(-0.5, @params.logprob_thold)
   end
 
   def test_no_speech_thold

--- a/bindings/ruby/tests/test_segment.rb
+++ b/bindings/ruby/tests/test_segment.rb
@@ -49,13 +49,13 @@ class TestSegment < TestBase
       if index == 0
         seg = segment
         assert_equal 0, segment.start_time
-        assert_match /ask not what your country can do for you, ask what you can do for your country/, segment.text
+        assert_match(/ask not what your country can do for you, ask what you can do for your country/, segment.text)
       end
       index += 1
     end
     whisper.transcribe(AUDIO, params)
     assert_equal 0, seg.start_time
-    assert_match /ask not what your country can do for you, ask what you can do for your country/, seg.text
+    assert_match(/ask not what your country can do for you, ask what you can do for your country/, seg.text)
   end
 
   def test_on_new_segment_twice

--- a/bindings/ruby/tests/test_whisper.rb
+++ b/bindings/ruby/tests/test_whisper.rb
@@ -18,7 +18,7 @@ class TestWhisper < TestBase
     params.print_timestamps = false
 
     @whisper.transcribe(AUDIO, params) {|text|
-      assert_match /ask not what your country can do for you, ask what you can do for your country/, text
+      assert_match(/ask not what your country can do for you, ask what you can do for your country/, text)
     }
   end
 
@@ -34,7 +34,7 @@ class TestWhisper < TestBase
     def test_full_get_segment
       segment = whisper.full_get_segment(0)
       assert_equal 0, segment.start_time
-      assert_match /ask not what your country can do for you, ask what you can do for your country/, segment.text
+      assert_match(/ask not what your country can do for you, ask what you can do for your country/, segment.text)
     end
 
     def test_full_get_segment_t0
@@ -61,7 +61,7 @@ class TestWhisper < TestBase
     end
 
     def test_full_get_segment_text
-      assert_match /ask not what your country can do for you, ask what you can do for your country/, whisper.full_get_segment_text(0)
+      assert_match(/ask not what your country can do for you, ask what you can do for your country/, whisper.full_get_segment_text(0))
     end
 
     def test_full_get_segment_no_speech_prob
@@ -136,14 +136,14 @@ class TestWhisper < TestBase
       @whisper.full(@params, @samples, @samples.length)
 
       assert_equal 1, @whisper.full_n_segments
-      assert_match /ask not what your country can do for you, ask what you can do for your country/, @whisper.each_segment.first.text
+      assert_match(/ask not what your country can do for you, ask what you can do for your country/, @whisper.each_segment.first.text)
     end
 
     def test_full_without_length
       @whisper.full(@params, @samples)
 
       assert_equal 1, @whisper.full_n_segments
-      assert_match /ask not what your country can do for you, ask what you can do for your country/, @whisper.each_segment.first.text
+      assert_match(/ask not what your country can do for you, ask what you can do for your country/, @whisper.each_segment.first.text)
     end
 
     def test_full_enumerator
@@ -151,7 +151,7 @@ class TestWhisper < TestBase
       @whisper.full(@params, samples, @samples.length)
 
       assert_equal 1, @whisper.full_n_segments
-      assert_match /ask not what your country can do for you, ask what you can do for your country/, @whisper.each_segment.first.text
+      assert_match(/ask not what your country can do for you, ask what you can do for your country/, @whisper.each_segment.first.text)
     end
 
     def test_full_enumerator_without_length
@@ -173,7 +173,7 @@ class TestWhisper < TestBase
       @whisper.full(@params, samples)
 
       assert_equal 1, @whisper.full_n_segments
-      assert_match /ask not what your country can do for you, ask what you can do for your country/, @whisper.each_segment.first.text
+      assert_match(/ask not what your country can do for you, ask what you can do for your country/, @whisper.each_segment.first.text)
     end
 
     def test_full_parallel
@@ -182,8 +182,8 @@ class TestWhisper < TestBase
 
       assert_equal nprocessors, @whisper.full_n_segments
       text = @whisper.each_segment.collect(&:text).join
-      assert_match /ask what you can do/i, text
-      assert_match /for your country/i, text
+      assert_match(/ask what you can do/i, text)
+      assert_match(/for your country/i, text)
     end
 
     def test_full_parallel_with_memory_view
@@ -193,8 +193,8 @@ class TestWhisper < TestBase
 
       assert_equal nprocessors, @whisper.full_n_segments
       text = @whisper.each_segment.collect(&:text).join
-      assert_match /ask what you can do/i, text
-      assert_match /for your country/i, text
+      assert_match(/ask what you can do/i, text)
+      assert_match(/for your country/i, text)
     end
 
     def test_full_parallel_without_length_and_n_processors
@@ -202,8 +202,8 @@ class TestWhisper < TestBase
 
       assert_equal 1, @whisper.full_n_segments
       text = @whisper.each_segment.collect(&:text).join
-      assert_match /ask what you can do/i, text
-      assert_match /for your country/i, text
+      assert_match(/ask what you can do/i, text)
+      assert_match(/for your country/i, text)
     end
 
     def test_full_parallel_without_length
@@ -212,8 +212,8 @@ class TestWhisper < TestBase
 
       assert_equal nprocessors, @whisper.full_n_segments
       text = @whisper.each_segment.collect(&:text).join
-      assert_match /ask what you can do/i, text
-      assert_match /for your country/i, text
+      assert_match(/ask what you can do/i, text)
+      assert_match(/for your country/i, text)
     end
 
     def test_full_parallel_without_n_processors
@@ -221,8 +221,8 @@ class TestWhisper < TestBase
 
       assert_equal 1, @whisper.full_n_segments
       text = @whisper.each_segment.collect(&:text).join
-      assert_match /ask what you can do/i, text
-      assert_match /for your country/i, text
+      assert_match(/ask what you can do/i, text)
+      assert_match(/for your country/i, text)
     end
   end
 end

--- a/bindings/ruby/tests/test_whisper.rb
+++ b/bindings/ruby/tests/test_whisper.rb
@@ -3,7 +3,9 @@ require "stringio"
 require "etc"
 
 # Exists to detect memory-related bug
-Whisper.log_set ->(level, buffer, user_data) {}, nil
+# TODO(danbev) Investigate how this works as it currently causes a segfault
+# when enabled.
+#Whisper.log_set ->(level, buffer, user_data) {}, nil
 
 class TestWhisper < TestBase
   def setup
@@ -175,19 +177,21 @@ class TestWhisper < TestBase
     end
 
     def test_full_parallel
-      @whisper.full_parallel(@params, @samples, @samples.length, Etc.nprocessors)
+      nprocessors = 2
+      @whisper.full_parallel(@params, @samples, @samples.length, nprocessors)
 
-      assert_equal Etc.nprocessors, @whisper.full_n_segments
+      assert_equal nprocessors, @whisper.full_n_segments
       text = @whisper.each_segment.collect(&:text).join
       assert_match /ask what you can do/i, text
       assert_match /for your country/i, text
     end
 
     def test_full_parallel_with_memory_view
+      nprocessors = 2
       samples = JFKReader.new(AUDIO)
-      @whisper.full_parallel(@params, samples, nil, Etc.nprocessors)
+      @whisper.full_parallel(@params, samples, nil, nprocessors)
 
-      assert_equal Etc.nprocessors, @whisper.full_n_segments
+      assert_equal nprocessors, @whisper.full_n_segments
       text = @whisper.each_segment.collect(&:text).join
       assert_match /ask what you can do/i, text
       assert_match /for your country/i, text
@@ -203,9 +207,10 @@ class TestWhisper < TestBase
     end
 
     def test_full_parallel_without_length
-      @whisper.full_parallel(@params, @samples, nil, Etc.nprocessors)
+      nprocessors = 2
+      @whisper.full_parallel(@params, @samples, nil, nprocessors)
 
-      assert_equal Etc.nprocessors, @whisper.full_n_segments
+      assert_equal nprocessors, @whisper.full_n_segments
       text = @whisper.each_segment.collect(&:text).join
       assert_match /ask what you can do/i, text
       assert_match /for your country/i, text

--- a/bindings/ruby/tests/test_whisper.rb
+++ b/bindings/ruby/tests/test_whisper.rb
@@ -3,9 +3,7 @@ require "stringio"
 require "etc"
 
 # Exists to detect memory-related bug
-# TODO(danbev) Investigate how this works as it currently causes a segfault
-# when enabled.
-#Whisper.log_set ->(level, buffer, user_data) {}, nil
+Whisper.log_set ->(level, buffer, user_data) {}, nil
 
 class TestWhisper < TestBase
   def setup


### PR DESCRIPTION
This commit updates the parallel tests to use 2 processors instead of the number of processors on the system. It also comments out the setting of the log callback to an empty lambda as this causes a segfault when enabled.

The motivation for the change to the number of processors is that if one has a large number of processors, for example I have 16 on the machine I used to test this, this would cause the following warning to be printed:
```console
whisper_full_with_state: input is too short - 680 ms < 1000 ms. consider padding the input audio with silence
```

This is logged from:
```c++
int whisper_full_with_state(
        struct whisper_context * ctx,
          struct whisper_state * state,
    struct whisper_full_params   params,
                   const float * samples,
                           int   n_samples) {
   ...
    if (seek_end < seek_start + 100) {
        WHISPER_LOG_WARN("%s: input is too short - %d ms < 1000 ms. consider padding the input audio with silence\n", __func__, (seek_end - seek_start)*10);
        return 0;
    }
```
This will return early and there will be no segment callbacks to be invoked which in turn will cause the tests to fail.