### PR TITLE
bench : update numbers [no ci]

### DIFF
--- a/scripts/bench-all-gg.txt
+++ b/scripts/bench-all-gg.txt
@@ -1,4 +1,4 @@
-## M1 Pro
+## M1 Pro (old 22c96b4)
 
 make -j && ./scripts/bench-all.sh 8
 
@@ -67,202 +67,184 @@ make -j && ./scripts/bench-all.sh 8
 
 Running memcpy benchmark
 
-memcpy:   46.58 GB/s (heat-up)
-memcpy:   54.16 GB/s ( 1 thread)
-memcpy:   54.23 GB/s ( 1 thread)
-memcpy:   99.63 GB/s ( 2 thread)
-memcpy:  140.59 GB/s ( 3 thread)
-memcpy:  176.52 GB/s ( 4 thread)
-memcpy:  158.90 GB/s ( 5 thread)
-memcpy:  163.00 GB/s ( 6 thread)
-memcpy:  189.69 GB/s ( 7 thread)
-memcpy:  197.15 GB/s ( 8 thread)
-sum:    -5120002007.000000
+memcpy:   48.01 GB/s (heat-up)
+memcpy:   56.00 GB/s ( 1 thread)
+memcpy:   56.20 GB/s ( 1 thread)
+memcpy:  102.69 GB/s ( 2 thread)
+memcpy:  140.32 GB/s ( 3 thread)
+memcpy:  179.04 GB/s ( 4 thread)
+memcpy:  159.61 GB/s ( 5 thread)
+memcpy:  159.02 GB/s ( 6 thread)
+memcpy:  180.29 GB/s ( 7 thread)
+memcpy:  198.10 GB/s ( 8 thread)
+sum:    -5119999345.000000
 
 
 make -j && ./scripts/bench-all.sh 1
 
 Running ggml_mul_mat benchmark with 1 threads
 
-  64 x   64: Q4_0   245.8 GFLOPS (128 runs) | Q4_1   168.6 GFLOPS (128 runs)
-  64 x   64: Q5_0   115.7 GFLOPS (128 runs) | Q5_1   125.9 GFLOPS (128 runs) | Q8_0   215.8 GFLOPS (128 runs)
-  64 x   64: F16    139.5 GFLOPS (128 runs) | F32    337.2 GFLOPS (128 runs)
- 128 x  128: Q4_0   494.8 GFLOPS (128 runs) | Q4_1   350.4 GFLOPS (128 runs)
- 128 x  128: Q5_0   257.1 GFLOPS (128 runs) | Q5_1   261.4 GFLOPS (128 runs) | Q8_0   509.4 GFLOPS (128 runs)
- 128 x  128: F16    302.3 GFLOPS (128 runs) | F32    672.8 GFLOPS (128 runs)
- 256 x  256: Q4_0   795.7 GFLOPS (128 runs) | Q4_1   663.7 GFLOPS (128 runs)
- 256 x  256: Q5_0   737.8 GFLOPS (128 runs) | Q5_1   757.6 GFLOPS (128 runs) | Q8_0   827.7 GFLOPS (128 runs)
- 256 x  256: F16    872.6 GFLOPS (128 runs) | F32    956.3 GFLOPS (128 runs)
- 512 x  512: Q4_0  1188.0 GFLOPS (128 runs) | Q4_1  1085.0 GFLOPS (128 runs)
- 512 x  512: Q5_0  1421.1 GFLOPS (128 runs) | Q5_1  1454.9 GFLOPS (128 runs) | Q8_0  1191.4 GFLOPS (128 runs)
- 512 x  512: F16   1577.4 GFLOPS (128 runs) | F32   1982.0 GFLOPS (128 runs)
-1024 x 1024: Q4_0  2342.6 GFLOPS (128 runs) | Q4_1  1955.8 GFLOPS (128 runs)
-1024 x 1024: Q5_0  2306.7 GFLOPS (128 runs) | Q5_1  2217.0 GFLOPS (128 runs) | Q8_0  2230.7 GFLOPS (128 runs)
-1024 x 1024: F16   2593.8 GFLOPS (128 runs) | F32   3269.0 GFLOPS (128 runs)
-2048 x 2048: Q4_0  3735.7 GFLOPS (128 runs) | Q4_1  3205.3 GFLOPS (128 runs)
-2048 x 2048: Q5_0  3584.5 GFLOPS (128 runs) | Q5_1  3621.7 GFLOPS (128 runs) | Q8_0  3622.3 GFLOPS (128 runs)
-2048 x 2048: F16   3763.6 GFLOPS (128 runs) | F32   4153.3 GFLOPS (128 runs)
-4096 x 4096: Q4_0  3891.1 GFLOPS ( 29 runs) | Q4_1  3554.0 GFLOPS ( 26 runs)
-4096 x 4096: Q5_0  3753.1 GFLOPS ( 28 runs) | Q5_1  3750.1 GFLOPS ( 28 runs) | Q8_0  3768.5 GFLOPS ( 28 runs)
-4096 x 4096: F16   3864.2 GFLOPS ( 29 runs) | F32   3970.5 GFLOPS ( 29 runs)
+  64 x   64: Q4_0    37.7 GFLOPS (128 runs) | Q4_1    36.0 GFLOPS (128 runs)
+  64 x   64: Q5_0    20.1 GFLOPS (128 runs) | Q5_1    19.8 GFLOPS (128 runs) | Q8_0    39.5 GFLOPS (128 runs)
+  64 x   64: F16     29.9 GFLOPS (128 runs) | F32     22.6 GFLOPS (128 runs)
+ 128 x  128: Q4_0    71.0 GFLOPS (128 runs) | Q4_1    62.2 GFLOPS (128 runs)
+ 128 x  128: Q5_0    33.4 GFLOPS (128 runs) | Q5_1    31.6 GFLOPS (128 runs) | Q8_0    79.8 GFLOPS (128 runs)
+ 128 x  128: F16     52.4 GFLOPS (128 runs) | F32     32.7 GFLOPS (128 runs)
+ 256 x  256: Q4_0    88.6 GFLOPS (128 runs) | Q4_1    77.2 GFLOPS (128 runs)
+ 256 x  256: Q5_0    40.3 GFLOPS (128 runs) | Q5_1    36.8 GFLOPS (128 runs) | Q8_0   102.5 GFLOPS (128 runs)
+ 256 x  256: F16     64.6 GFLOPS (128 runs) | F32     36.4 GFLOPS (128 runs)
+ 512 x  512: Q4_0    94.7 GFLOPS (128 runs) | Q4_1    83.6 GFLOPS (128 runs)
+ 512 x  512: Q5_0    45.9 GFLOPS (128 runs) | Q5_1    41.3 GFLOPS (128 runs) | Q8_0   112.8 GFLOPS (128 runs)
+ 512 x  512: F16     72.3 GFLOPS (128 runs) | F32     37.7 GFLOPS (128 runs)
+1024 x 1024: Q4_0    98.9 GFLOPS ( 47 runs) | Q4_1    88.2 GFLOPS ( 42 runs)
+1024 x 1024: Q5_0    49.0 GFLOPS ( 23 runs) | Q5_1    43.9 GFLOPS ( 21 runs) | Q8_0   121.0 GFLOPS ( 57 runs)
+1024 x 1024: F16     72.6 GFLOPS ( 34 runs) | F32     36.0 GFLOPS ( 17 runs)
+2048 x 2048: Q4_0   101.3 GFLOPS (  6 runs) | Q4_1    90.0 GFLOPS (  6 runs)
+2048 x 2048: Q5_0    50.8 GFLOPS (  3 runs) | Q5_1    45.3 GFLOPS (  3 runs) | Q8_0   124.1 GFLOPS (  8 runs)
+2048 x 2048: F16     70.7 GFLOPS (  5 runs) | F32     30.4 GFLOPS (  3 runs)
+4096 x 4096: Q4_0   101.7 GFLOPS (  3 runs) | Q4_1    90.3 GFLOPS (  3 runs)
+4096 x 4096: Q5_0    52.2 GFLOPS (  3 runs) | Q5_1    45.7 GFLOPS (  3 runs) | Q8_0   123.0 GFLOPS (  3 runs)
+4096 x 4096: F16     60.3 GFLOPS (  3 runs) | F32     29.8 GFLOPS (  3 runs)
 
 
 make -j && ./scripts/bench-all.sh 1 1 0
 
 |      CPU | Config |         Model |  Th |  FA |    Enc. |    Dec. |    Bch5 |      PP |  Commit |
 |      --- |    --- |           --- | --- | --- |     --- |     --- |     --- |     --- |     --- |
