### PR TITLE
ci : re-enable bindings-java (java) job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1045,8 +1045,8 @@ jobs:
             exit 1
           }
 
-          Copy-Item -Path "x64_SDL2.dll" -Destination "bindings\java\build\generated\resources\main\SDL2.dll" -Force
-          Write-Host "Copied x64_SDL2.dll to resources directory"
+          Copy-Item -Path "SDL2.dll" -Destination "bindings\java\build\generated\resources\main\SDL2.dll" -Force
+          Write-Host "Copied SDL2.dll to resources directory"
 
       - name: Build
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1037,17 +1037,16 @@ jobs:
         run: |
           New-Item -Path "build\Release" -ItemType Directory -Force
 
-          $dllPath = Get-ChildItem -Path "." -Recurse -Filter "*.dll" | Select-Object -First 1 -ExpandProperty FullName
-          if ($dllPath) {
-            Copy-Item -Path $dllPath -Destination "build\Release\whisper.dll" -Force
-            Write-Host "Copied from $dllPath to build\Release\whisper.dll"
-          } else {
-            Write-Host "No DLL found in the downloaded artifact"
-            exit 1
-          }
+          Copy-Item -Path "whisper.dll" -Destination "build\Release\whisper.dll" -Force
+          Write-Host "Copied whisper.dll to build\Release\whisper.dll directory"
 
           Copy-Item -Path "SDL2.dll" -Destination "build\Release\SDL2.dll" -Force
           Write-Host "Copied SDL2.dll to build\Release\SDL2.dll directory"
+
+      - name: List build release files
+        shell: pwsh
+        run: |
+          Get-ChildItem -Path "build\Release -Recurse -Filter "*.dll"
 
       - name: Build
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -570,6 +570,12 @@ jobs:
         if: matrix.sdl2 == 'ON'
         run: copy "$env:SDL2_DIR/../lib/${{ matrix.s2arc }}/SDL2.dll" build/bin/${{ matrix.build }}
 
+      - name: Upload SDL2.dll
+        uses: actions/upload-artifact@v4
+        with:
+          name: SDL2-dll
+          path: build/bin/${{ matrix.build }}/SDL2.dll
+
       - name: Upload dll
         uses: actions/upload-artifact@v4
         with:
@@ -845,12 +851,6 @@ jobs:
       - name: Copy SDL2.dll
         if: matrix.sdl2 == 'ON'
         run: copy "$env:SDL2_DIR/../lib/${{ matrix.arch }}/SDL2.dll" build/bin/${{ matrix.build }}
-
-      - name: Upload SDL2.dll
-        uses: actions/upload-artifact@v4
-        with:
-          name: SDL2-dll
-          path: build/bin/${{ matrix.build }}/SDL2.dll
 
       - name: Upload binaries
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -581,7 +581,7 @@ jobs:
       - name: Upload dll
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.jnaPath }}_whisper.dll
+          name: whisper_${{ matrix.arch }}.dll
           path: build/bin/${{ matrix.build }}/whisper.dll
 
       - name: Upload binaries
@@ -1020,7 +1020,7 @@ jobs:
       - name: Download Windows lib
         uses: actions/download-artifact@v4
         with:
-          name: win32-x86-64_whisper.dll
+          name: whisper_x64.dll
 
       - name: Download SDL2.dll
         uses: actions/download-artifact@v4
@@ -1037,8 +1037,8 @@ jobs:
         run: |
           New-Item -Path "build\Release" -ItemType Directory -Force
 
-          Copy-Item -Path "whisper.dll" -Destination "build\Release\whisper.dll" -Force
-          Write-Host "Copied whisper.dll to build\Release\whisper.dll directory"
+          Copy-Item -Path "whisper_x64.dll" -Destination "build\Release\whisper.dll" -Force
+          Write-Host "Copied whisper_x64.dll to build\Release\whisper.dll directory"
 
           Copy-Item -Path "SDL2.dll" -Destination "build\Release\SDL2.dll" -Force
           Write-Host "Copied SDL2.dll to build\Release\SDL2.dll directory"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -996,6 +996,8 @@ jobs:
 #          ./gradlew assembleRelease
 
   bindings-java:
+    if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' ||
+            github.event.inputs.run_type == 'full-ci' }}
     needs: ['windows']
     runs-on: windows-latest
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1045,8 +1045,8 @@ jobs:
             exit 1
           }
 
