### PR TITLE
whisper.wasm : fix unknown language issue

### DIFF
--- a/examples/whisper.wasm/emscripten.cpp
+++ b/examples/whisper.wasm/emscripten.cpp
@@ -71,7 +71,7 @@ EMSCRIPTEN_BINDINGS(whisper) {
         params.print_timestamps = true;
         params.print_special    = false;
         params.translate        = translate;
-        params.language         = whisper_is_multilingual(g_contexts[index]) ? lang.c_str() : "en";
+        params.language         = whisper_is_multilingual(g_contexts[index]) ? strdup(lang.c_str()) : "en";
         params.n_threads        = std::min(nthreads, std::min(16, mpow2(std::thread::hardware_concurrency())));
         params.offset_ms        = 0;
 
@@ -106,6 +106,9 @@ EMSCRIPTEN_BINDINGS(whisper) {
                 whisper_reset_timings(g_contexts[index]);
                 whisper_full(g_contexts[index], params, pcmf32.data(), pcmf32.size());
                 whisper_print_timings(g_contexts[index]);
+                if (params.language != nullptr && strcmp(params.language, "en") != 0) {
+                    free((void*)params.language);
+                }
             });
         }
 

--- a/examples/whisper.wasm/emscripten.cpp
+++ b/examples/whisper.wasm/emscripten.cpp
@@ -65,13 +65,14 @@ EMSCRIPTEN_BINDINGS(whisper) {
         }
 
         struct whisper_full_params params = whisper_full_default_params(whisper_sampling_strategy::WHISPER_SAMPLING_GREEDY);
+        bool is_multilingual = whisper_is_multilingual(g_contexts[index]);
 
         params.print_realtime   = true;
         params.print_progress   = false;
         params.print_timestamps = true;
         params.print_special    = false;
         params.translate        = translate;
-        params.language         = whisper_is_multilingual(g_contexts[index]) ? strdup(lang.c_str()) : "en";
+        params.language         = is_multilingual ? strdup(lang.c_str()) : "en";
         params.n_threads        = std::min(nthreads, std::min(16, mpow2(std::thread::hardware_concurrency())));
         params.offset_ms        = 0;
 
@@ -102,11 +103,11 @@ EMSCRIPTEN_BINDINGS(whisper) {
 
         // run the worker
         {
-            g_worker = std::thread([index, params, pcmf32 = std::move(pcmf32)]() {
+            g_worker = std::thread([index, params, pcmf32 = std::move(pcmf32), is_multilingual]() {
                 whisper_reset_timings(g_contexts[index]);
                 whisper_full(g_contexts[index], params, pcmf32.data(), pcmf32.size());
                 whisper_print_timings(g_contexts[index]);
-                if (params.language != nullptr && strcmp(params.language, "en") != 0) {
+                if (is_multilingual) {
                     free((void*)params.language);
                 }
             });


### PR DESCRIPTION
This commit addresses an issue with whisper.wasm where the following error was being displayed when running the application in github pages:
```
whisper_lang_id: unknown language 'д=␙c'
```

This turned out to be a memory corruption issue and further details can be found in the reference issue below.

Refs: https://github.com/ggerganov/whisper.cpp/issues/2998

----

I've deployed this to: https://danbev.github.io/whisper.cpp/