-| M2 ULTRA |  METAL |          tiny |   1 |   0 |   12.32 |    1.35 |    0.49 |    0.01 | 22c96b4 |
-| M2 ULTRA |  METAL |     tiny-q5_0 |   1 |   0 |   11.65 |    1.30 |    0.51 |    0.01 | 22c96b4 |
-| M2 ULTRA |  METAL |     tiny-q5_1 |   1 |   0 |   12.08 |    1.30 |    0.51 |    0.01 | 22c96b4 |
-| M2 ULTRA |  METAL |          base |   1 |   0 |   17.58 |    1.90 |    0.76 |    0.02 | 22c96b4 |
-| M2 ULTRA |  METAL |     base-q5_0 |   1 |   0 |   18.89 |    1.86 |    0.79 |    0.02 | 22c96b4 |
-| M2 ULTRA |  METAL |     base-q5_1 |   1 |   0 |   20.69 |    1.88 |    0.79 |    0.02 | 22c96b4 |
-| M2 ULTRA |  METAL |         small |   1 |   0 |   49.32 |    3.85 |    1.71 |    0.05 | 22c96b4 |
-| M2 ULTRA |  METAL |    small-q5_0 |   1 |   0 |   54.91 |    3.81 |    1.82 |    0.06 | 22c96b4 |
-| M2 ULTRA |  METAL |    small-q5_1 |   1 |   0 |   54.92 |    3.81 |    1.79 |    0.06 | 22c96b4 |
-| M2 ULTRA |  METAL |        medium |   1 |   0 |  134.34 |    8.04 |    3.82 |    0.13 | 22c96b4 |
-| M2 ULTRA |  METAL |   medium-q5_0 |   1 |   0 |  151.68 |    7.59 |    4.07 |    0.14 | 22c96b4 |
-| M2 ULTRA |  METAL |   medium-q5_1 |   1 |   0 |  151.58 |    7.67 |    4.07 |    0.14 | 22c96b4 |
-| M2 ULTRA |  METAL |    medium-dis |   1 |   0 |  120.82 |    1.07 |    0.41 |    0.02 | 22c96b4 |
-| M2 ULTRA |  METAL |      large-v2 |   1 |   0 |  235.63 |   12.27 |    5.85 |    0.22 | 22c96b4 |
-| M2 ULTRA |  METAL | large-v2-q5_0 |   1 |   0 |  273.38 |   11.17 |    6.40 |    0.26 | 22c96b4 |
-| M2 ULTRA |  METAL | large-v2-q5_1 |   1 |   0 |  272.44 |   11.32 |    6.29 |    0.26 | 22c96b4 |
-| M2 ULTRA |  METAL |  large-v2-dis |   1 |   0 |  212.51 |    1.20 |    0.47 |    0.02 | 22c96b4 |
+| M2 ULTRA |  METAL |          tiny |   1 |   0 |    8.74 |    1.20 |    0.36 |    0.01 | ad4e350 |
+| M2 ULTRA |  METAL |     tiny-q5_0 |   1 |   0 |   10.30 |    1.15 |    0.38 |    0.01 | ad4e350 |
+| M2 ULTRA |  METAL |     tiny-q5_1 |   1 |   0 |   10.71 |    1.13 |    0.38 |    0.01 | ad4e350 |
+| M2 ULTRA |  METAL |     tiny-q8_0 |   1 |   0 |    9.97 |    1.12 |    0.37 |    0.01 | ad4e350 |
+| M2 ULTRA |  METAL |          base |   1 |   0 |   16.77 |    1.71 |    0.44 |    0.02 | ad4e350 |
+| M2 ULTRA |  METAL |     base-q5_0 |   1 |   0 |   16.92 |    1.63 |    0.44 |    0.02 | ad4e350 |
+| M2 ULTRA |  METAL |     base-q5_1 |   1 |   0 |   16.84 |    1.63 |    0.44 |    0.02 | ad4e350 |
+| M2 ULTRA |  METAL |     base-q8_0 |   1 |   0 |   16.12 |    1.63 |    0.44 |    0.02 | ad4e350 |
+| M2 ULTRA |  METAL |         small |   1 |   0 |   45.29 |    3.44 |    0.92 |    0.05 | ad4e350 |
+| M2 ULTRA |  METAL |    small-q5_0 |   1 |   0 |   50.43 |    3.34 |    0.94 |    0.06 | ad4e350 |
+| M2 ULTRA |  METAL |    small-q5_1 |   1 |   0 |   50.49 |    3.35 |    0.93 |    0.06 | ad4e350 |
+| M2 ULTRA |  METAL |    small-q8_0 |   1 |   0 |   47.37 |    3.20 |    0.91 |    0.05 | ad4e350 |
+| M2 ULTRA |  METAL |        medium |   1 |   0 |  122.81 |    7.39 |    1.99 |    0.12 | ad4e350 |
+| M2 ULTRA |  METAL |   medium-q5_0 |   1 |   0 |  140.62 |    6.73 |    2.03 |    0.14 | ad4e350 |
+| M2 ULTRA |  METAL |   medium-q5_1 |   1 |   0 |  140.44 |    6.74 |    2.04 |    0.14 | ad4e350 |
+| M2 ULTRA |  METAL |   medium-q8_0 |   1 |   0 |  131.05 |    6.54 |    1.95 |    0.13 | ad4e350 |
+| M2 ULTRA |  METAL |    medium-dis |   1 |   0 |  110.95 |    0.99 |    0.24 |    0.02 | ad4e350 |
+| M2 ULTRA |  METAL |      large-v2 |   1 |   0 |  222.19 |   10.93 |    3.01 |    0.21 | ad4e350 |
+| M2 ULTRA |  METAL | large-v2-q5_0 |   1 |   0 |  258.47 |    9.75 |    3.01 |    0.25 | ad4e350 |
+| M2 ULTRA |  METAL | large-v2-q5_1 |   1 |   0 |  258.40 |    9.85 |    3.01 |    0.24 | ad4e350 |
+| M2 ULTRA |  METAL | large-v2-q8_0 |   1 |   0 |  236.68 |    9.61 |    2.85 |    0.23 | ad4e350 |
+| M2 ULTRA |  METAL |  large-v2-dis |   1 |   0 |  199.28 |    1.12 |    0.27 |    0.02 | ad4e350 |
+| M2 ULTRA |  METAL | large-v3-turbo |   1 |   0 |  201.49 |    1.76 |    0.45 |    0.03 | ad4e350 |
+| M2 ULTRA |  METAL | large-v3-turbo-q5_0 |   1 |   0 |  233.70 |    1.55 |    0.46 |    0.04 | ad4e350 |
+| M2 ULTRA |  METAL | large-v3-turbo-q8_0 |   1 |   0 |  214.20 |    1.51 |    0.44 |    0.04 | ad4e350 |
 
 
 make -j && ./scripts/bench-all.sh 1 1 1
 
 |      CPU | Config |         Model |  Th |  FA |    Enc. |    Dec. |    Bch5 |      PP |  Commit |
 |      --- |    --- |           --- | --- | --- |     --- |     --- |     --- |     --- |     --- |
