### PR TITLE
ci : add build of wasm examples to CI

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -4,10 +4,18 @@ on:
     paths:
       - examples/addon.node/**
       - whisper.h
+      - examples/command.wasm/**
+      - examples/bench.wasm/**
+      - examples/stream.wasm/**
+      - examples/whisper.wasm/**
   pull_request:
     paths:
       - examples/addon.node/**
       - whisper.h
+      - examples/command.wasm/**
+      - examples/bench.wasm/**
+      - examples/stream.wasm/**
+      - examples/whisper.wasm/**
 
 jobs:
   addon_node-ubuntu-22:
@@ -46,3 +54,22 @@ jobs:
         run: |
           cd examples/addon.node
           npm run test
+
+  wasm-ubuntu-22:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Clone
+        uses: actions/checkout@v1
+
+      - name: Setup emsdk
+        uses: mymindstorm/setup-emsdk@v14
+
+      - name: Verify
+        run: emcc -v
+
+      - name: Build
+        run: |
+          mkdir build-em && cd build-em
+          emcmake cmake ..
+          make -j

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -2,6 +2,8 @@ name: Examples Tests
 on:
   push:
     paths:
+      - src/**
+      - include/**
       - examples/addon.node/**
       - whisper.h
       - examples/command.wasm/**
@@ -10,6 +12,8 @@ on:
       - examples/whisper.wasm/**
   pull_request:
     paths:
+      - src/**
+      - include/**
       - examples/addon.node/**
       - whisper.h
       - examples/command.wasm/**

--- a/examples/command.wasm/README.md
+++ b/examples/command.wasm/README.md
@@ -30,5 +30,3 @@ to the server's HTTP path:
 cp bin/command.wasm/*       /path/to/html/
 cp bin/libcommand.worker.js /path/to/html/
 ```
-
-Remove me!! Just a dummy line to test CI.

--- a/examples/command.wasm/README.md
+++ b/examples/command.wasm/README.md
@@ -30,3 +30,5 @@ to the server's HTTP path:
 cp bin/command.wasm/*       /path/to/html/
 cp bin/libcommand.worker.js /path/to/html/
 ```
+
+Remove me!! Just a dummy line to test CI.


### PR DESCRIPTION
This commit add the building of the wasm examples to CI.

Refs: https://github.com/ggerganov/whisper.cpp/issues/2784