-          Copy-Item -Path "SDL2.dll" -Destination "bindings\java\build\generated\resources\main\SDL2.dll" -Force
-          Write-Host "Copied SDL2.dll to resources directory"
+          Copy-Item -Path "SDL2.dll" -Destination "build\Release\SDL2.dll" -Force
+          Write-Host "Copied SDL2.dll to build\Release\SDL2.dll directory"
 
       - name: Build
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -559,6 +559,7 @@ jobs:
         run: >
           cmake -S . -B ./build -A ${{ matrix.arch }}
           -DCMAKE_BUILD_TYPE=${{ matrix.build }}
+          -DBUILD_SHARED_LIBS=ON
           -DWHISPER_SDL2=${{ matrix.sdl2 }}
 
       - name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1022,12 +1022,12 @@ jobs:
       - name: Move DLL to correct location
         shell: pwsh
         run: |
+          New-Item -Path "build\Release" -ItemType Directory -Force
+
           $dllPath = Get-ChildItem -Path "." -Recurse -Filter "*.dll" | Select-Object -First 1 -ExpandProperty FullName
           if ($dllPath) {
-            $targetDir = "bindings\java\build\generated\resources\main"
-            New-Item -Path $targetDir -ItemType Directory -Force
-            Copy-Item -Path $dllPath -Destination "$targetDir\whisper.dll" -Force
-            Write-Host "Copied from $dllPath to $targetDir\whisper.dll"
+            Copy-Item -Path $dllPath -Destination "build\Release\whisper.dll" -Force
+            Write-Host "Copied from $dllPath to build\Release\whisper.dll"
           } else {
             Write-Host "No DLL found in the downloaded artifact"
             exit 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1013,11 +1013,25 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: win32-x86-64_whisper.dll
-          path: bindings/java/build/generated/resources/main/
 
-      - name: Rename DLL
+      - name: List downloaded files
+        shell: pwsh
         run: |
-          ren "bindings\java\build\generated\resources\main\win32-x86-64_whisper.dll" "whisper.dll"
+          Get-ChildItem -Path "." -Recurse -Filter "*.dll"
+
+      - name: Move DLL to correct location
+        shell: pwsh
+        run: |
+          $dllPath = Get-ChildItem -Path "." -Recurse -Filter "*.dll" | Select-Object -First 1 -ExpandProperty FullName
+          if ($dllPath) {
+            $targetDir = "bindings\java\build\generated\resources\main"
+            New-Item -Path $targetDir -ItemType Directory -Force
+            Copy-Item -Path $dllPath -Destination "$targetDir\whisper.dll" -Force
+            Write-Host "Copied from $dllPath to $targetDir\whisper.dll"
+          } else {
+            Write-Host "No DLL found in the downloaded artifact"
+            exit 1
+          }
 
       - name: Build
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1013,7 +1013,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: win32-x86-64_whisper.dll
-          path: bindings/java/build/generated/resources/main/win32-x86-64
+          path: bindings/java/build/generated/resources/main/windows-x86-64
 
       - name: Build
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1046,7 +1046,7 @@ jobs:
       - name: List build release files
         shell: pwsh
         run: |
-          Get-ChildItem -Path "build\Release -Recurse -Filter "*.dll"
+          Get-ChildItem -Path "build\Release" -Recurse -Filter "*.dll"
 
       - name: Build
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1037,8 +1037,8 @@ jobs:
         run: |
           New-Item -Path "build\Release" -ItemType Directory -Force
 
-          Copy-Item -Path "whisper_x64.dll" -Destination "build\Release\whisper.dll" -Force
-          Write-Host "Copied whisper_x64.dll to build\Release\whisper.dll directory"
+          Copy-Item -Path "whisper.dll" -Destination "build\Release\whisper.dll" -Force
+          Write-Host "Copied whisper.dll to build\Release\whisper.dll directory"
 
           Copy-Item -Path "SDL2.dll" -Destination "build\Release\SDL2.dll" -Force
           Write-Host "Copied SDL2.dll to build\Release\SDL2.dll directory"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1038,7 +1038,7 @@ jobs:
           models\download-ggml-model.cmd tiny.en
           cd bindings/java
           chmod +x ./gradlew
-          ./gradlew build
+          ./gradlew build --info
 
       - name: Upload jar
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1013,7 +1013,11 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: win32-x86-64_whisper.dll
-          path: bindings/java/build/generated/resources/main/windows-x86-64
+          path: bindings/java/build/generated/resources/main/
+
+      - name: Rename DLL
+        run: |
+          ren "bindings\java\build\generated\resources\main\win32-x86-64_whisper.dll" "whisper.dll"
 
       - name: Build
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -846,6 +846,12 @@ jobs:
         if: matrix.sdl2 == 'ON'
         run: copy "$env:SDL2_DIR/../lib/${{ matrix.arch }}/SDL2.dll" build/bin/${{ matrix.build }}
 
+      - name: Upload SDL2.dll
+        uses: actions/upload-artifact@v4
+        with:
+          name: SDL2-dll
+          path: build/bin/${{ matrix.build }}/SDL2.dll
+
       - name: Upload binaries
         uses: actions/upload-artifact@v4
         with:
@@ -1014,6 +1020,11 @@ jobs:
         with:
           name: win32-x86-64_whisper.dll
 
+      - name: Download SDL2.dll
+        uses: actions/download-artifact@v4
+        with:
+          name: SDL2-dll
+
       - name: List downloaded files
         shell: pwsh
         run: |
@@ -1032,6 +1043,9 @@ jobs:
             Write-Host "No DLL found in the downloaded artifact"
             exit 1
           }