-| M2 ULTRA |  METAL |          tiny |   1 |   1 |    9.07 |    1.33 |    0.45 |    0.01 | 22c96b4 |
-| M2 ULTRA |  METAL |     tiny-q5_0 |   1 |   1 |    9.74 |    1.33 |    0.47 |    0.01 | 22c96b4 |
-| M2 ULTRA |  METAL |     tiny-q5_1 |   1 |   1 |    8.93 |    1.31 |    0.46 |    0.01 | 22c96b4 |
-| M2 ULTRA |  METAL |          base |   1 |   1 |   15.75 |    1.87 |    0.71 |    0.02 | 22c96b4 |
-| M2 ULTRA |  METAL |     base-q5_0 |   1 |   1 |   17.04 |    1.83 |    0.74 |    0.02 | 22c96b4 |
-| M2 ULTRA |  METAL |     base-q5_1 |   1 |   1 |   17.17 |    1.83 |    0.74 |    0.02 | 22c96b4 |
-| M2 ULTRA |  METAL |         small |   1 |   1 |   42.33 |    3.64 |    1.60 |    0.05 | 22c96b4 |
-| M2 ULTRA |  METAL |    small-q5_0 |   1 |   1 |   47.61 |    3.63 |    1.70 |    0.05 | 22c96b4 |
-| M2 ULTRA |  METAL |    small-q5_1 |   1 |   1 |   47.70 |    3.66 |    1.68 |    0.05 | 22c96b4 |
-| M2 ULTRA |  METAL |        medium |   1 |   1 |  114.42 |    7.53 |    3.55 |    0.11 | 22c96b4 |
-| M2 ULTRA |  METAL |   medium-q5_0 |   1 |   1 |  132.63 |    7.02 |    3.77 |    0.13 | 22c96b4 |
-| M2 ULTRA |  METAL |   medium-q5_1 |   1 |   1 |  132.28 |    7.10 |    3.76 |    0.13 | 22c96b4 |
-| M2 ULTRA |  METAL |    medium-dis |   1 |   1 |  102.34 |    1.01 |    0.42 |    0.01 | 22c96b4 |
-| M2 ULTRA |  METAL |      large-v2 |   1 |   1 |  203.01 |   11.03 |    5.45 |    0.20 | 22c96b4 |
-| M2 ULTRA |  METAL | large-v2-q5_0 |   1 |   1 |  240.05 |   10.18 |    5.98 |    0.23 | 22c96b4 |
-| M2 ULTRA |  METAL | large-v2-q5_1 |   1 |   1 |  239.22 |   10.23 |    5.87 |    0.23 | 22c96b4 |
-| M2 ULTRA |  METAL |  large-v2-dis |   1 |   1 |  181.14 |    1.14 |    0.48 |    0.02 | 22c96b4 |
+| M2 ULTRA |  METAL |          tiny |   1 |   1 |    7.82 |    1.31 |    0.35 |    0.01 | ad4e350 |
+| M2 ULTRA |  METAL |     tiny-q5_0 |   1 |   1 |    8.32 |    1.28 |    0.37 |    0.01 | ad4e350 |
+| M2 ULTRA |  METAL |     tiny-q5_1 |   1 |   1 |    8.21 |    1.28 |    0.37 |    0.01 | ad4e350 |
+| M2 ULTRA |  METAL |     tiny-q8_0 |   1 |   1 |    7.97 |    1.23 |    0.36 |    0.01 | ad4e350 |
+| M2 ULTRA |  METAL |          base |   1 |   1 |   13.96 |    1.80 |    0.42 |    0.02 | ad4e350 |
+| M2 ULTRA |  METAL |     base-q5_0 |   1 |   1 |   15.19 |    1.75 |    0.42 |    0.02 | ad4e350 |
+| M2 ULTRA |  METAL |     base-q5_1 |   1 |   1 |   15.09 |    1.75 |    0.42 |    0.02 | ad4e350 |
+| M2 ULTRA |  METAL |     base-q8_0 |   1 |   1 |   14.45 |    1.70 |    0.41 |    0.02 | ad4e350 |
+| M2 ULTRA |  METAL |         small |   1 |   1 |   40.08 |    3.54 |    0.86 |    0.05 | ad4e350 |
+| M2 ULTRA |  METAL |    small-q5_0 |   1 |   1 |   45.07 |    3.51 |    0.88 |    0.05 | ad4e350 |
+| M2 ULTRA |  METAL |    small-q5_1 |   1 |   1 |   45.05 |    3.52 |    0.88 |    0.05 | ad4e350 |
+| M2 ULTRA |  METAL |    small-q8_0 |   1 |   1 |   42.04 |    3.34 |    0.85 |    0.05 | ad4e350 |
+| M2 ULTRA |  METAL |        medium |   1 |   1 |  107.20 |    7.28 |    1.79 |    0.11 | ad4e350 |
+| M2 ULTRA |  METAL |   medium-q5_0 |   1 |   1 |  125.02 |    6.67 |    1.83 |    0.12 | ad4e350 |
+| M2 ULTRA |  METAL |   medium-q5_1 |   1 |   1 |  124.83 |    6.70 |    1.84 |    0.12 | ad4e350 |
+| M2 ULTRA |  METAL |   medium-q8_0 |   1 |   1 |  114.56 |    6.53 |    1.79 |    0.11 | ad4e350 |
+| M2 ULTRA |  METAL |    medium-dis |   1 |   1 |   95.96 |    1.01 |    0.23 |    0.01 | ad4e350 |
+| M2 ULTRA |  METAL |      large-v2 |   1 |   1 |  194.29 |   10.57 |    2.67 |    0.20 | ad4e350 |
+| M2 ULTRA |  METAL | large-v2-q5_0 |   1 |   1 |  230.74 |    9.57 |    2.73 |    0.23 | ad4e350 |
+| M2 ULTRA |  METAL | large-v2-q5_1 |   1 |   1 |  229.97 |    9.69 |    2.74 |    0.23 | ad4e350 |
+| M2 ULTRA |  METAL | large-v2-q8_0 |   1 |   1 |  208.11 |    9.37 |    2.60 |    0.21 | ad4e350 |
+| M2 ULTRA |  METAL |  large-v2-dis |   1 |   1 |  172.72 |    1.12 |    0.26 |    0.02 | ad4e350 |
+| M2 ULTRA |  METAL | large-v3-turbo |   1 |   1 |  174.46 |    1.74 |    0.42 |    0.03 | ad4e350 |
+| M2 ULTRA |  METAL | large-v3-turbo-q5_0 |   1 |   1 |  205.78 |    1.54 |    0.42 |    0.04 | ad4e350 |
+| M2 ULTRA |  METAL | large-v3-turbo-q8_0 |   1 |   1 |  186.33 |    1.50 |    0.40 |    0.03 | ad4e350 |
 
 
+## M4 Max
 
