### PR TITLE
android.java : re-add ggml source updates

### DIFF
--- a/examples/whisper.android.java/app/src/main/jni/whisper/CMakeLists.txt
+++ b/examples/whisper.android.java/app/src/main/jni/whisper/CMakeLists.txt
@@ -12,6 +12,8 @@ set(SOURCE_FILES
     ${WHISPER_LIB_DIR}/ggml/src/ggml-cpu/ggml-cpu-traits.cpp
     ${WHISPER_LIB_DIR}/ggml/src/ggml-cpu/ggml-cpu-quants.c
     ${WHISPER_LIB_DIR}/ggml/src/ggml-cpu/ggml-cpu.cpp
+    ${WHISPER_LIB_DIR}/ggml/src/ggml-cpu/unary-ops.cpp
+    ${WHISPER_LIB_DIR}/ggml/src/ggml-cpu/binary-ops.cpp
     ${WHISPER_LIB_DIR}/ggml/src/ggml-alloc.c
     ${WHISPER_LIB_DIR}/ggml/src/ggml-backend.cpp
     ${WHISPER_LIB_DIR}/ggml/src/ggml-backend-reg.cpp


### PR DESCRIPTION
This commit updates the ggml source to include the new unary and binary operations. I merged https://github.com/ggerganov/whisper.cpp/pull/2958 which seems to have overwritten the changes to the ggml source which were added in https://github.com/ggerganov/whisper.cpp/pull/2972.

Sorry about this.