### PR TITLE
docs : add xcframework section to README.md [no ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,6 +647,33 @@ For more details, see the conversion script [models/convert-pt-to-ggml.py](model
 - [x] R: [bnosac/audio.whisper](https://github.com/bnosac/audio.whisper)
 - [x] Unity: [macoron/whisper.unity](https://github.com/Macoron/whisper.unity)
 
+## XCFramework
+The XCFramework is a precompiled version of the library for iOS, visionOS, tvOS,
+and macOS. It can be used in Swift projects without the need to compile the
+library from source. For examples:
+```swift
+// swift-tools-version: 5.10
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "Whisper",
+    targets: [
+        .executableTarget(
+            name: "Whisper",
+            dependencies: [
+                "WhisperFramework"
+            ]),
+        .binaryTarget(
+            name: "WhisperFramework",
+            url: "https://github.com/ggerganov/whisper.cpp/releases/download/v1.7.5/whisper-v1.7.5-xcframework.zip",
+            checksum: "c7faeb328620d6012e130f3d705c51a6ea6c995605f2df50f6e1ad68c59c6c4a"
+        )
+    ]
+)
+```
+
 ## Examples
 
 There are various examples of using the library for different projects in the [examples](examples) folder.


### PR DESCRIPTION
This adds a section to the README.md file that describes how to use the XCFramework.

The modification for this is that is not obvious how to use the XCFramework and and example will help.
One thing to note is that the example is using the latest release including the checksum. We are thinking about how we might automate this in the future but for now this is a good start.