-## Ryzen 9 5950X + RTX 2060
-
-make -j && ./scripts/bench-all.sh 8 0 0
+make -j && ./scripts/bench-all.sh 8
 
 Running memcpy benchmark
 
-memcpy:   12.36 GB/s (heat-up)
-memcpy:   12.33 GB/s ( 1 thread)
-memcpy:   12.38 GB/s ( 1 thread)
-memcpy:   14.48 GB/s ( 2 thread)
-memcpy:   15.00 GB/s ( 3 thread)
-memcpy:   14.77 GB/s ( 4 thread)
-memcpy:   14.60 GB/s ( 5 thread)
-memcpy:   14.57 GB/s ( 6 thread)
-memcpy:   14.34 GB/s ( 7 thread)
-memcpy:   14.40 GB/s ( 8 thread)
-sum:    -5119998076.000000
-
-Running ggml_mul_mat benchmark with 8 threads
-
-  64 x   64: Q4_0     3.1 GFLOPS (128 runs) | Q4_1     3.1 GFLOPS (128 runs)
-  64 x   64: Q5_0     3.0 GFLOPS (128 runs) | Q5_1     2.9 GFLOPS (128 runs) | Q8_0     3.1 GFLOPS (128 runs)
-  64 x   64: F16      3.0 GFLOPS (128 runs) | F32      3.0 GFLOPS (128 runs)
- 128 x  128: Q4_0    21.1 GFLOPS (128 runs) | Q4_1    20.3 GFLOPS (128 runs)
- 128 x  128: Q5_0    20.6 GFLOPS (128 runs) | Q5_1    20.4 GFLOPS (128 runs) | Q8_0    22.1 GFLOPS (128 runs)
- 128 x  128: F16     21.7 GFLOPS (128 runs) | F32     21.7 GFLOPS (128 runs)
- 256 x  256: Q4_0   105.7 GFLOPS (128 runs) | Q4_1    94.4 GFLOPS (128 runs)
- 256 x  256: Q5_0    94.8 GFLOPS (128 runs) | Q5_1    87.5 GFLOPS (128 runs) | Q8_0   107.2 GFLOPS (128 runs)
- 256 x  256: F16     95.1 GFLOPS (128 runs) | F32     94.3 GFLOPS (128 runs)
- 512 x  512: Q4_0   214.7 GFLOPS (128 runs) | Q4_1   189.8 GFLOPS (128 runs)
- 512 x  512: Q5_0   187.7 GFLOPS (128 runs) | Q5_1   176.2 GFLOPS (128 runs) | Q8_0   252.2 GFLOPS (128 runs)
- 512 x  512: F16    220.8 GFLOPS (128 runs) | F32    218.3 GFLOPS (128 runs)
-1024 x 1024: Q4_0   333.7 GFLOPS (128 runs) | Q4_1   305.8 GFLOPS (128 runs)
-1024 x 1024: Q5_0   283.2 GFLOPS (128 runs) | Q5_1   268.2 GFLOPS (125 runs) | Q8_0   394.1 GFLOPS (128 runs)
-1024 x 1024: F16    355.0 GFLOPS (128 runs) | F32    313.0 GFLOPS (128 runs)
-2048 x 2048: Q4_0   395.0 GFLOPS ( 23 runs) | Q4_1   380.6 GFLOPS ( 23 runs)
-2048 x 2048: Q5_0   336.6 GFLOPS ( 20 runs) | Q5_1   318.4 GFLOPS ( 19 runs) | Q8_0   482.6 GFLOPS ( 29 runs)
-2048 x 2048: F16    424.5 GFLOPS ( 25 runs) | F32    337.7 GFLOPS ( 20 runs)
-4096 x 4096: Q4_0   412.8 GFLOPS (  4 runs) | Q4_1   405.1 GFLOPS (  3 runs)
-4096 x 4096: Q5_0   346.0 GFLOPS (  3 runs) | Q5_1   334.6 GFLOPS (  3 runs) | Q8_0   502.6 GFLOPS (  4 runs)
-4096 x 4096: F16    412.5 GFLOPS (  4 runs) | F32    274.0 GFLOPS (  3 runs)
-
-|           CPU | Config |         Model |  Th |  FA |    Enc. |    Dec. |    Bch5 |      PP |  Commit |
-|           --- |    --- |           --- | --- | --- |     --- |     --- |     --- |     --- |     --- |
-| Ryzen 9 5950X |   AVX2 |          tiny |   8 |   0 |  195.29 |    1.57 |    0.51 |    0.26 | 22c96b4 |
-| Ryzen 9 5950X |   AVX2 |     tiny-q5_0 |   8 |   0 |  213.33 |    1.10 |    0.50 |    0.30 | 22c96b4 |
-| Ryzen 9 5950X |   AVX2 |     tiny-q5_1 |   8 |   0 |  219.38 |    1.18 |    0.53 |    0.32 | 22c96b4 |
-| Ryzen 9 5950X |   AVX2 |          base |   8 |   0 |  424.85 |    3.71 |    1.03 |    0.46 | 22c96b4 |
-| Ryzen 9 5950X |   AVX2 |     base-q5_0 |   8 |   0 |  473.61 |    1.81 |    0.82 |    0.52 | 22c96b4 |
-| Ryzen 9 5950X |   AVX2 |     base-q5_1 |   8 |   0 |  484.14 |    1.92 |    0.85 |    0.56 | 22c96b4 |
-| Ryzen 9 5950X |   AVX2 |         small |   8 |   0 | 1458.32 |   12.66 |    3.09 |    1.26 | 22c96b4 |
-| Ryzen 9 5950X |   AVX2 |    small-q5_0 |   8 |   0 | 1673.22 |    6.42 |    2.18 |    1.45 | 22c96b4 |
-| Ryzen 9 5950X |   AVX2 |    small-q5_1 |   8 |   0 | 1724.78 |    6.72 |    2.32 |    1.52 | 22c96b4 |
-| Ryzen 9 5950X |   AVX2 |        medium |   8 |   0 | 4333.87 |   36.80 |    8.56 |    3.37 | 22c96b4 |
-| Ryzen 9 5950X |   AVX2 |   medium-q5_0 |   8 |   0 | 5194.09 |   19.21 |    5.71 |    3.97 | 22c96b4 |
-| Ryzen 9 5950X |   AVX2 |   medium-q5_1 |   8 |   0 | 5450.39 |   20.01 |    5.99 |    4.17 | 22c96b4 |
-| Ryzen 9 5950X |   AVX2 |    medium-dis |   8 |   0 | 3995.19 |    5.08 |    1.21 |    0.55 | 22c96b4 |
-| Ryzen 9 5950X |   AVX2 |      large-v2 |   8 |   0 | 8056.16 |   69.74 |   16.11 |    6.13 | 22c96b4 |
-| Ryzen 9 5950X |   AVX2 | large-v2-q5_0 |   8 |   0 | 9799.58 |   35.16 |   10.49 |    7.28 | 22c96b4 |
-| Ryzen 9 5950X |   AVX2 | large-v2-q5_1 |   8 |   0 |      ms |   36.74 |   11.02 |    7.65 | 22c96b4 |
-| Ryzen 9 5950X |   AVX2 |  large-v2-dis |   8 |   0 | 7490.03 |    7.40 |    1.70 |    0.72 | 22c96b4 |
+memcpy:   57.23 GB/s (heat-up)
+memcpy:   68.85 GB/s ( 1 thread)
+memcpy:   70.00 GB/s ( 1 thread)
+memcpy:  104.83 GB/s ( 2 thread)
+memcpy:  124.54 GB/s ( 3 thread)
+memcpy:  144.30 GB/s ( 4 thread)
+memcpy:  141.24 GB/s ( 5 thread)
+memcpy:  147.03 GB/s ( 6 thread)
+memcpy:  147.18 GB/s ( 7 thread)
+memcpy:  149.83 GB/s ( 8 thread)
+sum:    -5120001475.000000
 
 
-WHISPER_CUDA=1 make -j && ./scripts/bench-all.sh 8 1 0
+make -j && ./scripts/bench-all.sh 1
 