+
+          Copy-Item -Path "SDL2.dll" -Destination "bindings\java\build\generated\resources\main\SDL2.dll" -Force
+          Write-Host "Copied SDL2.dll to resources directory"
 
       - name: Build
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -571,9 +571,10 @@ jobs:
         run: copy "$env:SDL2_DIR/../lib/${{ matrix.s2arc }}/SDL2.dll" build/bin/${{ matrix.build }}
 
       - name: Upload SDL2.dll
+        if: matrix.sdl2 == 'ON'
         uses: actions/upload-artifact@v4
         with:
-          name: SDL2-dll
+          name: ${{ matrix.s2arc }}_SDL2.dll
           path: build/bin/${{ matrix.build }}/SDL2.dll
 
       - name: Upload dll
@@ -1023,7 +1024,7 @@ jobs:
       - name: Download SDL2.dll
         uses: actions/download-artifact@v4
         with:
-          name: SDL2-dll
+          name: x64_SDL2.dll
 
       - name: List downloaded files
         shell: pwsh
@@ -1044,8 +1045,8 @@ jobs:
             exit 1
           }
 
-          Copy-Item -Path "SDL2.dll" -Destination "bindings\java\build\generated\resources\main\SDL2.dll" -Force
-          Write-Host "Copied SDL2.dll to resources directory"
+          Copy-Item -Path "x64_SDL2.dll" -Destination "bindings\java\build\generated\resources\main\SDL2.dll" -Force
+          Write-Host "Copied x64_SDL2.dll to resources directory"
 
       - name: Build
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -995,49 +995,48 @@ jobs:
 #          chmod +x ./gradlew
 #          ./gradlew assembleRelease
 
-# TODO: disabled because of following fail: https://github.com/ggerganov/whisper.cpp/actions/runs/9686220096/job/26735899598
-#  java:
-#    needs: [ 'windows' ]
-#    runs-on: windows-latest
-#    steps:
-#      - uses: actions/checkout@v4
-#
-#      - name: Install Java
-#        uses: actions/setup-java@v4
-#        with:
-#          distribution: zulu
-#          java-version: 20
-#
-#      - name: Download Windows lib
-#        uses: actions/download-artifact@v4
-#        with:
-#          name: win32-x86-64_whisper.dll
-#          path: bindings/java/build/generated/resources/main/win32-x86-64
-#
-#      - name: Build
-#        run: |
-#          models\download-ggml-model.cmd tiny.en
-#          cd bindings/java
-#          chmod +x ./gradlew
-#          ./gradlew build
-#
-#      - name: Upload jar
-#        uses: actions/upload-artifact@v4
-#        with:
-#          name: whispercpp.jar
-#          path: bindings/java/build/libs/whispercpp-*.jar
-#
-#      - name: Publish package
-#        if: ${{ github.ref == 'refs/heads/master' }}
-#        uses: gradle/gradle-build-action@v2.4.2
-#        with:
-#          arguments: publish
-#          build-root-directory: bindings/java
-#        env:
-#          MAVEN_USERNAME: ${{ secrets.JIRA_USER }}
-#          MAVEN_PASSWORD: ${{ secrets.JIRA_PASS }}
-#          PGP_SECRET: ${{ secrets.GPG_PRIVATE_KEY }}
-#          PGP_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+  bindings-java:
+    needs: ['windows']
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: 20
+
+      - name: Download Windows lib
+        uses: actions/download-artifact@v4
+        with:
+          name: win32-x86-64_whisper.dll
+          path: bindings/java/build/generated/resources/main/win32-x86-64
+
+      - name: Build
+        run: |
+          models\download-ggml-model.cmd tiny.en
+          cd bindings/java
+          chmod +x ./gradlew
+          ./gradlew build
+
+      - name: Upload jar
+        uses: actions/upload-artifact@v4
+        with:
+          name: whispercpp.jar
+          path: bindings/java/build/libs/whispercpp-*.jar
+
+      - name: Publish package
+        if: ${{ github.ref == 'refs/heads/master' }}
+        uses: gradle/gradle-build-action@v2.4.2
+        with:
+          arguments: publish
+          build-root-directory: bindings/java
+        env:
+          MAVEN_USERNAME: ${{ secrets.JIRA_USER }}
+          MAVEN_PASSWORD: ${{ secrets.JIRA_PASS }}
+          PGP_SECRET: ${{ secrets.GPG_PRIVATE_KEY }}
+          PGP_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
   quantize:
     if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' ||

