### PR TITLE
release : v1.7.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.5) # for add_link_options and implicit target directories.
 project("whisper.cpp" C CXX)
-project("whisper.cpp" VERSION 1.7.4)
+project("whisper.cpp" VERSION 1.7.5)
 include(CheckIncludeFileCXX)
 
 set(SOVERSION 1)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 > [!NOTE]
 > New maintenance roadmap: https://github.com/ggerganov/whisper.cpp/discussions/2788
 
-Stable: [v1.7.4](https://github.com/ggerganov/whisper.cpp/releases/tag/v1.7.4) / [Roadmap | F.A.Q.](https://github.com/ggerganov/whisper.cpp/discussions/126)
+Stable: [v1.7.5](https://github.com/ggerganov/whisper.cpp/releases/tag/v1.7.5) / [Roadmap | F.A.Q.](https://github.com/ggerganov/whisper.cpp/discussions/126)
 
 High-performance inference of [OpenAI's Whisper](https://github.com/openai/whisper) automatic speech recognition (ASR) model:
 

--- a/bindings/javascript/package.json
+++ b/bindings/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "whisper.cpp",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "description": "Whisper speech recognition",
   "main": "whisper.js",
   "scripts": {


### PR DESCRIPTION
- Update the version numbers to the new version
- Do not squash-merge this commit to avoid appending the (1234) suffix to the commit title

After that, we'll create a release from the Github UI, selecting this commit and creating a tag  `v1.7.5`.