-|      GPU |    Config |         Model |  Th |  FA |    Enc. |    Dec. |    Bch5 |      PP |  Commit |
-|      --- |       --- |           --- | --- | --- |     --- |     --- |     --- |     --- |     --- |
-| RTX 2060 | AVX2 CUDA |          tiny |   8 |   0 |   12.54 |    0.93 |    0.29 |    0.02 | 22c96b4 |
-| RTX 2060 | AVX2 CUDA |     tiny-q5_0 |   8 |   0 |   12.73 |    0.98 |    0.24 |    0.02 | 22c96b4 |
-| RTX 2060 | AVX2 CUDA |     tiny-q5_1 |   8 |   0 |   12.72 |    0.99 |    0.24 |    0.02 | 22c96b4 |
-| RTX 2060 | AVX2 CUDA |          base |   8 |   0 |   24.14 |    1.28 |    0.41 |    0.03 | 22c96b4 |
-| RTX 2060 | AVX2 CUDA |     base-q5_0 |   8 |   0 |   24.58 |    1.38 |    0.35 |    0.03 | 22c96b4 |
-| RTX 2060 | AVX2 CUDA |     base-q5_1 |   8 |   0 |   24.58 |    1.37 |    0.35 |    0.03 | 22c96b4 |
-| RTX 2060 | AVX2 CUDA |         small |   8 |   0 |   74.70 |    2.91 |    0.84 |    0.07 | 22c96b4 |
-| RTX 2060 | AVX2 CUDA |    small-q5_0 |   8 |   0 |   76.12 |    2.84 |    0.77 |    0.08 | 22c96b4 |
-| RTX 2060 | AVX2 CUDA |    small-q5_1 |   8 |   0 |   76.14 |    2.84 |    0.76 |    0.08 | 22c96b4 |
-| RTX 2060 | AVX2 CUDA |        medium |   8 |   0 |  200.69 |    6.46 |    1.83 |    0.17 | 22c96b4 |
-| RTX 2060 | AVX2 CUDA |   medium-q5_0 |   8 |   0 |  204.80 |    5.90 |    1.65 |    0.19 | 22c96b4 |
-| RTX 2060 | AVX2 CUDA |   medium-q5_1 |   8 |   0 |  205.61 |    5.85 |    1.61 |    0.19 | 22c96b4 |
-| RTX 2060 | AVX2 CUDA |    medium-dis |   8 |   0 |  186.17 |    0.86 |    0.24 |    0.02 | 22c96b4 |
-| RTX 2060 | AVX2 CUDA |      large-v2 |   8 |   0 |  347.22 |   10.36 |    2.82 |    0.29 | 22c96b4 |
-| RTX 2060 | AVX2 CUDA | large-v2-q5_0 |   8 |   0 |  357.06 |    8.81 |    2.58 |    0.34 | 22c96b4 |
-| RTX 2060 | AVX2 CUDA | large-v2-q5_1 |   8 |   0 |  356.97 |    8.62 |    2.49 |    0.33 | 22c96b4 |
-| RTX 2060 | AVX2 CUDA |  large-v2-dis |   8 |   0 |  318.05 |    1.03 |    0.34 |    0.04 | 22c96b4 |
+Running ggml_mul_mat benchmark with 1 threads
 
