### PR TITLE
tests : remove gh label test-whisper-cli-tiny-en

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,7 +24,7 @@ add_test(NAME ${TEST_TARGET}
     COMMAND $<TARGET_FILE:whisper-cli>
     -m ${PROJECT_SOURCE_DIR}/models/for-tests-ggml-tiny.en.bin
     -f ${PROJECT_SOURCE_DIR}/samples/jfk.wav)
-set_tests_properties(${TEST_TARGET} PROPERTIES LABELS "tiny;en;gh")
+set_tests_properties(${TEST_TARGET} PROPERTIES LABELS "tiny;en")
 
 set(TEST_TARGET test-whisper-cli-base)
 add_test(NAME ${TEST_TARGET}


### PR DESCRIPTION
This commit removes `test-whisper-cli-tiny-en` from the `gh` label.

The motivation for this change is that until recently the tests were disabled. But now that they are enabled some of the tests, specifically the ci jobs that use sanatizers (e.g. thread-sanitizer) take a long time to run as they are instrumented.
Some of these jobs also have matrices which means that there are multiple jobs are created that all run these tests. The suggestion here is to limit the number of tests that are run in the ci jobs so cut down the CI build time.