### PR TITLE
ci : add coreml job that converts base.en to coreml [no ci]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1064,7 +1064,6 @@ jobs:
     needs:
       - determine-tag
       - ios-xcode-build
-      - coreml-base-en
 
     steps:
       - name: Clone
@@ -1148,14 +1147,3 @@ jobs:
           source venv/bin/activate
           pip install ane_transformers openai-whisper coremltools
           ./models/generate-coreml-model.sh ${{ env.MODEL_NAME }}
-
-      - name: Pack CoreML model
-        id: pack_artifacts
-        run: |
-          zip --symlinks -r ${{ env.GEN_MODEL_NAME }}.zip models/ggml-${{env.MODEL_NAME}}-encoder.mlmodelc
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          path: ${{ env.GEN_MODEL_NAME }}.zip
-          name: ${{ env.GEN_MODEL_NAME }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -367,7 +367,9 @@ jobs:
             set -e
             apt update
             apt install -y build-essential cmake git
-            cmake . -DCMAKE_BUILD_TYPE=Debug -DWHISPER_SANITIZE_${{ matrix.sanitizer }}=ON
+            cmake . -DCMAKE_BUILD_TYPE=Debug \
+              -DWHISPER_SANITIZE_${{ matrix.sanitizer }}=ON \
+              -DGGML_OPENMP=OFF
             make
             ctest -L gh --output-on-failure'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1064,6 +1064,7 @@ jobs:
     needs:
       - determine-tag
       - ios-xcode-build
+      - coreml-base-en
 
     steps:
       - name: Clone
@@ -1119,3 +1120,42 @@ jobs:
                 });
               }
             }
+
+  coreml-base-en:
+    if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/master') ||
+            github.event.inputs.create_release == 'true' ||
+            github.event.inputs.pre_release_tag != '' }}
+    runs-on: macos-latest
+    needs: determine-tag
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set environment variables
+        id: set_vars
+        run: |
+          echo "MODEL_NAME=base.en" >> $GITHUB_ENV
+          echo "GEN_MODEL_NAME=whisper-${{ needs.determine-tag.outputs.tag_name }}-ggml-base.en-encoder.mlmodelc" >> $GITHUB_ENV
+
+      - name: Download model
+        run: |
+          ./models/download-ggml-model.sh ${{ env.MODEL_NAME }}
+
+      - name: Generate CoreML model
+        run: |
+          python3.11 -m venv venv
+          source venv/bin/activate
+          pip install ane_transformers openai-whisper coremltools
+          ./models/generate-coreml-model.sh ${{ env.MODEL_NAME }}
+
+      - name: Pack CoreML model
+        id: pack_artifacts
+        run: |
+          zip --symlinks -r ${{ env.GEN_MODEL_NAME }}.zip models/ggml-${{env.MODEL_NAME}}-encoder.mlmodelc
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          path: ${{ env.GEN_MODEL_NAME }}.zip
+          name: ${{ env.GEN_MODEL_NAME }}


### PR DESCRIPTION
This commit adds a new job to the CI pipeline that downloads the base.en model and converts it to CoreML format. The CoreML model is then packed into a zip file and uploaded as an artifact.

This will only be done for pushes to master, releases, or pre-releases.

Refs: https://github.com/ggerganov/whisper.cpp/issues/2783

----
I've run this on my fork and it produces the following release:
https://github.com/danbev/whisper.cpp/releases/tag/b2368

I've only included one model but this will exercise the model conversion scripts and should give early feedback if anything breaks. We could also add more models to be published too. 