-
-WHISPER_CUDA=1 make -j && ./scripts/bench-all.sh 8 1 1
-
-|      GPU |    Config |         Model |  Th |  FA |    Enc. |    Dec. |    Bch5 |      PP |  Commit |
-|      --- |       --- |           --- | --- | --- |     --- |     --- |     --- |     --- |     --- |
-| RTX 2060 | AVX2 CUDA |          tiny |   8 |   1 |    7.21 |    0.76 |    0.29 |    0.02 | 22c96b4 |
-| RTX 2060 | AVX2 CUDA |     tiny-q5_0 |   8 |   1 |    7.42 |    0.82 |    0.18 |    0.02 | 22c96b4 |
-| RTX 2060 | AVX2 CUDA |     tiny-q5_1 |   8 |   1 |    7.38 |    0.82 |    0.18 |    0.02 | 22c96b4 |
-| RTX 2060 | AVX2 CUDA |          base |   8 |   1 |   13.49 |    1.04 |    0.36 |    0.02 | 22c96b4 |
-| RTX 2060 | AVX2 CUDA |     base-q5_0 |   8 |   1 |   13.94 |    1.13 |    0.26 |    0.03 | 22c96b4 |
-| RTX 2060 | AVX2 CUDA |     base-q5_1 |   8 |   1 |   13.94 |    1.14 |    0.26 |    0.03 | 22c96b4 |
-| RTX 2060 | AVX2 CUDA |         small |   8 |   1 |   42.81 |    2.33 |    0.69 |    0.05 | 22c96b4 |
-| RTX 2060 | AVX2 CUDA |    small-q5_0 |   8 |   1 |   44.43 |    2.25 |    0.59 |    0.06 | 22c96b4 |
-| RTX 2060 | AVX2 CUDA |    small-q5_1 |   8 |   1 |   44.11 |    2.24 |    0.58 |    0.06 | 22c96b4 |
-| RTX 2060 | AVX2 CUDA |        medium |   8 |   1 |  115.47 |    5.17 |    1.45 |    0.11 | 22c96b4 |
-| RTX 2060 | AVX2 CUDA |   medium-q5_0 |   8 |   1 |  120.37 |    4.63 |    1.25 |    0.13 | 22c96b4 |
-| RTX 2060 | AVX2 CUDA |   medium-q5_1 |   8 |   1 |  120.28 |    4.55 |    1.21 |    0.13 | 22c96b4 |
-| RTX 2060 | AVX2 CUDA |    medium-dis |   8 |   1 |  101.69 |    0.75 |    0.20 |    0.02 | 22c96b4 |
-| RTX 2060 | AVX2 CUDA |      large-v2 |   8 |   1 |  205.67 |    8.49 |    2.19 |    0.18 | 22c96b4 |
-| RTX 2060 | AVX2 CUDA | large-v2-q5_0 |   8 |   1 |  214.07 |    6.88 |    1.94 |    0.22 | 22c96b4 |
-| RTX 2060 | AVX2 CUDA | large-v2-q5_1 |   8 |   1 |  213.98 |    6.70 |    1.86 |    0.22 | 22c96b4 |
-| RTX 2060 | AVX2 CUDA |  large-v2-dis |   8 |   1 |  176.71 |    0.91 |    0.31 |    0.03 | 22c96b4 |
+  64 x   64: Q4_0    49.6 GFLOPS (128 runs) | Q4_1    46.8 GFLOPS (128 runs)
+  64 x   64: Q5_0    28.1 GFLOPS (128 runs) | Q5_1    26.8 GFLOPS (128 runs) | Q8_0    52.3 GFLOPS (128 runs)
+  64 x   64: F16     38.1 GFLOPS (128 runs) | F32     26.0 GFLOPS (128 runs)
+ 128 x  128: Q4_0    87.6 GFLOPS (128 runs) | Q4_1    79.9 GFLOPS (128 runs)
+ 128 x  128: Q5_0    44.7 GFLOPS (128 runs) | Q5_1    41.6 GFLOPS (128 runs) | Q8_0    98.9 GFLOPS (128 runs)
+ 128 x  128: F16     64.1 GFLOPS (128 runs) | F32     35.4 GFLOPS (128 runs)
+ 256 x  256: Q4_0   104.2 GFLOPS (128 runs) | Q4_1    92.3 GFLOPS (128 runs)
+ 256 x  256: Q5_0    57.3 GFLOPS (128 runs) | Q5_1    51.5 GFLOPS (128 runs) | Q8_0   127.7 GFLOPS (128 runs)
+ 256 x  256: F16     71.4 GFLOPS (128 runs) | F32     40.6 GFLOPS (128 runs)
+ 512 x  512: Q4_0   109.5 GFLOPS (128 runs) | Q4_1    98.0 GFLOPS (128 runs)
+ 512 x  512: Q5_0    62.4 GFLOPS (128 runs) | Q5_1    54.6 GFLOPS (128 runs) | Q8_0   135.0 GFLOPS (128 runs)
+ 512 x  512: F16     82.6 GFLOPS (128 runs) | F32     44.6 GFLOPS (128 runs)
+1024 x 1024: Q4_0   112.1 GFLOPS ( 53 runs) | Q4_1   100.9 GFLOPS ( 47 runs)
+1024 x 1024: Q5_0    65.4 GFLOPS ( 31 runs) | Q5_1    56.7 GFLOPS ( 27 runs) | Q8_0   140.9 GFLOPS ( 66 runs)
+1024 x 1024: F16     88.0 GFLOPS ( 41 runs) | F32     43.4 GFLOPS ( 21 runs)
+2048 x 2048: Q4_0   113.4 GFLOPS (  7 runs) | Q4_1   102.0 GFLOPS (  6 runs)
+2048 x 2048: Q5_0    67.1 GFLOPS (  4 runs) | Q5_1    57.7 GFLOPS (  4 runs) | Q8_0   142.7 GFLOPS (  9 runs)
+2048 x 2048: F16     84.6 GFLOPS (  5 runs) | F32     37.5 GFLOPS (  3 runs)
+4096 x 4096: Q4_0   113.8 GFLOPS (  3 runs) | Q4_1   102.0 GFLOPS (  3 runs)
+4096 x 4096: Q5_0    67.7 GFLOPS (  3 runs) | Q5_1    58.0 GFLOPS (  3 runs) | Q8_0   142.9 GFLOPS (  3 runs)
+4096 x 4096: F16     73.7 GFLOPS (  3 runs) | F32     36.1 GFLOPS (  3 runs)
 
 
+make -j && ./scripts/bench-all.sh 1 1 0
+
+|    CPU |  Config |         Model |  Th |  FA |    Enc. |    Dec. |    Bch5 |      PP |  Commit |
+|    --- |     --- |           --- | --- | --- |     --- |     --- |     --- |     --- |     --- |
+| M4 Max |   METAL |          tiny |   1 |   0 |   13.12 |    0.87 |    0.29 |    0.01 | ad4e3509 |
+| M4 Max |   METAL |     tiny-q8_0 |   1 |   0 |   15.90 |    0.88 |    0.31 |    0.01 | ad4e3509 |
+| M4 Max |   METAL |          base |   1 |   0 |   23.10 |    1.42 |    0.34 |    0.02 | ad4e3509 |
+| M4 Max |   METAL |     base-q8_0 |   1 |   0 |   27.25 |    1.31 |    0.34 |    0.02 | ad4e3509 |
+| M4 Max |   METAL |         small |   1 |   0 |   71.76 |    3.02 |    0.70 |    0.06 | ad4e3509 |
+| M4 Max |   METAL |    small-q8_0 |   1 |   0 |   73.88 |    2.60 |    0.71 |    0.06 | ad4e3509 |
+| M4 Max |   METAL |        medium |   1 |   0 |  208.22 |    6.94 |    1.55 |    0.16 | ad4e3509 |
+| M4 Max |   METAL |   medium-q8_0 |   1 |   0 |  214.65 |    5.90 |    1.57 |    0.17 | ad4e3509 |
+| M4 Max |   METAL |      large-v2 |   1 |   0 |  381.72 |   11.28 |    2.51 |    0.29 | ad4e3509 |
+| M4 Max |   METAL | large-v2-q8_0 |   1 |   0 |  394.97 |    8.90 |    2.45 |    0.30 | ad4e3509 |
+
+
+make -j && ./scripts/bench-all.sh 1 1 1
+
+|    CPU |  Config |         Model |  Th |  FA |    Enc. |    Dec. |    Bch5 |      PP |  Commit |
+|    --- |     --- |           --- | --- | --- |     --- |     --- |     --- |     --- |     --- |
+| M4 Max |   METAL |          tiny |   1 |   1 |   15.22 |    0.89 |    0.26 |    0.01 | ad4e3509 |
+| M4 Max |   METAL |     tiny-q8_0 |   1 |   1 |   14.70 |    0.86 |    0.26 |    0.01 | ad4e3509 |
+| M4 Max |   METAL |          base |   1 |   1 |   25.33 |    1.36 |    0.30 |    0.02 | ad4e3509 |
+| M4 Max |   METAL |     base-q8_0 |   1 |   1 |   21.27 |    1.31 |    0.30 |    0.02 | ad4e3509 |
+| M4 Max |   METAL |         small |   1 |   1 |   58.43 |    2.78 |    0.60 |    0.05 | ad4e3509 |
+| M4 Max |   METAL |    small-q8_0 |   1 |   1 |   60.26 |    2.39 |    0.60 |    0.05 | ad4e3509 |
+| M4 Max |   METAL |        medium |   1 |   1 |  169.73 |    6.03 |    1.31 |    0.14 | ad4e3509 |
+| M4 Max |   METAL |   medium-q8_0 |   1 |   1 |  176.61 |    4.99 |    1.31 |    0.14 | ad4e3509 |
+| M4 Max |   METAL |      large-v2 |   1 |   1 |  316.18 |    9.60 |    2.08 |    0.24 | ad4e3509 |
+| M4 Max |   METAL | large-v2-q8_0 |   1 |   1 |  329.59 |    7.55 |    2.08 |    0.25 | ad4e3509 |
 
 
 # V100