--- a/bindings/java/build.gradle
+++ b/bindings/java/build.gradle
@@ -42,8 +42,14 @@ tasks.register('copyWhisperDll', Copy) {
     into 'build/generated/resources/main'
 }
 
+tasks.register('copySDL2Dll', Copy) {
+    from '../../build/Release'
+    include 'SDL2.dll'
+    into 'build/generated/resources/main'
+}
+
 tasks.register('copyLibs') {
-    dependsOn copyLibwhisperDynlib, copyLibwhisperSo, copyWhisperDll
+    dependsOn copyLibwhisperDynlib, copyLibwhisperSo, copyWhisperDll, copySDL2Dll
 }
 
 test {

--- a/bindings/java/build.gradle
+++ b/bindings/java/build.gradle
@@ -27,19 +27,19 @@ sourceSets {
 tasks.register('copyLibwhisperDynlib', Copy) {
     from '../../build/src'
     include 'libwhisper.dylib'
-    into 'build/generated/resources/main/darwin'
+    into 'build/generated/resources/main'
 }
 
 tasks.register('copyLibwhisperSo', Copy) {
     from '../../build/src'
     include 'libwhisper.so'
-    into 'build/generated/resources/main/linux-x86-64'
+    into 'build/generated/resources/main'
 }
 
 tasks.register('copyWhisperDll', Copy) {
     from '../../build/Release'
     include 'whisper.dll'
-    into 'build/generated/resources/main/windows-x86-64'
+    into 'build/generated/resources/main'
 }
 
 tasks.register('copyLibs') {

--- a/bindings/java/src/main/java/io/github/ggerganov/whispercpp/WhisperCppJnaLibrary.java
+++ b/bindings/java/src/main/java/io/github/ggerganov/whispercpp/WhisperCppJnaLibrary.java
@@ -8,7 +8,21 @@ import io.github.ggerganov.whispercpp.model.WhisperTokenData;
 import io.github.ggerganov.whispercpp.params.WhisperContextParams;
 import io.github.ggerganov.whispercpp.params.WhisperFullParams;
 
+class JnaDebugHelper {
+    static {
+        System.out.println("JNA Library Path: " + System.getProperty("jna.library.path"));
+        System.out.println("Working directory: " + System.getProperty("user.dir"));
+
+        if (System.getProperty("jna.library.path") != null) {
+            java.io.File libraryFile = new java.io.File(System.getProperty("jna.library.path"), System.mapLibraryName("whisper"));
+            System.out.println("Library file exists: " + libraryFile.exists() + " at " + libraryFile.getAbsolutePath());
+        }
+    }
+}
+
 public interface WhisperCppJnaLibrary extends Library {
+    JnaDebugHelper DEBUG_HELPER = new JnaDebugHelper();
+
     WhisperCppJnaLibrary instance = Native.load("whisper", WhisperCppJnaLibrary.class);
 
     String whisper_print_system_info();

--- a/bindings/java/src/main/java/io/github/ggerganov/whispercpp/WhisperCppJnaLibrary.java
+++ b/bindings/java/src/main/java/io/github/ggerganov/whispercpp/WhisperCppJnaLibrary.java
@@ -10,6 +10,7 @@ import io.github.ggerganov.whispercpp.params.WhisperFullParams;
 
 class JnaDebugHelper {
     static {
+        System.setProperty("jna.debug_load", "true");
         System.out.println("JNA Library Path: " + System.getProperty("jna.library.path"));
         System.out.println("Working directory: " + System.getProperty("user.dir"));
 


### PR DESCRIPTION
This commit re-enables the job previously name `java` which was disabled in the build.yml file.

The motivation for this is that we recently fixed a few issue in the java bindings and it should be possible to build them on windows.

Refs: https://github.com/ggerganov/whisper.cpp/pull/2949
Refs: https://github.com/ggerganov/whisper.cpp/issues/2781