### PR TITLE
examples : update README links to point to pages deployment

### DIFF
--- a/examples/bench.wasm/README.md
+++ b/examples/bench.wasm/README.md
@@ -2,7 +2,7 @@
 
 Benchmark the performance of whisper.cpp in the browser using WebAssembly
 
-Link: https://whisper.ggerganov.com/bench/
+Link: https://ggerganov.github.io/whisper.cpp/bench.wasm
 
 Terminal version: [examples/bench](/examples/bench)
 

--- a/examples/command.wasm/README.md
+++ b/examples/command.wasm/README.md
@@ -3,7 +3,7 @@
 This is a basic Voice Assistant example that accepts voice commands from the microphone.
 It runs in fully in the browser via WebAseembly.
 
-Online demo: https://whisper.ggerganov.com/command/
+Online demo: https://ggerganov.github.io/whisper.cpp/command.wasm
 
 Terminal version: [examples/command](/examples/command)
 

--- a/examples/whisper.wasm/README.md
+++ b/examples/whisper.wasm/README.md
@@ -22,7 +22,7 @@ audio is limited to 120 seconds.
 
 ## Live demo
 
-Link: https://whisper.ggerganov.com
+Link: https://ggerganov.github.io/whisper.cpp/
 
 ![image](https://user-images.githubusercontent.com/1991296/197348344-1a7fead8-3dae-4922-8b06-df223a206603.png)
 


### PR DESCRIPTION
This commit updates the README links to point to the pages deployment instead of whisper.ggerganov.com.