@@ -271,28 +253,33 @@ WHISPER_CUDA=1 make -j && ./scripts/bench-all.sh 8 1 0
 
 |  GPU |    Config |         Model |  Th |  FA |    Enc. |    Dec. |    Bch5 |      PP |  Commit |
 |  --- |       --- |           --- | --- | --- |     --- |     --- |     --- |     --- |     --- |
-| V100 | AVX2 CUDA |          tiny |   1 |   0 |    6.21 |    1.11 |    0.30 |    0.02 | 22c96b4 |
-| V100 | AVX2 CUDA |     tiny-q5_1 |   1 |   0 |    5.97 |    1.10 |    0.26 |    0.02 | 22c96b4 |
-| V100 | AVX2 CUDA |          base |   1 |   0 |   10.95 |    1.47 |    0.42 |    0.03 | 22c96b4 |
-| V100 | AVX2 CUDA |     base-q5_1 |   1 |   0 |   11.13 |    1.53 |    0.36 |    0.03 | 22c96b4 |
-| V100 | AVX2 CUDA |         small |   1 |   0 |   31.57 |    2.96 |    0.84 |    0.05 | 22c96b4 |
-| V100 | AVX2 CUDA |    small-q5_1 |   1 |   0 |   32.19 |    3.14 |    0.75 |    0.05 | 22c96b4 |
-| V100 | AVX2 CUDA |        medium |   1 |   0 |   85.88 |    6.49 |    1.80 |    0.10 | 22c96b4 |
-| V100 | AVX2 CUDA |   medium-q5_0 |   1 |   0 |   87.53 |    5.82 |    1.37 |    0.10 | 22c96b4 |
-| V100 | AVX2 CUDA |      large-v2 |   1 |   0 |  142.23 |    8.92 |    2.62 |    0.15 | 22c96b4 |
+| V100 | AVX2 CUDA |          tiny |   8 |   0 |    6.15 |    1.02 |    0.30 |    0.01 | ad4e3509 |
+| V100 | AVX2 CUDA |     tiny-q5_1 |   8 |   0 |    5.92 |    0.96 |    0.25 |    0.01 | ad4e3509 |
+| V100 | AVX2 CUDA |          base |   8 |   0 |   10.60 |    1.43 |    0.43 |    0.02 | ad4e3509 |
+| V100 | AVX2 CUDA |     base-q5_1 |   8 |   0 |   10.80 |    1.37 |    0.36 |    0.02 | ad4e3509 |
+| V100 | AVX2 CUDA |         small |   8 |   0 |   31.83 |    2.82 |    0.87 |    0.04 | ad4e3509 |
+| V100 | AVX2 CUDA |    small-q5_1 |   8 |   0 |   31.88 |    2.68 |    0.72 |    0.04 | ad4e3509 |
+| V100 | AVX2 CUDA |        medium |   8 |   0 |   81.30 |    6.02 |    1.81 |    0.09 | ad4e3509 |
+| V100 | AVX2 CUDA |   medium-q5_0 |   8 |   0 |   83.21 |    5.44 |    1.41 |    0.10 | ad4e3509 |
+| V100 | AVX2 CUDA |      large-v2 |   8 |   0 |  134.81 |    8.64 |    2.69 |    0.14 | ad4e3509 |
+| V100 | AVX2 CUDA | large-v2-q5_0 |   8 |   0 |  138.95 |    7.57 |    2.04 |    0.15 | ad4e3509 |
+| V100 | AVX2 CUDA | large-v3-turbo |   8 |   0 |  124.42 |    1.37 |    0.43 |    0.02 | ad4e3509 |
+| V100 | AVX2 CUDA | large-v3-turbo-q5_0 |   8 |   0 |  127.81 |    1.13 |    0.32 |    0.03 | ad4e3509 |
 
 
 WHISPER_CUDA=1 make -j && ./scripts/bench-all.sh 8 1 1
 
 |  GPU |    Config |         Model |  Th |  FA |    Enc. |    Dec. |    Bch5 |      PP |  Commit |
 |  --- |       --- |           --- | --- | --- |     --- |     --- |     --- |     --- |     --- |
