### PR TITLE
tests : re-enable tests [no ci]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,8 +190,8 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/whisper.pc"
 #
 
 if (WHISPER_BUILD_TESTS AND NOT CMAKE_JS_VERSION)
-    #include(CTest)
-    #add_subdirectory(tests)
+    include(CTest)
+    add_subdirectory(tests)
 endif ()
 
 if (WHISPER_BUILD_EXAMPLES)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,74 +12,74 @@ if (EMSCRIPTEN)
     return()
 endif()
 
-set(TEST_TARGET test-main-tiny)
+set(TEST_TARGET test-whisper-cli-tiny)
 add_test(NAME ${TEST_TARGET}
-    COMMAND $<TARGET_FILE:main>
+    COMMAND $<TARGET_FILE:whisper-cli>
     -m ${PROJECT_SOURCE_DIR}/models/for-tests-ggml-tiny.bin -l fr
     -f ${PROJECT_SOURCE_DIR}/samples/jfk.wav)
 set_tests_properties(${TEST_TARGET} PROPERTIES LABELS "tiny;gh")
 
-set(TEST_TARGET test-main-tiny.en)
+set(TEST_TARGET test-whisper-cli-tiny.en)
 add_test(NAME ${TEST_TARGET}
-    COMMAND $<TARGET_FILE:main>
+    COMMAND $<TARGET_FILE:whisper-cli>
     -m ${PROJECT_SOURCE_DIR}/models/for-tests-ggml-tiny.en.bin
     -f ${PROJECT_SOURCE_DIR}/samples/jfk.wav)
 set_tests_properties(${TEST_TARGET} PROPERTIES LABELS "tiny;en;gh")
 
-set(TEST_TARGET test-main-base)
+set(TEST_TARGET test-whisper-cli-base)
 add_test(NAME ${TEST_TARGET}
-    COMMAND $<TARGET_FILE:main>
+    COMMAND $<TARGET_FILE:whisper-cli>
     -m ${PROJECT_SOURCE_DIR}/models/for-tests-ggml-base.bin -l fr
     -f ${PROJECT_SOURCE_DIR}/samples/jfk.wav)
 set_tests_properties(${TEST_TARGET} PROPERTIES LABELS "base")
 
-set(TEST_TARGET test-main-base.en)
+set(TEST_TARGET test-whisper-cli-base.en)
 add_test(NAME ${TEST_TARGET}
-    COMMAND $<TARGET_FILE:main>
+    COMMAND $<TARGET_FILE:whisper-cli>
     -m ${PROJECT_SOURCE_DIR}/models/for-tests-ggml-base.en.bin
     -f ${PROJECT_SOURCE_DIR}/samples/jfk.wav)
 set_tests_properties(${TEST_TARGET} PROPERTIES LABELS "base;en")
 
-set(TEST_TARGET test-main-small)
+set(TEST_TARGET test-whisper-cli-small)
 add_test(NAME ${TEST_TARGET}
-    COMMAND $<TARGET_FILE:main>
+    COMMAND $<TARGET_FILE:whisper-cli>
     -m ${PROJECT_SOURCE_DIR}/models/for-tests-ggml-small.bin -l fr
     -f ${PROJECT_SOURCE_DIR}/samples/jfk.wav)
 set_tests_properties(${TEST_TARGET} PROPERTIES LABELS "small")
 
-set(TEST_TARGET test-main-small.en)
+set(TEST_TARGET test-whisper-cli-small.en)
 add_test(NAME ${TEST_TARGET}
-    COMMAND $<TARGET_FILE:main>
+    COMMAND $<TARGET_FILE:whisper-cli>
     -m ${PROJECT_SOURCE_DIR}/models/for-tests-ggml-small.en.bin
     -f ${PROJECT_SOURCE_DIR}/samples/jfk.wav)
 set_tests_properties(${TEST_TARGET} PROPERTIES LABELS "small;en")
 
-set(TEST_TARGET test-main-medium)
+set(TEST_TARGET test-whisper-cli-medium)
 add_test(NAME ${TEST_TARGET}
-    COMMAND $<TARGET_FILE:main>
+    COMMAND $<TARGET_FILE:whisper-cli>
     -m ${PROJECT_SOURCE_DIR}/models/for-tests-ggml-medium.bin -l fr
     -f ${PROJECT_SOURCE_DIR}/samples/jfk.wav)
 set_tests_properties(${TEST_TARGET} PROPERTIES LABELS "medium")
 
-set(TEST_TARGET test-main-medium.en)
+set(TEST_TARGET test-whisper-cli-medium.en)
 add_test(NAME ${TEST_TARGET}
-    COMMAND $<TARGET_FILE:main>
+    COMMAND $<TARGET_FILE:whisper-cli>
     -m ${PROJECT_SOURCE_DIR}/models/for-tests-ggml-medium.en.bin
     -f ${PROJECT_SOURCE_DIR}/samples/jfk.wav)
 set_tests_properties(${TEST_TARGET} PROPERTIES LABELS "medium;en")
 
-set(TEST_TARGET test-main-large)
+set(TEST_TARGET test-whisper-cli-large)
 add_test(NAME ${TEST_TARGET}
-    COMMAND $<TARGET_FILE:main>
+    COMMAND $<TARGET_FILE:whisper-cli>
     -m ${PROJECT_SOURCE_DIR}/models/for-tests-ggml-large.bin
     -f ${PROJECT_SOURCE_DIR}/samples/jfk.wav)
 set_tests_properties(${TEST_TARGET} PROPERTIES LABELS "large")
 
 if (WHISPER_FFMPEG)
-    set(TEST_TARGET test-main-tiny-mp3)
+    set(TEST_TARGET test-whisper-cli-tiny-mp3)
     # Check with reviewers: any way to check the output transcription via ctest (diff, ...)?
     add_test(NAME ${TEST_TARGET}
-      COMMAND $<TARGET_FILE:main>
+      COMMAND $<TARGET_FILE:whisper-cli>
       -m ${PROJECT_SOURCE_DIR}/models/for-tests-ggml-tiny.en.bin
       -f ${PROJECT_SOURCE_DIR}/samples/jfk.mp3)
     set_tests_properties(${TEST_TARGET} PROPERTIES LABELS "tiny;mp3")


### PR DESCRIPTION
This commit re-enables the tests in the build process which are currently commented out.

It is possible to build the tests using `-DWHISPER_BUILD_TESTS=ON` and then run a single test using:
```console
$ ctest -R test-whisper-cli-tiny.en --test-dir build
Internal ctest changing into directory: /home/danbev/work/ai/whisper-work/build
Test project /home/danbev/work/ai/whisper-work/build
    Start 2: test-whisper-cli-tiny.en
1/1 Test #2: test-whisper-cli-tiny.en .........   Passed    4.44 sec

100% tests passed, 0 tests failed out of 1

Label Time Summary:
en      =   4.44 sec*proc (1 test)
gh      =   4.44 sec*proc (1 test)
tiny    =   4.44 sec*proc (1 test)

Total Test time (real) =   4.44 sec
```

Some of the tests take a long time to run so it might not be a good idea to enable them in CI, or perhaps we could only run a subset of the tests in CI.