### PR TITLE
feat: add health check endpoint to server

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -1024,6 +1024,11 @@ int main(int argc, char ** argv) {
         // check if the model is in the file system
     });
 
+    svr.Get(sparams.request_path + "/health", [&](const Request &, Response &res){
+        const std::string health_response = "{\"status\":\"ok\"}";
+        res.set_content(health_response, "application/json");
+    });
+
     svr.set_exception_handler([](const Request &, Response &res, std::exception_ptr ep) {
         const char fmt[] = "500 Internal Server Error\n%s";
         char buf[BUFSIZ];


### PR DESCRIPTION
# Add health check endpoint

This PR adds a simple health check endpoint that responds to GET requests at `{request_path}/health` and returns a JSON response with `{"status":"ok"}`.

## Purpose
- Allows monitoring tools, load balancers, and container orchestration systems to verify the service is running
- Provides a lightweight endpoint for uptime checks
- Helps with system integration in containerized environments

## Implementation
- Uses existing request path configuration
- Returns appropriate content type header
- Simple JSON response for easy parsing