-| V100 | AVX2 CUDA |          tiny |   1 |   1 |    3.96 |    0.82 |    0.24 |    0.02 | 22c96b4 |
-| V100 | AVX2 CUDA |     tiny-q5_1 |   1 |   1 |    4.05 |    0.85 |    0.18 |    0.02 | 22c96b4 |
-| V100 | AVX2 CUDA |          base |   1 |   1 |    7.21 |    1.16 |    0.36 |    0.02 | 22c96b4 |
-| V100 | AVX2 CUDA |     base-q5_1 |   1 |   1 |    7.39 |    1.21 |    0.26 |    0.02 | 22c96b4 |
-| V100 | AVX2 CUDA |         small |   1 |   1 |   19.81 |    2.41 |    0.71 |    0.04 | 22c96b4 |
-| V100 | AVX2 CUDA |    small-q5_1 |   1 |   1 |   20.50 |    2.31 |    0.51 |    0.04 | 22c96b4 |
-| V100 | AVX2 CUDA |        medium |   1 |   1 |   56.02 |    4.89 |    1.44 |    0.07 | 22c96b4 |
-| V100 | AVX2 CUDA |   medium-q5_0 |   1 |   1 |   57.85 |    4.73 |    1.09 |    0.08 | 22c96b4 |
-| V100 | AVX2 CUDA |      large-v2 |   1 |   1 |   92.73 |    7.18 |    2.14 |    0.10 | 22c96b4 |
-
+| V100 | AVX2 CUDA |          tiny |   8 |   1 |    4.01 |    0.90 |    0.25 |    0.01 | ad4e3509 |
+| V100 | AVX2 CUDA |     tiny-q5_1 |   8 |   1 |    4.12 |    0.88 |    0.18 |    0.01 | ad4e3509 |
+| V100 | AVX2 CUDA |          base |   8 |   1 |    7.00 |    1.30 |    0.35 |    0.01 | ad4e3509 |
+| V100 | AVX2 CUDA |     base-q5_1 |   8 |   1 |    7.22 |    1.21 |    0.26 |    0.02 | ad4e3509 |
+| V100 | AVX2 CUDA |         small |   8 |   1 |   18.68 |    2.39 |    0.69 |    0.03 | ad4e3509 |
+| V100 | AVX2 CUDA |    small-q5_1 |   8 |   1 |   19.38 |    2.32 |    0.51 |    0.03 | ad4e3509 |
+| V100 | AVX2 CUDA |        medium |   8 |   1 |   53.17 |    5.15 |    1.45 |    0.06 | ad4e3509 |
+| V100 | AVX2 CUDA |   medium-q5_0 |   8 |   1 |   55.09 |    4.64 |    1.05 |    0.07 | ad4e3509 |
+| V100 | AVX2 CUDA |      large-v2 |   8 |   1 |   85.77 |    7.57 |    2.19 |    0.10 | ad4e3509 |
+| V100 | AVX2 CUDA | large-v2-q5_0 |   8 |   1 |   89.24 |    6.48 |    1.48 |    0.11 | ad4e3509 |
+| V100 | AVX2 CUDA | large-v3-turbo |   8 |   1 |   75.56 |    1.25 |    0.37 |    0.02 | ad4e3509 |
+| V100 | AVX2 CUDA | large-v3-turbo-q5_0 |   8 |   1 |   78.48 |    1.01 |    0.24 |    0.02 | ad4e3509 |


### PR DESCRIPTION
Preparing performance numbers for the `v1.7.5` release.